### PR TITLE
Fix #75: libasdf "forgets" the original type of a value when resolved as an extension type

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -217,7 +217,7 @@ asdf_value_err_t asdf_get_mapping(asdf_file_t *file, const char *path, asdf_valu
     if (!value)
         return ASDF_VALUE_ERR_NOT_FOUND;
 
-    if (value->type != ASDF_VALUE_MAPPING) {
+    if (value->raw_type != ASDF_VALUE_MAPPING) {
         asdf_value_destroy(value);
         return ASDF_VALUE_ERR_TYPE_MISMATCH;
     }
@@ -233,7 +233,7 @@ asdf_value_err_t asdf_get_sequence(asdf_file_t *file, const char *path, asdf_val
     if (!value)
         return ASDF_VALUE_ERR_NOT_FOUND;
 
-    if (value->type != ASDF_VALUE_SEQUENCE) {
+    if (value->raw_type != ASDF_VALUE_SEQUENCE) {
         asdf_value_destroy(value);
         return ASDF_VALUE_ERR_TYPE_MISMATCH;
     }

--- a/src/value.h
+++ b/src/value.h
@@ -21,6 +21,8 @@ typedef struct {
 typedef struct asdf_value {
     asdf_file_t *file;
     asdf_value_type_t type;
+    /** Preserve the underling YAML type even after type inference; see #75 */
+    asdf_value_type_t raw_type;
     asdf_value_err_t err;
     struct fy_node *node;
     const char *tag;


### PR DESCRIPTION
Resolves #75 