### PR TITLE
test: rename test suites and tests to drop `test_asdf_` prefix

### DIFF
--- a/tests/test-block.c
+++ b/tests/test-block.c
@@ -4,7 +4,7 @@
 #include "file.h"
 
 
-MU_TEST(test_asdf_block_data) {
+MU_TEST(block_data) {
     const char *filename = get_fixture_file_path("255.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -26,9 +26,9 @@ MU_TEST(test_asdf_block_data) {
 
 
 MU_TEST_SUITE(
-    test_asdf_block,
-    MU_RUN_TEST(test_asdf_block_data)
+    block,
+    MU_RUN_TEST(block_data)
 );
 
 
-MU_RUN_SUITE(test_asdf_block);
+MU_RUN_SUITE(block);

--- a/tests/test-core-extensions.c
+++ b/tests/test-core-extensions.c
@@ -15,7 +15,7 @@
 /* TODO: Should have more tests for this, for now just using one test case that's already lying
  * around...
  */
-MU_TEST(test_asdf_extension_metadata) {
+MU_TEST(extension_metadata) {
     const char *path = get_reference_file_path("1.6.0/basic.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -67,7 +67,7 @@ MU_TEST(test_asdf_extension_metadata) {
 }
 
 
-MU_TEST(test_asdf_history_entry) {
+MU_TEST(history_entry) {
     const char *path = get_fixture_file_path("255.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -92,7 +92,7 @@ MU_TEST(test_asdf_history_entry) {
 }
 
 
-MU_TEST(test_asdf_meta) {
+MU_TEST(meta) {
     const char *path = get_fixture_file_path("255.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -137,7 +137,7 @@ MU_TEST(test_asdf_meta) {
 /*
  * Very basic test of ndarray parsing; will have more comprehensive ndarray tests in their own suite
  */
-MU_TEST(test_asdf_ndarray) {
+MU_TEST(ndarray) {
     const char *path = get_reference_file_path("1.6.0/basic.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -167,7 +167,7 @@ MU_TEST(test_asdf_ndarray) {
 }
 
 
-MU_TEST(test_asdf_software) {
+MU_TEST(software) {
     const char *path = get_reference_file_path("1.6.0/basic.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -186,13 +186,13 @@ MU_TEST(test_asdf_software) {
 
 
 MU_TEST_SUITE(
-    test_asdf_core_extensions,
-    MU_RUN_TEST(test_asdf_extension_metadata),
-    MU_RUN_TEST(test_asdf_history_entry),
-    MU_RUN_TEST(test_asdf_meta),
-    MU_RUN_TEST(test_asdf_ndarray),
-    MU_RUN_TEST(test_asdf_software)
+    core_extensions,
+    MU_RUN_TEST(extension_metadata),
+    MU_RUN_TEST(history_entry),
+    MU_RUN_TEST(meta),
+    MU_RUN_TEST(ndarray),
+    MU_RUN_TEST(software)
 );
 
 
-MU_RUN_SUITE(test_asdf_core_extensions);
+MU_RUN_SUITE(core_extensions);

--- a/tests/test-event.c
+++ b/tests/test-event.c
@@ -74,7 +74,7 @@
 const off_t expected_offsets[] = {664};
 
 
-MU_TEST(test_asdf_event_basic) {
+MU_TEST(basic) {
     // TODO: Move all of this setup into setup/teardown functions; lots of repetition here
     const char *filename = get_reference_file_path("1.6.0/basic.asdf");
     asdf_parser_cfg_t parser_cfg = {.flags = ASDF_PARSER_OPT_EMIT_YAML_EVENTS};
@@ -202,9 +202,9 @@ MU_TEST(test_asdf_event_basic) {
 
 
 /**
- * Like `test_asdf_event_basic` but with YAML events disabled
+ * Like `basic` but with YAML events disabled
  */
-MU_TEST(test_asdf_event_basic_no_yaml) {
+MU_TEST(basic_no_yaml) {
     const char *filename = get_reference_file_path("1.6.0/basic.asdf");
     asdf_parser_cfg_t parser_cfg = {0};
 
@@ -272,9 +272,9 @@ MU_TEST(test_asdf_event_basic_no_yaml) {
 
 
 /**
- * Like `test_asdf_event_basic_no_yaml` but with YAML buffering enabled
+ * Like `basic_no_yaml` but with YAML buffering enabled
  */
-MU_TEST(test_asdf_event_basic_no_yaml_buffer_yaml) {
+MU_TEST(basic_no_yaml_buffer_yaml) {
     const char *filename = get_reference_file_path("1.6.0/basic.asdf");
     asdf_parser_cfg_t parser_cfg = {.flags = ASDF_PARSER_OPT_BUFFER_TREE};
 
@@ -340,9 +340,9 @@ MU_TEST(test_asdf_event_basic_no_yaml_buffer_yaml) {
 
 
 /**
- * Like `test_asdf_event_basic` but with YAML buffering enabled
+ * Like `basic` but with YAML buffering enabled
  */
-MU_TEST(test_asdf_event_basic_buffer_yaml) {
+MU_TEST(basic_buffer_yaml) {
     const char *filename = get_reference_file_path("1.6.0/basic.asdf");
     FILE *file = fopen(filename, "r");
     assert_not_null(file);
@@ -477,12 +477,12 @@ static MunitParameterEnum test_params[] = {
 
 
 MU_TEST_SUITE(
-    test_asdf_event,
-    MU_RUN_TEST(test_asdf_event_basic, test_params),
-    MU_RUN_TEST(test_asdf_event_basic_no_yaml, test_params),
-    MU_RUN_TEST(test_asdf_event_basic_no_yaml_buffer_yaml, test_params),
-    MU_RUN_TEST(test_asdf_event_basic_buffer_yaml, test_params)
+    event,
+    MU_RUN_TEST(basic, test_params),
+    MU_RUN_TEST(basic_no_yaml, test_params),
+    MU_RUN_TEST(basic_no_yaml_buffer_yaml, test_params),
+    MU_RUN_TEST(basic_buffer_yaml, test_params)
 );
 
 
-MU_RUN_SUITE(test_asdf_event);
+MU_RUN_SUITE(event);

--- a/tests/test-extension.c
+++ b/tests/test-extension.c
@@ -77,7 +77,7 @@ ASDF_REGISTER_EXTENSION(
 )
 
 
-MU_TEST(test_asdf_extension_registered) {
+MU_TEST(extension_registered) {
     const char *path = get_fixture_file_path("trivial-extension.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -148,8 +148,8 @@ MU_TEST(test_asdf_get_foo) {
 
 
 MU_TEST_SUITE(
-    test_asdf_extension,
-    MU_RUN_TEST(test_asdf_extension_registered),
+    extension,
+    MU_RUN_TEST(extension_registered),
     MU_RUN_TEST(test_asdf_value_is_foo),
     MU_RUN_TEST(test_asdf_value_as_foo),
     MU_RUN_TEST(test_asdf_is_foo),
@@ -157,4 +157,4 @@ MU_TEST_SUITE(
 );
 
 
-MU_RUN_SUITE(test_asdf_extension);
+MU_RUN_SUITE(extension);

--- a/tests/test-file.c
+++ b/tests/test-file.c
@@ -53,7 +53,7 @@ MU_TEST(test_asdf_open_file) {
 
 
 /* Test the high-level asdf_is_* and asdf_get_* helpers */
-MU_TEST(test_asdf_scalar_getters) {
+MU_TEST(scalar_getters) {
     const char *filename = get_fixture_file_path("scalars.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -188,7 +188,7 @@ static asdf_block_decomp_mode_t decomp_mode_from_param(const char *mode) {
 
 
 /** Basic test against the compressed.asdf reference file */
-MU_TEST(test_asdf_read_compressed_reference_file) {
+MU_TEST(read_compressed_reference_file) {
     const char *comp = munit_parameters_get(params, "comp");
 
     if (strcmp(comp, "lz4") == 0) {
@@ -331,7 +331,7 @@ static int test_compressed_file(
 }
 
 
-MU_TEST(test_asdf_read_compressed_block) {
+MU_TEST(read_compressed_block) {
     const char *comp = munit_parameters_get(params, "comp");
     const char *filename = get_fixture_file_path("compressed.asdf");
     asdf_config_t config = {
@@ -349,7 +349,7 @@ MU_TEST(test_asdf_read_compressed_block) {
 /**
  * Test decompression to a temp file (set memory threshold very low to force it)
  */
-MU_TEST(test_asdf_read_compressed_block_to_file) {
+MU_TEST(read_compressed_block_to_file) {
     const char *comp = munit_parameters_get(params, "comp");
     const char *filename = get_fixture_file_path("compressed.asdf");
 
@@ -369,7 +369,7 @@ MU_TEST(test_asdf_read_compressed_block_to_file) {
 /**
  * Test decompression to a temp file based on memory threshold
  */
-MU_TEST(test_asdf_read_compressed_block_to_file_on_threshold) {
+MU_TEST(read_compressed_block_to_file_on_threshold) {
     const char *comp = munit_parameters_get(params, "comp");
     const char *filename = get_fixture_file_path("compressed.asdf");
 
@@ -404,7 +404,7 @@ MU_TEST(test_asdf_read_compressed_block_to_file_on_threshold) {
  * Tests edge cases where the compression handler isn't stopped properly or
  * goes into an undefined state if we don't decompress the whole file first.
  */
-MU_TEST(test_asdf_open_close_compressed_block) {
+MU_TEST(open_close_compressed_block) {
     const char *comp = munit_parameters_get(params, "comp");
     const char *filename = get_fixture_file_path("compressed.asdf");
     asdf_config_t config = {
@@ -430,7 +430,7 @@ MU_TEST(test_asdf_open_close_compressed_block) {
 }
 
 
-/* Used for test_asdf_compressed_block_no_hang_on_segfault
+/* Used for compressed_block_no_hang_on_segfault
  *
  * This is to ensure that trying to access the data after the block is closed
  * actually results in a segfault instead of just hanging the process
@@ -445,7 +445,7 @@ static void segv_handler(int sig) {
 }
 
 
-MU_TEST(test_asdf_compressed_block_no_hang_on_segfault) {
+MU_TEST(compressed_block_no_hang_on_segfault) {
     const char *comp = munit_parameters_get(params, "comp");
     const char *filename = get_fixture_file_path("compressed.asdf");
     asdf_config_t config = {
@@ -510,7 +510,7 @@ MU_TEST(test_asdf_compressed_block_no_hang_on_segfault) {
 /**
  * Test decompressed block lazy random access
  */
-MU_TEST(test_asdf_read_compressed_block_lazy_random_access) {
+MU_TEST(read_compressed_block_lazy_random_access) {
     const char *comp = munit_parameters_get(params, "comp");
     const char *filename = get_fixture_file_path("compressed.asdf");
 
@@ -530,20 +530,20 @@ MU_TEST(test_asdf_read_compressed_block_lazy_random_access) {
 
 
 MU_TEST_SUITE(
-    test_asdf_file,
+    file,
     MU_RUN_TEST(test_asdf_open_file),
-    MU_RUN_TEST(test_asdf_scalar_getters),
+    MU_RUN_TEST(scalar_getters),
     MU_RUN_TEST(test_asdf_get_mapping),
     MU_RUN_TEST(test_asdf_get_sequence),
     MU_RUN_TEST(test_asdf_block_count),
-    MU_RUN_TEST(test_asdf_read_compressed_reference_file, comp_mode_test_params),
-    MU_RUN_TEST(test_asdf_read_compressed_block, comp_mode_test_params),
-    MU_RUN_TEST(test_asdf_read_compressed_block_to_file, comp_test_params),
-    MU_RUN_TEST(test_asdf_read_compressed_block_to_file_on_threshold, comp_test_params),
-    MU_RUN_TEST(test_asdf_open_close_compressed_block, comp_mode_test_params),
-    MU_RUN_TEST(test_asdf_read_compressed_block_lazy_random_access, comp_mode_test_params),
-    MU_RUN_TEST(test_asdf_compressed_block_no_hang_on_segfault, comp_mode_test_params)
+    MU_RUN_TEST(read_compressed_reference_file, comp_mode_test_params),
+    MU_RUN_TEST(read_compressed_block, comp_mode_test_params),
+    MU_RUN_TEST(read_compressed_block_to_file, comp_test_params),
+    MU_RUN_TEST(read_compressed_block_to_file_on_threshold, comp_test_params),
+    MU_RUN_TEST(open_close_compressed_block, comp_mode_test_params),
+    MU_RUN_TEST(read_compressed_block_lazy_random_access, comp_mode_test_params),
+    MU_RUN_TEST(compressed_block_no_hang_on_segfault, comp_mode_test_params)
 );
 
 
-MU_RUN_SUITE(test_asdf_file);
+MU_RUN_SUITE(file);

--- a/tests/test-gwcs.c
+++ b/tests/test-gwcs.c
@@ -109,10 +109,10 @@ MU_TEST(test_asdf_get_gwcs) {
 
 
 MU_TEST_SUITE(
-    test_asdf_gwcs,
+    gwcs,
     MU_RUN_TEST(test_asdf_get_gwcs_fits),
     MU_RUN_TEST(test_asdf_get_gwcs)
 );
 
 
-MU_RUN_SUITE(test_asdf_gwcs);
+MU_RUN_SUITE(gwcs);

--- a/tests/test-ndarray.c
+++ b/tests/test-ndarray.c
@@ -11,7 +11,7 @@
 
 
 /* Read contiguous 1-D "tiles" from arrays of different shapes */
-MU_TEST(test_asdf_ndarray_read_1d_tile_contiguous) {
+MU_TEST(ndarray_read_1d_tile_contiguous) {
     const char *path = get_fixture_file_path("tiles.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -67,7 +67,7 @@ MU_TEST(test_asdf_ndarray_read_1d_tile_contiguous) {
 
 
 /* Read 2-D tiles from 2-D and 3-D arrays */
-MU_TEST(test_asdf_ndarray_read_2d_tile) {
+MU_TEST(test_asdf_ndarray_read_tile_2d) {
     const char *path = get_fixture_file_path("tiles.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -106,7 +106,7 @@ MU_TEST(test_asdf_ndarray_read_2d_tile) {
 
 
 /* Read a 3-D cube from a a 3-D array */
-MU_TEST(test_asdf_ndarray_read_3d_tile) {
+MU_TEST(ndarray_read_3d_tile) {
     const char *path = get_fixture_file_path("tiles.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -131,7 +131,7 @@ MU_TEST(test_asdf_ndarray_read_3d_tile) {
 }
 
 
-/* Helper for test_asdf_ndarray_read_tile_byteswap
+/* Helper for ndarray_read_tile_byteswap
  *
  * Each array in byteorder.asdf just contains 0...7 in different int types, different
  * endianness
@@ -159,7 +159,7 @@ MU_TEST(test_asdf_ndarray_read_3d_tile) {
 
 
 /* Test reading from (1-D) arrays with different byte orders */
-MU_TEST(test_asdf_ndarray_read_tile_byteswap) {
+MU_TEST(ndarray_read_tile_byteswap) {
     const char *path = get_fixture_file_path("byteorder.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -188,10 +188,10 @@ static MunitParameterEnum test_numeric_conversion_params[] = {
 };
 
 
-/** Helper functions for `test_asdf_ndarray_numeric_conversion` */
+/** Helper functions for `ndarray_numeric_conversion` */
 
 /**
- * For the purposes of `test_asdf_ndarray_numeric_conversion` will the result
+ * For the purposes of `ndarray_numeric_conversion` will the result
  * overflow for a given source and destination datatype
  *
  * This is not a guaranteed overflow in general (as it depends on the data in
@@ -442,7 +442,7 @@ static char *append_char(const char *src, char c) {
 }
 
 
-MU_TEST(test_asdf_ndarray_numeric_conversion) {
+MU_TEST(ndarray_numeric_conversion) {
     const char *src_dtype = munit_parameters_get(params, "src_dtype");
     const char *dst_dtype = munit_parameters_get(params, "dst_dtype");
     const char *src_byteorder = munit_parameters_get(params, "src_byteorder");
@@ -475,7 +475,7 @@ MU_TEST(test_asdf_ndarray_numeric_conversion) {
 }
 
 
-MU_TEST(test_asdf_ndarray_record_datatype) {
+MU_TEST(ndarray_record_datatype) {
     const char *path = get_fixture_file_path("datatypes.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -551,7 +551,7 @@ MU_TEST(test_asdf_ndarray_record_datatype) {
 }
 
 
-MU_TEST(test_heap_use_after_free_issue_63) {
+MU_TEST(heap_use_after_free_issue_63) {
     const char *path = get_fixture_file_path("multiple_hdu.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -600,15 +600,15 @@ MU_TEST(test_heap_use_after_free_issue_63) {
 
 
 MU_TEST_SUITE(
-    test_asdf_ndarray,
-    MU_RUN_TEST(test_asdf_ndarray_read_1d_tile_contiguous),
-    MU_RUN_TEST(test_asdf_ndarray_read_2d_tile),
-    MU_RUN_TEST(test_asdf_ndarray_read_3d_tile),
-    MU_RUN_TEST(test_asdf_ndarray_read_tile_byteswap),
-    MU_RUN_TEST(test_asdf_ndarray_numeric_conversion, test_numeric_conversion_params),
-    MU_RUN_TEST(test_asdf_ndarray_record_datatype),
-    MU_RUN_TEST(test_heap_use_after_free_issue_63)
+    ndarray,
+    MU_RUN_TEST(ndarray_read_1d_tile_contiguous),
+    MU_RUN_TEST(test_asdf_ndarray_read_tile_2d),
+    MU_RUN_TEST(ndarray_read_3d_tile),
+    MU_RUN_TEST(ndarray_read_tile_byteswap),
+    MU_RUN_TEST(ndarray_numeric_conversion, test_numeric_conversion_params),
+    MU_RUN_TEST(ndarray_record_datatype),
+    MU_RUN_TEST(heap_use_after_free_issue_63)
 );
 
 
-MU_RUN_SUITE(test_asdf_ndarray);
+MU_RUN_SUITE(ndarray);

--- a/tests/test-parse-util.c
+++ b/tests/test-parse-util.c
@@ -37,10 +37,10 @@ MU_TEST(test_is_generic_yaml_directive) {
 
 
 MU_TEST_SUITE(
-    test_asdf_parse_util,
+    parse_util,
     MU_RUN_TEST(test_is_yaml_1_1_directive),
     MU_RUN_TEST(test_is_generic_yaml_directive)
 );
 
 
-MU_RUN_SUITE(test_asdf_parse_util);
+MU_RUN_SUITE(parse_util);

--- a/tests/test-parse.c
+++ b/tests/test-parse.c
@@ -17,7 +17,7 @@
  *
  * It just consists of the #ASDF and #ASDF_STANDARD comments, and nothing more
  */
-MU_TEST(test_asdf_parse_minimal) {
+MU_TEST(parse_minimal) {
     const char *filename = get_fixture_file_path("parse-minimal.asdf");
 
     asdf_parser_t *parser = asdf_parser_create(NULL);
@@ -45,9 +45,9 @@ MU_TEST(test_asdf_parse_minimal) {
 
 
 /**
- * Like `test_asdf_parse_minimal` but with an additional non-standard comment event
+ * Like `parse_minimal` but with an additional non-standard comment event
  */
-MU_TEST(test_asdf_parse_minimal_extra_comment) {
+MU_TEST(parse_minimal_extra_comment) {
     const char *filename = get_fixture_file_path("parse-minimal-extra-comment.asdf");
 
     asdf_parser_t *parser = asdf_parser_create(NULL);
@@ -78,10 +78,10 @@ MU_TEST(test_asdf_parse_minimal_extra_comment) {
 
 
 MU_TEST_SUITE(
-    test_asdf_parse,
-    MU_RUN_TEST(test_asdf_parse_minimal),
-    MU_RUN_TEST(test_asdf_parse_minimal_extra_comment)
+    parse,
+    MU_RUN_TEST(parse_minimal),
+    MU_RUN_TEST(parse_minimal_extra_comment)
 );
 
 
-MU_RUN_SUITE(test_asdf_parse);
+MU_RUN_SUITE(parse);

--- a/tests/test-stream.c
+++ b/tests/test-stream.c
@@ -18,7 +18,7 @@ static const uint8_t *tokens[] = {TOKEN("dummy"), TOKEN("asdf")};
 static size_t token_lens[] = {TOKEN_LEN("dummy"), TOKEN_LEN("asdf")};
 
 
-MU_TEST(test_file_scan_token_no_match) {
+MU_TEST(file_scan_token_no_match) {
     char buffer[] = "fdsa and some other garbage";
     FILE *file = fmemopen(buffer, strlen(buffer), "r");
     asdf_stream_t *stream = asdf_stream_from_fp(NULL, file, NULL);
@@ -37,7 +37,7 @@ MU_TEST(test_file_scan_token_no_match) {
 }
 
 
-MU_TEST(test_file_scan_token_at_beginning) {
+MU_TEST(file_scan_token_at_beginning) {
     char buffer[] = "asdf and some other garbage";
     FILE *file = fmemopen(buffer, strlen(buffer), "r");
     asdf_stream_t *stream = asdf_stream_from_fp(NULL, file, NULL);
@@ -57,7 +57,7 @@ MU_TEST(test_file_scan_token_at_beginning) {
 }
 
 
-MU_TEST(test_file_scan_token_at_end) {
+MU_TEST(file_scan_token_at_end) {
     char buffer[] = "and some other garbage asdf";
     FILE *file = fmemopen(buffer, strlen(buffer), "r");
     asdf_stream_t *stream = asdf_stream_from_fp(NULL, file, NULL);
@@ -78,7 +78,7 @@ MU_TEST(test_file_scan_token_at_end) {
 }
 
 
-MU_TEST(test_file_scan_token_in_middle) {
+MU_TEST(file_scan_token_in_middle) {
     char buffer[] = "fdsa and some asdf other garbage";
     FILE *file = fmemopen(buffer, strlen(buffer), "r");
     asdf_stream_t *stream = asdf_stream_from_fp(NULL, file, NULL);
@@ -99,7 +99,7 @@ MU_TEST(test_file_scan_token_in_middle) {
 }
 
 
-MU_TEST(test_file_scan_token_spans_buffers) {
+MU_TEST(file_scan_token_spans_buffers) {
     char buffer[] = "fdsa and some asdf other garbage";
 
     // Hack buf_size so that it only reads up to part-way into the token to match
@@ -133,7 +133,7 @@ MU_TEST(test_file_scan_token_spans_buffers) {
 }
 
 
-MU_TEST(test_stream_file_open_mem) {
+MU_TEST(stream_file_open_mem) {
     const char *filename = get_fixture_file_path("255.asdf");
     asdf_stream_t *stream = asdf_stream_from_file(NULL, filename);
     assert_not_null(stream);
@@ -153,7 +153,7 @@ MU_TEST(test_stream_file_open_mem) {
 }
 
 
-MU_TEST(test_stream_mem_open_mem) {
+MU_TEST(stream_mem_open_mem) {
     const char *filename = get_fixture_file_path("255.asdf");
     size_t filesize = 0;
     char *data = tail_file(filename, 0, &filesize);
@@ -178,14 +178,14 @@ MU_TEST(test_stream_mem_open_mem) {
 
 
 MU_TEST_SUITE(
-    test_asdf_stream,
-    MU_RUN_TEST(test_file_scan_token_at_beginning),
-    MU_RUN_TEST(test_file_scan_token_at_end),
-    MU_RUN_TEST(test_file_scan_token_in_middle),
-    MU_RUN_TEST(test_file_scan_token_spans_buffers),
-    MU_RUN_TEST(test_stream_file_open_mem),
-    MU_RUN_TEST(test_stream_mem_open_mem)
+    stream,
+    MU_RUN_TEST(file_scan_token_at_beginning),
+    MU_RUN_TEST(file_scan_token_at_end),
+    MU_RUN_TEST(file_scan_token_in_middle),
+    MU_RUN_TEST(file_scan_token_spans_buffers),
+    MU_RUN_TEST(stream_file_open_mem),
+    MU_RUN_TEST(stream_mem_open_mem)
 );
 
 
-MU_RUN_SUITE(test_asdf_stream);
+MU_RUN_SUITE(stream);

--- a/tests/test-value-util.c
+++ b/tests/test-value-util.c
@@ -13,9 +13,9 @@ MU_TEST(test_asdf_common_tag_get) {
 
 
 MU_TEST_SUITE(
-    test_asdf_value_util,
+    value_util,
     MU_RUN_TEST(test_asdf_common_tag_get)
 );
 
 
-MU_RUN_SUITE(test_asdf_value_util);
+MU_RUN_SUITE(value_util);

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -491,7 +491,7 @@ MU_TEST(test_asdf_value_as_double) {
 /**
  * Test that scalars explicitly tagged as !!str as interpreted as strings
  */
-MU_TEST(test_asdf_value_tagged_strings) {
+MU_TEST(test_value_tagged_strings) {
     const char *path = get_fixture_file_path("tagged-scalars.asdf");
     asdf_file_t *file = asdf_open_file(path, "r");
     assert_not_null(file);
@@ -746,7 +746,7 @@ static bool value_find_pred_b(asdf_value_t *value) {
 }
 
 
-MU_TEST(test_value_find_iter_ex_descend_mapping_only) {
+MU_TEST(test_asdf_value_find_iter_ex_descend_mapping_only) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -786,7 +786,7 @@ MU_TEST(test_value_find_iter_ex_descend_mapping_only) {
 }
 
 
-MU_TEST(test_value_find_iter_ex_descend_sequence_only) {
+MU_TEST(test_asdf_value_find_iter_ex_descend_sequence_only) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -826,7 +826,7 @@ MU_TEST(test_value_find_iter_ex_descend_sequence_only) {
 }
 
 
-MU_TEST(test_value_find_iter_max_depth) {
+MU_TEST(test_asdf_value_find_iter_max_depth) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -860,7 +860,7 @@ MU_TEST(test_value_find_iter_max_depth) {
 }
 
 
-MU_TEST(test_value_find_ex) {
+MU_TEST(test_asdf_value_find_ex) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -887,7 +887,7 @@ MU_TEST(test_value_find_ex) {
 }
 
 
-MU_TEST(test_value_find_iter) {
+MU_TEST(test_asdf_value_find_iter) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -935,7 +935,7 @@ MU_TEST(test_value_find_iter) {
 }
 
 
-MU_TEST(test_value_find) {
+MU_TEST(test_asdf_value_find) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -961,7 +961,7 @@ MU_TEST(test_value_find) {
 }
 
 
-MU_TEST(test_value_find_on_scalar) {
+MU_TEST(test_asdf_value_find_on_scalar) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open_file(filename, "r");
     assert_not_null(file);
@@ -1043,7 +1043,7 @@ MU_TEST(test_clone_extension_value) {
 
 
 MU_TEST_SUITE(
-    test_asdf_value,
+    value,
     MU_RUN_TEST(test_asdf_value_get_type),
     MU_RUN_TEST(test_asdf_value_as_string),
     MU_RUN_TEST(test_asdf_value_as_string0),
@@ -1062,23 +1062,23 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_value_as_uint64_on_bigint),
     MU_RUN_TEST(test_asdf_value_as_float),
     MU_RUN_TEST(test_asdf_value_as_double),
-    MU_RUN_TEST(test_asdf_value_tagged_strings),
+    MU_RUN_TEST(test_value_tagged_strings),
     MU_RUN_TEST(test_asdf_mapping_iter),
     MU_RUN_TEST(test_asdf_mapping_get),
     MU_RUN_TEST(test_asdf_sequence_iter),
     MU_RUN_TEST(test_asdf_sequence_get),
     MU_RUN_TEST(test_asdf_container_iter),
     MU_RUN_TEST(test_value_copy_with_parent_path),
-    MU_RUN_TEST(test_value_find_iter_ex_descend_mapping_only),
-    MU_RUN_TEST(test_value_find_iter_ex_descend_sequence_only),
-    MU_RUN_TEST(test_value_find_iter_max_depth),
-    MU_RUN_TEST(test_value_find_ex),
-    MU_RUN_TEST(test_value_find_iter),
-    MU_RUN_TEST(test_value_find),
-    MU_RUN_TEST(test_value_find_on_scalar),
+    MU_RUN_TEST(test_asdf_value_find_iter_ex_descend_mapping_only),
+    MU_RUN_TEST(test_asdf_value_find_iter_ex_descend_sequence_only),
+    MU_RUN_TEST(test_asdf_value_find_iter_max_depth),
+    MU_RUN_TEST(test_asdf_value_find_ex),
+    MU_RUN_TEST(test_asdf_value_find_iter),
+    MU_RUN_TEST(test_asdf_value_find),
+    MU_RUN_TEST(test_asdf_value_find_on_scalar),
     MU_RUN_TEST(test_raw_value_type_preserved_after_type_resolution),
     MU_RUN_TEST(test_clone_extension_value)
 );
 
 
-MU_RUN_SUITE(test_asdf_value);
+MU_RUN_SUITE(value);


### PR DESCRIPTION
It was just annoying, and mostly unnecessary as long as none of the names clash with existing symbols.  Dropping these prefixes makes the the logs a bit more readable for me and also makes it less hassle to type individual test names.

Did however keep `test_asdf_` in the case of unit tests for specific functions like `test_asdf_mapping_get`, etc.