### PR TITLE
update version format to use PEP-440 style

### DIFF
--- a/.bumpver.toml
+++ b/.bumpver.toml
@@ -1,6 +1,6 @@
 [bumpver]
-current_version = "0.1.0-alpha1"
-version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
+current_version = "0.1.0a1"
+version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"
 commit_message = "bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"
 tag_scope = "default"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 # Internal full package version
-set(PACKAGE_VERSION 0.1.0-alpha1)
+set(PACKAGE_VERSION 0.1.0a1)
 
 # CMake-compatible project version
 set(PROJECT_VERSION 0.1.0)

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ([2.69])
 AC_INIT(
-  [libasdf], [0.1.0-alpha1],
+  [libasdf], [0.1.0a1],
   [https://github.com/asdf-format/libasdf/issues],
   [],
   [https://github.com/asdf-format/libasdf],

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ from pathlib import Path
 def read_config_h() -> tuple[str, str, str]:
     """Read package data out of config.h if possible"""
     project = 'libasdf'
-    release = '0.1.0-alpha1'
+    release = '0.1.0a1'
 
     config_h_path = Path(__file__).parent.parent / 'config.h'
 

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,6 +1,6 @@
 [tool.towncrier]
 name = "libasdf"
-version = "0.1.0-alpha1"
+version = "0.1.0a1"
 directory = "changes"
 filename = "CHANGES.rst"
 issue_format = "`#{issue} <https://github.com/asdf-format/asdf/issues/{issue}>`_"


### PR DESCRIPTION
Resolves #92 

I was thinking at first I might do a little more with this, like adding a `.dev` after release, but it seems bumpver doesn't really fully support that, which is too bad.  Haven't really thought much about it beyond that, just bugs me that after a release any development build has the previous release version number attached with is maybe not right.  Not very important right now especially if I'm the only one making releases.