### PR TITLE
chore: clean up of includes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,12 @@ src_headers = \
     src/compression/compression.h \
     src/compression/compressor_registry.h \
     src/context.h \
+    src/core/asdf.h \
+    src/core/extension_metadata.h \
+    src/core/history_entry.h \
+    src/core/ndarray.h \
     src/core/ndarray_convert.h \
+    src/core/software.h \
     src/emitter.h \
     src/error.h \
     src/extension_registry.h \
@@ -69,6 +74,7 @@ if WITH_GWCS
     src_headers += \
         src/gwcs/fitswcs_imaging.h \
         src/gwcs/frame.h \
+        src/gwcs/gwcs.h \
         src/gwcs/step.h \
         src/gwcs/transform.h \
         src/gwcs/types/asdf_gwcs_transform_map.h

--- a/src/compression/compression.c
+++ b/src/compression/compression.c
@@ -13,9 +13,9 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
+#ifdef HAVE_CONFIG_H
 #include "config.h"
-#include <asdf/file.h>
-#include <asdf/log.h>
+#endif
 
 #ifdef HAVE_USERFAULTFD
 #include <fcntl.h>
@@ -38,6 +38,7 @@
 #include "../file.h"
 #include "../log.h"
 #include "../util.h"
+
 #include "compression.h"
 #include "compressor_registry.h"
 

--- a/src/compression/compression.h
+++ b/src/compression/compression.h
@@ -6,11 +6,16 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #ifdef HAVE_USERFAULTFD
 #include <linux/userfaultfd.h>
 #endif
 
-#include <asdf/file.h>
+#include "../file.h"
+#include "../util.h"
 
 
 typedef enum {

--- a/src/compression/compressor_registry.h
+++ b/src/compression/compressor_registry.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <asdf/util.h>
-
+#include "../util.h"
 #include "compression.h"
 
 

--- a/src/context.h
+++ b/src/context.h
@@ -12,7 +12,7 @@
 #include <stdatomic.h>
 #include <stdio.h>
 
-#include <asdf/log.h>
+#include "asdf/log.h"
 
 #include "util.h"
 

--- a/src/core/asdf.c
+++ b/src/core/asdf.c
@@ -1,8 +1,3 @@
-#include <asdf/core/asdf.h>
-#include <asdf/core/extension_metadata.h>
-#include <asdf/core/history_entry.h>
-#include <asdf/core/software.h>
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -11,6 +6,11 @@
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
+
+#include "asdf.h"
+#include "extension_metadata.h"
+#include "history_entry.h"
+#include "software.h"
 
 
 asdf_software_t libasdf_software = {

--- a/src/core/asdf.h
+++ b/src/core/asdf.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "asdf/core/asdf.h" // IWYU pragma: export

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -1,11 +1,11 @@
-#include <asdf/core/asdf.h>
-#include <asdf/core/extension_metadata.h>
-#include <asdf/core/software.h>
-#include <asdf/extension.h>
-
+#include "../extension_registry.h"
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
+
+#include "asdf.h"
+#include "extension_metadata.h"
+#include "software.h"
 
 
 static asdf_value_err_t asdf_extension_metadata_deserialize(

--- a/src/core/extension_metadata.h
+++ b/src/core/extension_metadata.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "asdf/core/extension_metadata.h" // IWYU pragma: export

--- a/src/core/history_entry.c
+++ b/src/core/history_entry.c
@@ -6,15 +6,14 @@
 #include <string.h>
 #include <time.h>
 
-#include <asdf/core/asdf.h>
-#include <asdf/core/history_entry.h>
-#include <asdf/core/software.h>
-#include <asdf/extension.h>
-
 #include "../error.h"
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
+
+#include "asdf.h"
+#include "history_entry.h"
+#include "software.h"
 
 
 /*

--- a/src/core/history_entry.h
+++ b/src/core/history_entry.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "asdf/core/history_entry.h" // IWYU pragma: export

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -1,37 +1,17 @@
-#include "asdf/value.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-
-#include <asdf/core/asdf.h>
-#define ASDF_CORE_NDARRAY_INTERNAL
-#include <asdf/core/ndarray.h>
-#undef ASDF_CORE_NDARRAY_INTERNAL
-#include <asdf/extension.h>
 
 #include "../extension_util.h"
 #include "../file.h"
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
+
+#include "asdf.h"
+#include "ndarray.h"
 #include "ndarray_convert.h"
-
-
-/** Internal definition of the asdf_ndarray_t type with extended internal fields */
-typedef struct asdf_ndarray {
-    size_t source;
-    uint32_t ndim;
-    uint64_t *shape;
-    asdf_datatype_t datatype;
-    asdf_byteorder_t byteorder;
-    uint64_t offset;
-    int64_t *strides;
-
-    // Internal fields
-    asdf_block_t *block;
-    asdf_file_t *file;
-} asdf_ndarray_t;
 
 
 #ifdef ASDF_LOG_ENABLED

--- a/src/core/ndarray.h
+++ b/src/core/ndarray.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#define ASDF_CORE_NDARRAY_INTERNAL
+#include "asdf/core/ndarray.h" // IWYU pragma: export
+
+
+/** Internal definition of the asdf_ndarray_t type with extended internal fields */
+typedef struct asdf_ndarray {
+    size_t source;
+    uint32_t ndim;
+    uint64_t *shape;
+    asdf_datatype_t datatype;
+    asdf_byteorder_t byteorder;
+    uint64_t offset;
+    int64_t *strides;
+
+    // Internal fields
+    asdf_block_t *block;
+    asdf_file_t *file;
+} asdf_ndarray_t;

--- a/src/core/ndarray_convert.c
+++ b/src/core/ndarray_convert.c
@@ -12,9 +12,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <asdf/core/ndarray.h>
-
 #include "../util.h"
+
+#include "ndarray.h"
 #include "ndarray_convert.h"
 
 

--- a/src/core/ndarray_convert.h
+++ b/src/core/ndarray_convert.h
@@ -3,9 +3,9 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include <asdf/core/ndarray.h>
-
 #include "../util.h"
+
+#include "ndarray.h"
 
 
 typedef int (*asdf_ndarray_convert_fn_t)(

--- a/src/core/software.c
+++ b/src/core/software.c
@@ -1,10 +1,8 @@
-#include <asdf/core/asdf.h>
-#include <asdf/core/software.h>
-#include <asdf/extension.h>
-
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
+
+#include "asdf.h"
 
 
 static asdf_value_err_t asdf_software_deserialize(

--- a/src/core/software.h
+++ b/src/core/software.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "asdf/core/software.h" // IWYU pragma: export

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -1,8 +1,6 @@
 #include <assert.h>
-#include <errno.h>
 #include <stdbool.h>
 
-#include "asdf/emitter.h"
 #include "context.h"
 #include "emitter.h"
 #include "error.h"

--- a/src/emitter.h
+++ b/src/emitter.h
@@ -9,7 +9,7 @@
  */
 #pragma once
 
-#include <asdf/emitter.h>
+#include "asdf/emitter.h" // IWYU pragma: export
 
 #include "context.h"
 #include "stream.h"

--- a/src/event.c
+++ b/src/event.c
@@ -14,6 +14,7 @@
 #include "parse_util.h"
 #include "parser.h"
 #include "util.h"
+#include "yaml.h"
 
 
 asdf_event_type_t asdf_event_type(asdf_event_t *event) {

--- a/src/event.h
+++ b/src/event.h
@@ -7,10 +7,9 @@
 #include "config.h"
 #endif
 
-#include <asdf/event.h>
+#include "asdf/event.h" // IWYU pragma: export
 
 #include "util.h"
-#include "yaml.h"
 
 
 static const char *const asdf_event_type_names[] = {

--- a/src/extension_registry.h
+++ b/src/extension_registry.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#include <asdf/extension.h>
+#include "asdf/extension.h" // IWYU pragma: export

--- a/src/extension_util.c
+++ b/src/extension_util.c
@@ -1,12 +1,10 @@
-#include <ctype.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <asdf/value.h>
-
 #include "extension_util.h"
 #include "log.h"
+#include "value.h"
 
 
 /**

--- a/src/extension_util.h
+++ b/src/extension_util.h
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <asdf/extension.h>
-#include <asdf/util.h>
-
+#include "extension_registry.h"
+#include "util.h"
 #include "value.h"
 
 

--- a/src/file.h
+++ b/src/file.h
@@ -6,9 +6,8 @@
 #include "config.h"
 #endif
 
-#include <asdf/file.h>
+#include "asdf/file.h" // IWYU pragma: export
 
-#include "compression/compression.h"
 #include "context.h"
 #include "emitter.h"
 #include "parser.h"
@@ -49,6 +48,8 @@ typedef struct asdf_file {
 /* Internal helper to get the `struct fy_document` for the tree, if any */
 ASDF_LOCAL struct fy_document *asdf_file_get_tree_document(asdf_file_t *file);
 
+// Forward-declaration
+typedef struct _asdf_block_comp_state_t asdf_block_comp_state_t;
 
 /**
  * User-level object for inspecting ASDF block metadata and data

--- a/src/gwcs/fitswcs_imaging.c
+++ b/src/gwcs/fitswcs_imaging.c
@@ -1,29 +1,14 @@
 #include <assert.h>
 #include <stdlib.h>
 
-// NOTE: The internal definitions for asdf_gwcs_transform_t must be included early
-#include "transform.h"
-
-#include <asdf/core/asdf.h>
-#include <asdf/core/ndarray.h>
-#include <string.h>
-#define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/core.h>
-#include <asdf/gwcs/fitswcs_imaging.h>
-#include <asdf/gwcs/frame.h>
-#include <asdf/gwcs/frame_celestial.h>
-#include <asdf/gwcs/gwcs.h>
-#include <asdf/gwcs/step.h>
-#include <asdf/gwcs/transform.h>
-#include <asdf/gwcs/transforms/property/bounding_box.h>
-#undef ASDF_GWCS_INTERNAL
-#include <asdf/value.h>
-
+#include "../core/ndarray.h"
 #include "../extension_util.h"
 #include "../log.h"
 #include "../util.h"
 
+#include "gwcs.h"
 #include "step.h"
+#include "transform.h"
 
 
 /** Helper to read crpix, crval, etc. */

--- a/src/gwcs/fitswcs_imaging.h
+++ b/src/gwcs/fitswcs_imaging.h
@@ -2,11 +2,10 @@
  * Internal routines for fitswcs_imaging
  */
 
-#include <asdf/file.h>
-#define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/wcs.h>
-#undef ASDF_GWCS_INTERNAL
-#include <asdf/util.h>
+#include "../file.h"
+#include "../util.h"
+
+#include "gwcs.h"
 
 
 ASDF_LOCAL asdf_gwcs_err_t asdf_gwcs_fits_get_ctype(

--- a/src/gwcs/frame.c
+++ b/src/gwcs/frame.c
@@ -2,19 +2,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include <asdf/core/asdf.h>
-#include <asdf/extension.h>
-#include <asdf/gwcs/frame.h>
-#include <asdf/gwcs/frame2d.h>
-#include <asdf/gwcs/gwcs.h>
-#include <asdf/log.h>
-#include <asdf/value.h>
-
 #include "../extension_util.h"
 #include "../util.h"
 #include "../value.h"
 
 #include "frame.h"
+#include "gwcs.h"
 
 #ifdef ASDF_LOGGING_ENABLED
 static inline void warn_invalid_frame_axes_param(

--- a/src/gwcs/frame.h
+++ b/src/gwcs/frame.h
@@ -2,9 +2,9 @@
 
 #include <stdint.h>
 
-#include <asdf/gwcs/frame.h>
-#include <asdf/util.h>
+#include "gwcs.h"
 
+#include "../util.h"
 #include "../value.h"
 
 

--- a/src/gwcs/frame2d.c
+++ b/src/gwcs/frame2d.c
@@ -1,13 +1,8 @@
-#include <asdf/core/asdf.h>
-#include <asdf/gwcs/gwcs.h>
-#include <asdf/log.h>
-
 #include "../util.h"
 #include "../value.h"
 
-#include "asdf/gwcs/frame.h"
-#include "asdf/value.h"
 #include "frame.h"
+#include "gwcs.h"
 
 
 static asdf_value_err_t asdf_gwcs_frame2d_deserialize(

--- a/src/gwcs/frame_celestial.c
+++ b/src/gwcs/frame_celestial.c
@@ -1,13 +1,8 @@
-#include <asdf/core/asdf.h>
-#include <asdf/gwcs/gwcs.h>
-#include <asdf/log.h>
-
 #include "../util.h"
 #include "../value.h"
 
-#include "asdf/gwcs/frame.h"
-#include "asdf/value.h"
 #include "frame.h"
+#include "gwcs.h"
 
 
 static asdf_value_err_t asdf_gwcs_frame_celestial_deserialize(

--- a/src/gwcs/gwcs.h
+++ b/src/gwcs/gwcs.h
@@ -1,0 +1,8 @@
+#pragma once
+#define ASDF_GWCS_INTERNAL
+#include "asdf/gwcs/core.h"                             // IWYU pragma: export
+#include "asdf/gwcs/fitswcs_imaging.h"                  // IWYU pragma: export
+#include "asdf/gwcs/frame.h"                            // IWYU pragma: export
+#include "asdf/gwcs/frame2d.h"                          // IWYU pragma: export
+#include "asdf/gwcs/frame_celestial.h"                  // IWYU pragma: export
+#include "asdf/gwcs/transforms/property/bounding_box.h" // IWYU pragma: export

--- a/src/gwcs/step.c
+++ b/src/gwcs/step.c
@@ -1,21 +1,14 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
-#include <asdf/core/asdf.h>
-#include <asdf/extension.h>
-#define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/frame.h>
-#include <asdf/gwcs/frame2d.h>
-#include <asdf/gwcs/gwcs.h>
-#undef ASDF_GWCS_INTERNAL
-#include <asdf/value.h>
+#include "gwcs.h"
+#include "step.h"
+#include "transform.h"
 
 #include "../extension_util.h"
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
-#include "step.h"
-#include "transform.h"
 
 
 static asdf_value_err_t asdf_gwcs_step_deserialize(

--- a/src/gwcs/transform.c
+++ b/src/gwcs/transform.c
@@ -1,17 +1,8 @@
 #include <stdatomic.h>
 
-#define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/core.h>
-#include <asdf/gwcs/fitswcs_imaging.h>
-#include <asdf/gwcs/transform.h>
-#include <asdf/gwcs/transforms/property/bounding_box.h>
-#include <asdf/gwcs/wcs.h>
-#undef ASDF_GWCS_INTERNAL
-#include <asdf/util.h>
-#include <asdf/value.h>
-
 #include "../extension_util.h"
-#include "transform.h"
+
+#include "gwcs.h"
 #include "types/asdf_gwcs_transform_map.h"
 
 

--- a/src/gwcs/transform.h
+++ b/src/gwcs/transform.h
@@ -2,10 +2,11 @@
 #pragma once
 
 #define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/transform.h>
+#include "asdf/gwcs/transform.h" // IWYU pragma: export
 #undef ASDF_GWCS_INTERNAL
-#include <asdf/util.h>
-#include <asdf/value.h>
+
+#include "../util.h"
+#include "../value.h"
 
 
 ASDF_LOCAL asdf_value_err_t

--- a/src/gwcs/transforms/property/bounding_box.c
+++ b/src/gwcs/transforms/property/bounding_box.c
@@ -1,14 +1,10 @@
 #include <stdlib.h>
 
-#include <asdf/core/asdf.h>
-#define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/transform.h>
-#include <asdf/gwcs/transforms/property/bounding_box.h>
-#undef ASDF_GWCS_INTERNAL
-#include <asdf/value.h>
-
 #include "../../../extension_util.h"
 #include "../../../log.h"
+#include "../../../value.h"
+
+#include "../../gwcs.h"
 
 
 static asdf_value_err_t asdf_gwcs_bounding_box_deserialize(

--- a/src/gwcs/types/asdf_gwcs_transform_map.h
+++ b/src/gwcs/types/asdf_gwcs_transform_map.h
@@ -6,8 +6,6 @@
 
 #include <stc/cstr.h>
 
-#include <asdf/gwcs/transform.h>
-
 #define i_type asdf_gwcs_transform_map
 #define i_keypro cstr
 #define i_val asdf_gwcs_transform_type_t

--- a/src/gwcs/wcs.c
+++ b/src/gwcs/wcs.c
@@ -1,19 +1,12 @@
 #include <stdlib.h>
 
-#include <asdf/core/asdf.h>
-#include <asdf/extension.h>
-#define ASDF_GWCS_INTERNAL
-#include <asdf/gwcs/fitswcs_imaging.h>
-#include <asdf/gwcs/gwcs.h>
-#include <asdf/gwcs/transform.h>
-#undef ASDF_GWCS_INTERNAL
-#include <asdf/value.h>
-
 #include "../extension_util.h"
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
+
 #include "fitswcs_imaging.h"
+#include "gwcs.h"
 #include "step.h"
 
 

--- a/src/log.h
+++ b/src/log.h
@@ -4,9 +4,7 @@
 #include "config.h"
 #endif
 
-#include <stdio.h>
-
-#include <asdf/log.h>
+#include "asdf/log.h" // IWYU pragma: export
 
 #include "context.h"
 #include "util.h"

--- a/src/parser.h
+++ b/src/parser.h
@@ -9,13 +9,12 @@
 
 #include <libfyaml.h>
 
-#include <asdf/parser.h>
+#include "asdf/parser.h" // IWYU pragma: export
 
 #include "block.h"
 #include "context.h"
 #include "event.h"
 #include "stream.h"
-#include "util.h"
 
 
 #define ASDF_COMMENT_CHAR '#'

--- a/src/util.h
+++ b/src/util.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <string.h>
 
-#include <asdf/util.h>
+#include "asdf/util.h" // IWYU pragma: export
 
 
 #if defined(__GNUC__) || defined(__clang__)

--- a/src/value.h
+++ b/src/value.h
@@ -5,11 +5,11 @@
 
 #include <libfyaml.h>
 
-#include <asdf/extension.h>
-#include <asdf/util.h>
-#include <asdf/value.h>
+#include "asdf/extension.h"
+#include "asdf/value.h" // IWYU pragma: export
 
 #include "file.h"
+#include "util.h"
 
 
 typedef struct {

--- a/src/yaml.h
+++ b/src/yaml.h
@@ -14,4 +14,4 @@
 #endif
 
 
-#include <asdf/yaml.h>
+#include "asdf/yaml.h" // IWYU pragma: export

--- a/tests/test-event.c
+++ b/tests/test-event.c
@@ -1,8 +1,8 @@
-#include <errno.h>
 #include <string.h>
 
 #include <asdf/event.h>
 #include <asdf/parser.h>
+#include <asdf/yaml.h>
 
 #include "munit.h"
 #include "util.h"
@@ -10,7 +10,6 @@
 #include "block.h"
 #include "event.h"
 #include "parser.h"
-#include "yaml.h"
 
 
 /**

--- a/tests/test-file.c
+++ b/tests/test-file.c
@@ -24,6 +24,7 @@
 #include <asdf/core/ndarray.h>
 #include <asdf/value.h>
 
+#include "compression/compression.h"
 #include "config.h"
 #include "file.h"
 #include "munit.h"


### PR DESCRIPTION
This was something that was bothering me for a while and is good to fix now.  Have been sloppy with handling includes particularly within the source code:

- Never `#include <asdf/...>`: this can get confused with system-installed headers

- .c sources should prefer to use the internal headers under src/*.h where possible

- Add IWYU (Include What You Use) pragmas in the internal headers so that clangd stops complaining about "Include file ... not used directly"