### PR TITLE
Workaround for checksum verification bug on ASDF files generated by Python

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ src_files = \
     src/util.c \
     src/value.c \
     src/value_util.c \
+    src/version.c \
     src/yaml.c
 
 src_headers = \

--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -136,12 +136,16 @@ For this example we need to write a few pieces of code:
        const char *foo;
    } asdf_foo_t;
 
+   static asdf_version_t asdf_foo_version = {
+       .version = "1.0.0",
+       .major = 1
+   }
 
    static asdf_software_t asdf_foo_software = {
        .name = "foo",
        .author = "STScI",
        .homepage = "https://stsci.edu",
-       .version = "1.0.0"
+       .version = &asdf_foo_version
    };
 
 The ``asdf_foo_deserialize`` function will be passed the raw value (as an

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -17,6 +17,7 @@ install(
         asdf/parser.h
         asdf/util.h
         asdf/value.h
+        asdf/version.h
         asdf/yaml.h
 
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/asdf"

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,6 +17,7 @@ nobase_include_HEADERS = \
     asdf/parser.h \
     asdf/util.h \
     asdf/value.h \
+    asdf/version.h \
     asdf/yaml.h
 
 

--- a/include/asdf/core/asdf.h
+++ b/include/asdf/core/asdf.h
@@ -7,10 +7,12 @@
 #include <asdf/core/time.h>
 #include <asdf/extension.h>
 #include <asdf/util.h>
+#include <asdf/version.h>
 
 
 ASDF_BEGIN_DECLS
 
+ASDF_EXPORT extern asdf_version_t libasdf_version;
 ASDF_EXPORT extern asdf_software_t libasdf_software;
 
 

--- a/include/asdf/extension.h
+++ b/include/asdf/extension.h
@@ -3,24 +3,24 @@
 #define ASDF_EXTENSION_H
 
 #include <stdbool.h>
-#include <stdlib.h>
 
 #include <asdf/file.h>
 #include <asdf/util.h>
 #include <asdf/value.h>
+#include <asdf/version.h>
 
 
 ASDF_BEGIN_DECLS
 
 typedef struct {
     const char *name;
-    const char *version;
+    const asdf_version_t *version;
 } asdf_tag_t;
 
 
 typedef struct {
     const char *name;
-    const char *version;
+    const asdf_version_t *version;
     const char *author;
     const char *homepage;
 } asdf_software_t;
@@ -63,12 +63,12 @@ ASDF_EXPORT const asdf_extension_t *asdf_extension_get(asdf_file_t *file, const 
 /**
  * Parse a tag string of the form "name" or "name-version" into an
  * asdf_tag_t.  Returns NULL on OOM.  The caller owns the result
- * and must free it with asdf_tag_free.
+ * and must free it with asdf_tag_destroy.
  */
 ASDF_EXPORT asdf_tag_t *asdf_tag_parse(const char *tag);
 
 /** Free a tag returned by asdf_tag_parse. */
-ASDF_EXPORT void asdf_tag_free(asdf_tag_t *tag);
+ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
 
 
 #define ASDF_EXT_PREFIX asdf

--- a/include/asdf/file.h
+++ b/include/asdf/file.h
@@ -1009,17 +1009,29 @@ ASDF_EXPORT bool asdf_block_checksum_verify(
 /**
  * Returns a `void *` to the beginning of the block data, and optionally its size
  *
- * .. note::
- *
- *   Compressed blocks are not yet supported, or rather, are not automatically
- *   decompressed.  This is a TODO.
- *
  * :param block: The `asdf_block_t *` handle
  * :param size: Optional `size_t *` into which the size of the block data is
  *   is returned
  * :return: A `void *` to the block data
  */
 ASDF_EXPORT const void *asdf_block_data(asdf_block_t *block, size_t *size);
+
+
+/**
+ * Returns a `void *` to the beginning of the block data, and optionally its size
+ *
+ * For uncompressed block data this is equivalent to `asdf_block_data`; for
+ * compressed blocks, however, this returns the raw compressed data without
+ * decompression, and the size returned is the size of the compressed data.
+ *
+ * Use `asdf_block_data` for access to the uncompressed data.
+ *
+ * :param block: The `asdf_block_t *` handle
+ * :param size: Optional `size_t *` into which the size of the block data is
+ *   is returned
+ * :return: A `void *` to the block data
+ */
+ASDF_EXPORT const void *asdf_block_data_raw(asdf_block_t *block, size_t *size);
 
 ASDF_END_DECLS
 

--- a/include/asdf/version.h
+++ b/include/asdf/version.h
@@ -50,6 +50,15 @@ typedef struct {
  */
 ASDF_EXPORT asdf_version_t *asdf_version_parse(const char *version);
 
+
+/**
+ * Deep copy of an `asdf_version_t *`
+ *
+ * :param version: The `asdf_version_t *` to copy -- all fields are deep-copied
+ *   as well
+ */
+ASDF_EXPORT asdf_version_t *asdf_version_copy(const asdf_version_t *version);
+
 /**
  * Free memory allocated for an `asdf_version_t` by `asdf_version_parse`
  *

--- a/include/asdf/version.h
+++ b/include/asdf/version.h
@@ -1,0 +1,64 @@
+/** Version parsing utils */
+
+#ifndef ASDF_VERSION_H
+#define ASDF_VERSION_H
+
+#include <asdf/util.h>
+
+ASDF_BEGIN_DECLS
+
+/**
+ * Struct representing a version string from an ASDF file
+ *
+ * This is used forthe ASDF format version, ASDF Standard version,
+ * tag versions, etc. where applicable.
+ */
+typedef struct {
+    /** The full, unparsed version string */
+    const char *version;
+    /** The major version number, if the version was in X.Y.Z format */
+    unsigned int major;
+    /** The minor version number, if the version was in X.Y.Z format */
+    unsigned int minor;
+    /** The patch version number, if the version was in X.Y.Z format */
+    unsigned int patch;
+    /**
+     * Extra version info
+     *
+     * Any trailing version info following parsed X.Y.Z versions; if there
+     * was an additional dot as in PEP-440 .devN versions, the dot is omitted.
+     * Likewise if the extra version info was separated from the main version
+     * by a hyphen ``-`` that is omitted.  Any other less common version
+     * suffixes are returned here verbatim.
+     */
+    const char *extra;
+} asdf_version_t;
+
+
+/**
+ * Parse a version string into an `asdf_version_t`
+ *
+ * If the version is not in MAJOR.MINOR.PATCH format an `asdf_version_t *` is
+ * still returned but with the full version string copied verbatim into the
+ * ``version`` field, and the major/minor/patch fields set to 0.
+ *
+ * The `asdf_version_t` allocated by this function must be freed with
+ * `asdf_version_destroy`.
+ *
+ * :param version: The version string to parse
+ * :return: A heap-allocated `asdf_version_t` into which the version was parsed
+ */
+ASDF_EXPORT asdf_version_t *asdf_version_parse(const char *version);
+
+/**
+ * Free memory allocated for an `asdf_version_t` by `asdf_version_parse`
+ *
+ * :param version: The `asdf_version_t *` to free; the memory it points to is
+ *   also zeroed out.
+ */
+ASDF_EXPORT void asdf_version_destroy(asdf_version_t *version);
+
+
+ASDF_END_DECLS
+
+#endif /* ASDF_VERSION_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,7 @@ set(libasdf_sources
     util.c
     value.c
     value_util.c
+    version.c
     yaml.c
 )
 

--- a/src/core/asdf.c
+++ b/src/core/asdf.c
@@ -2,6 +2,8 @@
 #include "config.h"
 #endif
 
+#include "asdf/version.h"
+
 #include "../error.h"
 #include "../log.h"
 #include "../util.h"
@@ -13,9 +15,12 @@
 #include "software.h"
 
 
+asdf_version_t libasdf_version = {0};
+
+
 asdf_software_t libasdf_software = {
     .name = PACKAGE_NAME,
-    .version = PACKAGE_VERSION,
+    .version = &libasdf_version,
     .homepage = PACKAGE_URL,
     .author = "The libasdf Developers"};
 
@@ -449,3 +454,20 @@ ASDF_REGISTER_EXTENSION(
     asdf_meta_copy,
     asdf_meta_dealloc,
     NULL);
+
+
+ASDF_CONSTRUCTOR static void asdf_libasdf_version_init() {
+    asdf_version_t *version = asdf_version_parse(PACKAGE_VERSION);
+    libasdf_version.version = version->version;
+    libasdf_version.major = version->major;
+    libasdf_version.minor = version->minor;
+    libasdf_version.patch = version->patch;
+    libasdf_version.extra = version->extra;
+    free(version);
+}
+
+
+ASDF_DESTRUCTOR static void asdf_libasdf_version_destroy() {
+    free((void *)libasdf_version.version);
+    free((void *)libasdf_version.extra);
+}

--- a/src/core/software.c
+++ b/src/core/software.c
@@ -45,7 +45,7 @@ static asdf_value_t *asdf_software_serialize(
     if (err != ASDF_VALUE_OK)
         goto cleanup;
 
-    err = asdf_mapping_set_string0(software_map, "version", software->version);
+    err = asdf_mapping_set_string0(software_map, "version", software->version->version);
 
     if (err != ASDF_VALUE_OK)
         goto cleanup;
@@ -125,7 +125,7 @@ static asdf_value_err_t asdf_software_deserialize(
     }
 
     software->name = name ? strdup(name) : name;
-    software->version = version ? strdup(version) : version;
+    software->version = (const asdf_version_t *)asdf_version_parse(version);
     software->homepage = homepage ? strdup(homepage) : homepage;
     software->author = author ? strdup(author) : author;
     *out = software;
@@ -142,7 +142,7 @@ static void asdf_software_dealloc(void *value) {
 
     asdf_software_t *software = value;
     free((void *)software->name);
-    free((void *)software->version);
+    asdf_version_destroy((asdf_version_t *)software->version);
     free((void *)software->homepage);
     free((void *)software->author);
     free(value);
@@ -167,7 +167,7 @@ static void *asdf_software_copy(const void *value) {
     }
 
     if (software->version) {
-        copy->version = strdup(software->version);
+        copy->version = asdf_version_copy(software->version);
 
         if (!copy->version)
             goto failure;
@@ -222,8 +222,8 @@ void asdf_library_set_version(asdf_file_t *file, const char *version) {
     }
 
     if (software->version)
-        free((void *)software->version);
+        asdf_version_destroy((asdf_version_t *)software->version);
 
-    software->version = version ? strdup(version) : strdup("");
+    software->version = asdf_version_parse(version);
     file->asdf_library = software;
 }

--- a/src/event.c
+++ b/src/event.c
@@ -9,6 +9,8 @@
 
 #include <libfyaml.h>
 
+#include "asdf/version.h"
+
 #include "block.h"
 #include "event.h"
 #include "parse_util.h"
@@ -66,11 +68,6 @@ void asdf_event_cleanup(asdf_parser_t *parser, asdf_event_t *event) {
         break;
     case ASDF_ASDF_VERSION_EVENT:
     case ASDF_STANDARD_VERSION_EVENT:
-        if (event->payload.version)
-            free(event->payload.version->version);
-
-        free(event->payload.version);
-        break;
     case ASDF_BLOCK_EVENT:
         break;
     case ASDF_COMMENT_EVENT:

--- a/src/event.h
+++ b/src/event.h
@@ -8,6 +8,7 @@
 #endif
 
 #include "asdf/event.h" // IWYU pragma: export
+#include "asdf/version.h"
 
 #include "types/asdf_block_index.h"
 #include "util.h"
@@ -18,11 +19,6 @@ static const char *const asdf_event_type_names[] = {
     ASDF_EVENT_TYPES(X)
 #undef X
 };
-
-
-typedef struct {
-    char *version;
-} asdf_version_t;
 
 
 typedef struct asdf_tree_info {

--- a/src/file.c
+++ b/src/file.c
@@ -1,5 +1,6 @@
 #include <limits.h>
 #include <math.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -13,6 +14,7 @@
 #include "compression/compression.h"
 #include "context.h"
 #include "core/asdf.h"
+#include "core/software.h"
 #include "emitter.h"
 #include "error.h"
 #include "event.h"
@@ -1115,7 +1117,7 @@ size_t asdf_block_data_size(asdf_block_t *block) {
 }
 
 
-const void *asdf_block_data(asdf_block_t *block, size_t *size) {
+const void *asdf_block_data_impl(asdf_block_t *block, size_t *size, bool decompress) {
     if (!block)
         return NULL;
 
@@ -1144,17 +1146,19 @@ const void *asdf_block_data(asdf_block_t *block, size_t *size) {
     block->avail_size = avail;
 
     // Open compressed data if applicable
-    if (asdf_block_comp_open(block) != 0) {
-        ASDF_LOG(block->file, ASDF_LOG_ERROR, "failed to open compressed block data");
-        return NULL;
-    }
+    if (decompress) {
+        if (asdf_block_comp_open(block) != 0) {
+            ASDF_LOG(block->file, ASDF_LOG_ERROR, "failed to open compressed block data");
+            return NULL;
+        }
 
-    if (block->comp_state) {
-        // Return the destination of the compressed data
-        if (size)
-            *size = block->comp_state->dest_size;
+        if (block->comp_state) {
+            // Return the destination of the compressed data
+            if (size)
+                *size = block->comp_state->dest_size;
 
-        return block->comp_state->dest;
+            return block->comp_state->dest;
+        } // else was not compressed to begin with
     }
 
     if (size)
@@ -1162,6 +1166,16 @@ const void *asdf_block_data(asdf_block_t *block, size_t *size) {
 
     // Just the raw data
     return block->data;
+}
+
+
+const void *asdf_block_data(asdf_block_t *block, size_t *size) {
+    return asdf_block_data_impl(block, size, true);
+}
+
+
+const void *asdf_block_data_raw(asdf_block_t *block, size_t *size) {
+    return asdf_block_data_impl(block, size, false);
 }
 
 
@@ -1224,6 +1238,16 @@ const unsigned char *asdf_block_checksum(asdf_block_t *block) {
 }
 
 
+#define ASDF_PYTHON_CHECKSUM_BUG_MAJOR_VERSION 5
+
+
+static inline bool asdf_library_has_checksum_bug(asdf_software_t *software) {
+    return (
+        strcmp(software->name, "asdf") == 0 &&
+        software->version->major <= ASDF_PYTHON_CHECKSUM_BUG_MAJOR_VERSION);
+}
+
+
 bool asdf_block_checksum_verify(
     asdf_block_t *block, unsigned char computed[ASDF_BLOCK_CHECKSUM_DIGEST_SIZE]) {
     if (!block)
@@ -1237,7 +1261,36 @@ bool asdf_block_checksum_verify(
     size_t size = 0;
     asdf_md5_ctx_t md5_ctx = {0};
     unsigned char digest[ASDF_BLOCK_CHECKSUM_DIGEST_SIZE] = {0};
-    const void *data = asdf_block_data(block, &size);
+    const void *data = NULL;
+    asdf_meta_t *meta = NULL;
+    asdf_file_t *file = block->file;
+
+    /* Python asdf has a bug that when it writes binary blocks it computes
+     * the checksum based on the uncompressed data, not the compressed data.
+     * In this case then we must use the decompresed data to compute the
+     * checksum.  This is slated to be fixed in a later version; for now
+     * the problem exists in all versions at least 5.x and below.
+     * See https://github.com/asdf-format/asdf/issues/2015 */
+    const char *comp = asdf_block_compression_orig(block);
+    if (comp && *comp != '\0') {
+        asdf_value_err_t err = asdf_get_meta(file, "", &meta);
+
+        if (ASDF_VALUE_OK == err && meta && asdf_library_has_checksum_bug(meta->asdf_library)) {
+            ASDF_LOG(
+                file,
+                ASDF_LOG_WARN,
+                "%s version %s has compressed data checksum bug; "
+                "the checksum will be verified against the uncompressed data",
+                meta->asdf_library->name,
+                meta->asdf_library->version->version);
+            data = asdf_block_data(block, &size);
+            asdf_meta_destroy(meta);
+        } else {
+            data = asdf_block_data_raw(block, &size);
+        }
+    } else {
+        data = asdf_block_data_raw(block, &size);
+    }
 
     if (!data)
         return false;

--- a/src/parser.c
+++ b/src/parser.c
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "asdf/version.h"
+
 #include "block.h"
 #include "context.h"
 #include "error.h"
@@ -65,7 +67,7 @@ typedef enum {
 
 
 static int parse_version_comment(
-    asdf_parser_t *parser, const char *expected, char *out_buf, size_t out_size) {
+    asdf_parser_t *parser, const char *expected, asdf_version_t **version) {
     size_t expected_len;
     size_t line_len = 0;
     const uint8_t *line = asdf_stream_readline(parser->stream, &line_len);
@@ -83,12 +85,21 @@ static int parse_version_comment(
     }
 
     size_t to_copy = line_len - expected_len - 1;
+    char *version_str = strndup((char *)line + expected_len, to_copy);
 
-    if (to_copy >= out_size)
-        to_copy = out_size - 1;
+    if (!version_str) {
+        ASDF_ERROR_OOM(parser);
+        return 1;
+    }
 
-    memcpy(out_buf, line + expected_len, to_copy);
-    out_buf[to_copy] = '\0';
+    asdf_version_t *parsed = asdf_version_parse(version_str);
+    free(version_str);
+
+    if (!parsed) {
+        ASDF_ERROR_OOM(parser);
+        return 1;
+    }
+    *version = parsed;
     return 0;
 }
 
@@ -96,55 +107,22 @@ static int parse_version_comment(
 // TODO: These need to be more flexible for acccepting different ASDF versions
 // TODO: Depending on strictness level we can resume even if this fails
 static parse_result_t parse_asdf_version(asdf_parser_t *parser, asdf_event_t *event) {
-    if (parse_version_comment(
-            parser, asdf_version_comment, parser->asdf_version, ASDF_ASDF_VERSION_BUFFER_SIZE) != 0)
+    if (parse_version_comment(parser, asdf_version_comment, &parser->asdf_version))
         return ASDF_PARSE_ERROR;
 
     event->type = ASDF_ASDF_VERSION_EVENT;
-    event->payload.version = malloc(sizeof(asdf_version_t));
-
-    if (!event->payload.version) {
-        ASDF_ERROR_OOM(parser);
-        return ASDF_PARSE_ERROR;
-    }
-
-    event->payload.version->version = strdup(parser->asdf_version);
-
-    if (!event->payload.version->version) {
-        free(event->payload.version);
-        ASDF_ERROR_OOM(parser);
-        return ASDF_PARSE_ERROR;
-    }
-
+    event->payload.version = parser->asdf_version;
     parser->state = ASDF_PARSER_STATE_STANDARD_VERSION;
     return ASDF_PARSE_EVENT;
 }
 
 
 static parse_result_t parse_standard_version(asdf_parser_t *parser, asdf_event_t *event) {
-    if (parse_version_comment(
-            parser,
-            asdf_standard_comment,
-            parser->standard_version,
-            ASDF_STANDARD_VERSION_BUFFER_SIZE) != 0)
+    if (parse_version_comment(parser, asdf_standard_comment, &parser->standard_version))
         return ASDF_PARSE_ERROR;
 
     event->type = ASDF_STANDARD_VERSION_EVENT;
-    event->payload.version = malloc(sizeof(asdf_version_t));
-
-    if (!event->payload.version) {
-        ASDF_ERROR_OOM(parser);
-        return ASDF_PARSE_ERROR;
-    }
-
-    event->payload.version->version = strdup(parser->standard_version);
-
-    if (!event->payload.version->version) {
-        free(event->payload.version);
-        ASDF_ERROR_OOM(parser);
-        return ASDF_PARSE_ERROR;
-    }
-
+    event->payload.version = parser->standard_version;
     parser->state = ASDF_PARSER_STATE_COMMENT;
     return ASDF_PARSE_EVENT;
 }
@@ -1123,8 +1101,6 @@ asdf_parser_t *asdf_parser_create_ctx(asdf_context_t *ctx, const asdf_parser_cfg
     parser->state = ASDF_PARSER_STATE_INITIAL;
     parser->done = false;
     parser->tree.has_tree = -1;
-    ZERO_MEMORY(parser->asdf_version, sizeof(parser->asdf_version));
-    ZERO_MEMORY(parser->standard_version, sizeof(parser->standard_version));
     ASDF_LOG(parser, ASDF_LOG_DEBUG, "parser config flags: 0x%x", parser->config.flags);
     return parser;
 }
@@ -1230,6 +1206,8 @@ void asdf_parser_destroy(asdf_parser_t *parser) {
     asdf_parse_event_freelist_free(parser);
     asdf_block_index_drop(&parser->block.index);
     asdf_block_info_vec_drop(&parser->block.infos);
+    asdf_version_destroy(parser->asdf_version);
+    asdf_version_destroy(parser->standard_version);
     asdf_context_release(parser->base.ctx);
     free(parser);
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -10,6 +10,7 @@
 #include <libfyaml.h>
 
 #include "asdf/parser.h" // IWYU pragma: export
+#include "asdf/version.h"
 
 #include "context.h"
 #include "event.h"
@@ -18,8 +19,6 @@
 
 
 #define ASDF_COMMENT_CHAR '#'
-#define ASDF_ASDF_VERSION_BUFFER_SIZE 16
-#define ASDF_STANDARD_VERSION_BUFFER_SIZE 16
 #define ASDF_PARSER_READ_BUFFER_INIT_SIZE 512
 
 
@@ -91,8 +90,8 @@ typedef struct asdf_parser {
     bool should_close;
     struct asdf_event_p *event_freelist;
     struct asdf_event_p *current_event_p;
-    char asdf_version[ASDF_ASDF_VERSION_BUFFER_SIZE];
-    char standard_version[ASDF_STANDARD_VERSION_BUFFER_SIZE];
+    asdf_version_t *asdf_version;
+    asdf_version_t *standard_version;
     struct fy_parser *yaml_parser;
     asdf_parser_tree_info_t tree;
     asdf_parser_block_info_t block;

--- a/src/tag.c
+++ b/src/tag.c
@@ -9,7 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "asdf/version.h"
 #include "tag.h"
+#include "util.h"
 
 
 asdf_tag_t *asdf_tag_parse(const char *tag) {
@@ -38,7 +40,6 @@ asdf_tag_t *asdf_tag_parse(const char *tag) {
     }
 
     size_t name_len = sep - tag;
-    const char *version = sep + 1;
     res->name = strndup(tag, name_len);
 
     if (!res->name) {
@@ -46,7 +47,8 @@ asdf_tag_t *asdf_tag_parse(const char *tag) {
         return NULL;
     }
 
-    res->version = strdup(version);
+    const char *version = strdup(sep + 1);
+    res->version = asdf_version_parse(version);
 
     if (!res->version) {
         free((char *)res->name);
@@ -58,11 +60,12 @@ asdf_tag_t *asdf_tag_parse(const char *tag) {
 }
 
 
-void asdf_tag_free(asdf_tag_t *tag) {
+void asdf_tag_destroy(asdf_tag_t *tag) {
     if (!tag)
         return;
 
     free((char *)tag->name);
-    free((char *)tag->version);
+    asdf_version_destroy((asdf_version_t *)tag->version);
+    ZERO_MEMORY(tag, sizeof(asdf_tag_t));
     free(tag);
 }

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,108 @@
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "asdf/version.h"
+#include "util.h"
+
+
+asdf_version_t *asdf_version_parse(const char *version) {
+    if (UNLIKELY(!version))
+        return NULL;
+
+    asdf_version_t *ver = calloc(1, sizeof(asdf_version_t));
+
+    if (UNLIKELY(!ver))
+        return NULL;
+
+    ver->version = strdup(version);
+
+    if (UNLIKELY(!ver->version))
+        goto fail;
+
+    const char *chr = version;
+    char *end = NULL;
+
+    if (!isdigit(*chr)) // Not a semver; early return
+        return ver;
+
+    // NOLINTNEXTLINE(readability-magic-numbers)
+    ver->major = strtoul(chr, &end, 10);
+
+    if (*end != '.') {
+        if (*end != '\0') {
+            ver->extra = strdup(end);
+
+            if (UNLIKELY(!ver->extra))
+                goto fail;
+        }
+
+        return ver;
+    }
+
+    chr = end + 1;
+    if (!isdigit(*chr)) {
+        ver->extra = strdup(chr);
+
+        if (UNLIKELY(!ver->extra))
+            goto fail;
+
+        return ver;
+    }
+
+    // NOLINTNEXTLINE(readability-magic-numbers)
+    ver->minor = strtoul(chr, &end, 10);
+
+    if (*end != '.') {
+        if (*end != '\0') {
+            ver->extra = strdup(end);
+
+            if (UNLIKELY(!ver->extra))
+                goto fail;
+        }
+
+        return ver;
+    }
+
+    chr = end + 1;
+    if (!isdigit(*chr)) {
+        ver->extra = strdup(chr);
+
+        if (UNLIKELY(!ver->extra))
+            goto fail;
+
+        return ver;
+    }
+
+    // NOLINTNEXTLINE(readability-magic-numbers)
+    ver->patch = strtoul(chr, &end, 10);
+    chr = end;
+
+    if (*chr != '\0') {
+        if (*chr == '.' || *chr == '-')
+            chr++;
+
+        if (*chr != '\0') {
+            ver->extra = strdup(chr);
+
+            if (UNLIKELY(!ver->extra))
+                goto fail;
+        }
+    }
+
+    return ver;
+fail:
+    asdf_version_destroy(ver);
+    return NULL;
+}
+
+
+void asdf_version_destroy(asdf_version_t *version) {
+    if (!version)
+        return;
+
+    free((void *)version->version);
+    free((void *)version->extra);
+    ZERO_MEMORY(version, sizeof(asdf_version_t));
+    free(version);
+}

--- a/src/version.c
+++ b/src/version.c
@@ -18,7 +18,7 @@ asdf_version_t *asdf_version_parse(const char *version) {
     ver->version = strdup(version);
 
     if (UNLIKELY(!ver->version))
-        goto fail;
+        goto failure;
 
     const char *chr = version;
     char *end = NULL;
@@ -34,7 +34,7 @@ asdf_version_t *asdf_version_parse(const char *version) {
             ver->extra = strdup(end);
 
             if (UNLIKELY(!ver->extra))
-                goto fail;
+                goto failure;
         }
 
         return ver;
@@ -45,7 +45,7 @@ asdf_version_t *asdf_version_parse(const char *version) {
         ver->extra = strdup(chr);
 
         if (UNLIKELY(!ver->extra))
-            goto fail;
+            goto failure;
 
         return ver;
     }
@@ -58,7 +58,7 @@ asdf_version_t *asdf_version_parse(const char *version) {
             ver->extra = strdup(end);
 
             if (UNLIKELY(!ver->extra))
-                goto fail;
+                goto failure;
         }
 
         return ver;
@@ -69,7 +69,7 @@ asdf_version_t *asdf_version_parse(const char *version) {
         ver->extra = strdup(chr);
 
         if (UNLIKELY(!ver->extra))
-            goto fail;
+            goto failure;
 
         return ver;
     }
@@ -86,13 +86,42 @@ asdf_version_t *asdf_version_parse(const char *version) {
             ver->extra = strdup(chr);
 
             if (UNLIKELY(!ver->extra))
-                goto fail;
+                goto failure;
         }
     }
 
     return ver;
-fail:
+failure:
     asdf_version_destroy(ver);
+    return NULL;
+}
+
+
+asdf_version_t *asdf_version_copy(const asdf_version_t *version) {
+    asdf_version_t *new_version = calloc(1, sizeof(asdf_version_t));
+
+    if (UNLIKELY(!new_version))
+        return NULL;
+
+    new_version->version = strdup(version->version);
+
+    if (UNLIKELY(!new_version->version))
+        goto failure;
+
+    new_version->major = version->major;
+    new_version->minor = version->minor;
+    new_version->patch = version->patch;
+
+    if (version->extra) {
+        new_version->extra = strdup(version->extra);
+
+        if (UNLIKELY(!new_version->extra))
+            goto failure;
+    }
+
+    return new_version;
+failure:
+    asdf_version_destroy(new_version);
     return NULL;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -377,6 +377,7 @@ EXTRA_DIST += \
     fixtures/value-types.asdf \
     fixtures/verify-checksums/255-2-blocks.verify-checksums.txt \
     fixtures/verify-checksums/255-invalid-checksum.verify-checksums.txt \
+    fixtures/verify-checksums/compressed.verify-checksums.txt \
     munit/COPYING \
     munit/munit.c \
     munit/munit.h \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -40,6 +40,7 @@ check_PROGRAMS = \
     test-time.unit \
     test-value.unit \
     test-value-util.unit \
+    test-version.unit \
     test-yaml.unit
 
 TESTS_ENVIRONMENT = top_builddir=$(top_builddir) top_srcdir=$(top_srcdir)
@@ -169,6 +170,7 @@ test_malloc_fail_unit_SOURCES = \
     $(top_srcdir)/src/parser.c \
     $(top_srcdir)/src/stream.c \
     $(top_srcdir)/src/util.c \
+    $(top_srcdir)/src/version.c \
     $(top_srcdir)/src/yaml.c \
     $(top_srcdir)/third_party/STC/src/cstr_core.c
 test_malloc_fail_unit_CPPFLAGS = $(unit_test_cppflags)
@@ -222,6 +224,13 @@ test_value_util_unit_CPPFLAGS = $(unit_test_cppflags)
 test_value_util_unit_CFLAGS = $(unit_test_cflags)
 test_value_util_unit_LDFLAGS = $(unit_test_ldflags)
 test_value_util_unit_LDADD = libmunit.a $(STATGRAB_LIBS)
+
+# test-version.unit
+test_version_unit_SOURCES = test-version.c
+test_version_unit_CPPFLAGS = $(unit_test_cppflags)
+test_version_unit_CFLAGS = $(unit_test_cflags)
+test_version_unit_LDFLAGS = $(unit_test_ldflags)
+test_version_unit_LDADD = $(unit_test_ldadd)
 
 # test-yaml.unit
 test_yaml_unit_SOURCES = \

--- a/tests/fixtures/verify-checksums/compressed.verify-checksums.txt
+++ b/tests/fixtures/verify-checksums/compressed.verify-checksums.txt
@@ -1,0 +1,6 @@
+Block 0: OK
+  checksum: 3059cc116ed1ba5a6e5be642a96ebe1a
+Block 1: OK
+  checksum: 3059cc116ed1ba5a6e5be642a96ebe1a
+Block 2: OK
+  checksum: 3059cc116ed1ba5a6e5be642a96ebe1a

--- a/tests/test-compression.c
+++ b/tests/test-compression.c
@@ -788,6 +788,50 @@ MU_TEST(access_then_write) {
 }
 
 
+MU_TEST(verify_checksum) {
+    const char *comp = munit_parameters_get(params, "comp");
+    const size_t n = 4096;
+
+    uint8_t *data = malloc(n);
+
+    if (!data)
+        return MUNIT_ERROR;
+
+    for (size_t idx = 0; idx < n; idx++)
+        data[idx] = (uint8_t)(idx % 4);
+
+    const char *path = write_compressed_ndarray_to_file(
+        comp, fixture->tempfile_prefix, data, n);
+
+    if (!path) {
+        free(data);
+        return MUNIT_ERROR;
+    }
+
+    /* re-open, verify checksum, close block */
+    asdf_file_t *file = asdf_open_file(path, "r");
+    assert_not_null(file);
+    asdf_block_t *block = asdf_block_open(file, 0);
+    assert_not_null(block);
+    const unsigned char *checksum = asdf_block_checksum(block);
+    assert_not_null(checksum);
+    unsigned char *empty = calloc(ASDF_BLOCK_CHECKSUM_DIGEST_SIZE, sizeof(unsigned char));
+    
+    if (!empty)
+        return MUNIT_ERROR;
+
+    assert_memory_not_equal(ASDF_BLOCK_CHECKSUM_DIGEST_SIZE, checksum, empty);
+    free(empty);
+    assert_true(asdf_block_checksum_verify(block, NULL));
+    asdf_block_close(block);
+    asdf_close(file);
+
+    free(data);
+    free((void *)path);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     compression,
     MU_RUN_TEST(write_compressed_ndarray, comp_test_params),

--- a/tests/test-core-extensions.c
+++ b/tests/test-core-extensions.c
@@ -49,7 +49,7 @@ MU_TEST(extension_metadata) {
     assert_int(asdf_value_as_software(prop, &software), ==, ASDF_VALUE_OK);
     assert_not_null(software);
     assert_string_equal(software->name, "asdf_standard");
-    assert_string_equal(software->version, "1.1.1");
+    assert_string_equal(software->version->version, "1.1.1");
     asdf_software_destroy(software);
     asdf_value_destroy(prop);
 
@@ -60,7 +60,7 @@ MU_TEST(extension_metadata) {
     assert_int(asdf_value_as_software(prop, &software), ==, ASDF_VALUE_OK);
     assert_not_null(software);
     assert_string_equal(software->name, "asdf");
-    assert_string_equal(software->version, "4.1.0");
+    assert_string_equal(software->version->version, "4.1.0");
     asdf_software_destroy(software);
     asdf_value_destroy(prop);
 
@@ -75,7 +75,7 @@ MU_TEST(extension_metadata) {
 // of the extension API?
 static void assert_software_equal(const asdf_software_t *software0, const asdf_software_t *software1) {
     assert_string_equal(software0->name, software1->name);
-    assert_string_equal(software0->version, software1->version);
+    assert_string_equal(software0->version->version, software1->version->version);
     assert_string_equal(software0->author, software1->author);
     assert_string_equal(software0->homepage, software1->homepage);
 }
@@ -138,8 +138,9 @@ MU_TEST(extension_metadata_serialize) {
     const char *path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
     asdf_file_t *file = asdf_open(NULL);
     assert_not_null(file);
+    asdf_version_t manifest_version = {.version = "1.1.1"};
     asdf_software_t manifest_software = {
-        .name = "asdf_standard", .version = "1.1.1"};
+        .name = "asdf_standard", .version = &manifest_version};
     asdf_mapping_t *extra_meta = make_extra_meta(file, &manifest_software);
     asdf_extension_metadata_t extension = {
         .metadata = extra_meta, .extension_class = "asdf.extension._manifest.ManifestExtension",
@@ -327,8 +328,9 @@ MU_TEST(meta_serialize) {
     asdf_file_t *file = asdf_open(NULL);
 
     assert_not_null(file);
+    asdf_version_t manifest_version = {.version = "1.1.1"};
     asdf_software_t manifest_software = {
-        .name = "asdf_standard", .version = "1.1.1"};
+        .name = "asdf_standard", .version = &manifest_version};
     asdf_mapping_t *extra_meta = make_extra_meta(file, &manifest_software);
     assert_not_null(extra_meta);
     asdf_extension_metadata_t extension = {
@@ -650,7 +652,7 @@ MU_TEST(software) {
     assert_int(asdf_get_software(file, "asdf_library", &software), ==, ASDF_VALUE_OK);
     assert_not_null(software);
     assert_string_equal(software->name, "asdf");
-    assert_string_equal(software->version, "4.1.0");
+    assert_string_equal(software->version->version, "4.1.0");
     assert_string_equal(software->homepage, "http://github.com/asdf-format/asdf");
     assert_string_equal(software->author, "The ASDF Developers");
     asdf_software_destroy(software);

--- a/tests/test-extension.c
+++ b/tests/test-extension.c
@@ -8,6 +8,7 @@
 #include <asdf/extension.h>
 #include <asdf/file.h>
 #include <asdf/util.h>
+#include <asdf/version.h>
 
 
 /* Struct that represents the "foo" type extension */
@@ -16,11 +17,17 @@ typedef struct {
 } asdf_foo_t;
 
 
+static asdf_version_t asdf_foo_version = {
+    .version = "1.0.0",
+    .minor = 1
+};
+
+
 static asdf_software_t asdf_foo_software = {
     .name = "foo",
     .author = "STScI",
     .homepage = "https://stsci.edu",
-    .version = "1.0.0"
+    .version = &asdf_foo_version
 };
 
 

--- a/tests/test-verify-checksums.sh
+++ b/tests/test-verify-checksums.sh
@@ -10,4 +10,5 @@ fi
 
 "${srcdir}"/shell-test.sh verify-checksums --verbose $@ \
   "${srcdir}"/fixtures/255-2-blocks.asdf \
-  "${srcdir}"/fixtures/255-invalid-checksum.asdf
+  "${srcdir}"/fixtures/255-invalid-checksum.asdf \
+  "${srcdir}"/fixtures/compressed.asdf

--- a/tests/test-version.c
+++ b/tests/test-version.c
@@ -1,0 +1,104 @@
+/** Version parsing tests */
+#include "munit.h"
+
+#include "asdf/version.h"
+
+
+MU_TEST(test_asdf_version_parse_unknown) {
+    asdf_version_t *version = asdf_version_parse("2026-04-15");
+    assert_not_null(version);
+    assert_string_equal(version->version, "2026-04-15");
+    assert_int(version->major, ==, 2026);
+    assert_int(version->minor, ==, 0);
+    assert_int(version->patch, ==, 0);
+    assert_string_equal(version->extra, "-04-15");
+    asdf_version_destroy(version);
+    return MUNIT_OK;
+}
+
+
+MU_TEST(test_asdf_version_parse_partial) {
+    asdf_version_t *version = asdf_version_parse("1");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 0);
+    assert_int(version->patch, ==, 0);
+    assert_null(version->extra);
+    asdf_version_destroy(version);
+
+    version = asdf_version_parse("1.1");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1.1");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 1);
+    assert_int(version->patch, ==, 0);
+    assert_null(version->extra);
+    asdf_version_destroy(version);
+
+    version = asdf_version_parse("1.1asdf");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1.1asdf");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 1);
+    assert_int(version->patch, ==, 0);
+    assert_string_equal(version->extra, "asdf");
+    asdf_version_destroy(version);
+    return MUNIT_OK;
+}
+
+
+MU_TEST(test_asdf_version_parse) {
+    asdf_version_t *version = asdf_version_parse("1.2.3");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1.2.3");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 2);
+    assert_int(version->patch, ==, 3);
+    assert_null(version->extra);
+    asdf_version_destroy(version);
+    return MUNIT_OK;
+}
+
+
+MU_TEST(test_asdf_version_parse_extra) {
+    asdf_version_t *version = asdf_version_parse("1.2.3asdf");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1.2.3asdf");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 2);
+    assert_int(version->patch, ==, 3);
+    assert_string_equal(version->extra, "asdf");
+    asdf_version_destroy(version);
+
+    version = asdf_version_parse("1.2.3.asdf");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1.2.3.asdf");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 2);
+    assert_int(version->patch, ==, 3);
+    assert_string_equal(version->extra, "asdf");
+    asdf_version_destroy(version);
+
+    version = asdf_version_parse("1.2.3-asdf");
+    assert_not_null(version);
+    assert_string_equal(version->version, "1.2.3-asdf");
+    assert_int(version->major, ==, 1);
+    assert_int(version->minor, ==, 2);
+    assert_int(version->patch, ==, 3);
+    assert_string_equal(version->extra, "asdf");
+    asdf_version_destroy(version);
+    return MUNIT_OK;
+}
+
+
+MU_TEST_SUITE(
+    version,
+    MU_RUN_TEST(test_asdf_version_parse_unknown),
+    MU_RUN_TEST(test_asdf_version_parse_partial),
+    MU_RUN_TEST(test_asdf_version_parse),
+    MU_RUN_TEST(test_asdf_version_parse_extra)
+);
+
+
+MU_RUN_SUITE(version);


### PR DESCRIPTION
Resolves #172

This also introduces a new `asdf_version_t` struct and version parsing utility which will be useful for handling most common cases.  Version strings that appear throughout the library are replaced with a parsed `asdf_version_t` with major/minor/patch fields.