### PR TITLE
fix: small memory leak in asdf_tag_parse

### DIFF
--- a/src/tag.c
+++ b/src/tag.c
@@ -47,8 +47,9 @@ asdf_tag_t *asdf_tag_parse(const char *tag) {
         return NULL;
     }
 
-    const char *version = strdup(sep + 1);
+    char *version = strdup(sep + 1);
     res->version = asdf_version_parse(version);
+    free(version);
 
     if (!res->version) {
         free((char *)res->name);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -36,6 +36,7 @@ check_PROGRAMS = \
     test-parse-util.unit \
     test-parser.unit \
     test-stream.unit \
+    test-tag.unit \
     test-tests.unit \
     test-time.unit \
     test-value.unit \
@@ -193,6 +194,13 @@ test_stream_unit_CPPFLAGS = $(unit_test_cppflags)
 test_stream_unit_CFLAGS = $(unit_test_cflags)
 test_stream_unit_LDFLAGS = $(unit_test_ldflags)
 test_stream_unit_LDADD = $(FYAML_LIBS) libmunit.a $(STATGRAB_LIBS)
+
+# test-tag.unit
+test_tag_unit_SOURCES = test-tag.c
+test_tag_unit_CPPFLAGS = $(unit_test_cppflags)
+test_tag_unit_CFLAGS = $(unit_test_cflags)
+test_tag_unit_LDFLAGS = $(unit_test_ldflags)
+test_tag_unit_LDADD = $(unit_test_ldadd)
 
 # test-tests.unit
 test_tests_unit_SOURCES = test-tests.c

--- a/tests/test-tag.c
+++ b/tests/test-tag.c
@@ -1,0 +1,27 @@
+/** Tag parsing tests */
+#include "munit.h"
+
+#include "asdf/extension.h"
+
+
+MU_TEST(test_asdf_tag_parse) {
+    asdf_tag_t *tag = asdf_tag_parse("tag:stsci.edu:gwcs/frame-1.0.0");
+    assert_not_null(tag);
+    assert_string_equal(tag->name, "tag:stsci.edu:gwcs/frame");
+    assert_not_null(tag->version);
+    assert_string_equal(tag->version->version, "1.0.0");
+    assert_int(tag->version->major, ==, 1);
+    assert_int(tag->version->minor, ==, 0);
+    assert_int(tag->version->patch, ==, 0);
+    asdf_tag_destroy(tag);
+    return MUNIT_OK;
+}
+
+
+MU_TEST_SUITE(
+    tag,
+    MU_RUN_TEST(test_asdf_tag_parse)
+);
+
+
+MU_RUN_SUITE(tag);


### PR DESCRIPTION
test: add simple test for asdf_tag_parse

Still not totally sure about the future of asdf_tag_parse but it is used in libasdf-gwcs so let's make sure it actually works.