### PR TITLE
refactor: simplify and improve the iterator APIs

### DIFF
--- a/changes/73.general
+++ b/changes/73.general
@@ -1,0 +1,1 @@
+Reworked the iterator interfaces (asdf_mapping_iter_t, asdf_sequence_iter_t, asdf_container_iter_t, and asdf_find_iter_t) to be simpler, more consistent, and better documented.

--- a/docs/usage/values.rst
+++ b/docs/usage/values.rst
@@ -229,7 +229,7 @@ about in libasdf.
 from a mapping or a sequence.  This is an opaque struct that holds the value
 until we try to coerce it to one of the supported C-native data types.  If we
 try to get a value out of a mapping using functions like `asdf_mapping_get` or
-`asdf_mapping_iter` (or likewise for sequences) it is returned as an
+`asdf_mapping_iter_t` (or likewise for sequences) it is returned as an
 `asdf_value_t`.
 
 We can then test its type using any of the ``asdf_value_is_<type>`` methods,

--- a/include/asdf/value.h
+++ b/include/asdf/value.h
@@ -1,9 +1,5 @@
 /**
  * Structures and methods pertaining to ASDF tree values
- *
- * .. todo::
- *
- *   Document API for generic values.
  */
 
 //
@@ -187,6 +183,19 @@ typedef struct asdf_file asdf_file_t;
  * :param value: The `asdf_value_t *` handle
  */
 ASDF_EXPORT void asdf_value_destroy(asdf_value_t *value);
+
+
+/**
+ * Clone an `asdf_value_t`
+ *
+ * This performs a deep-copy of a value and may be used in certain cases
+ * (such as container iteration) when the user needs an owned copy of the
+ * value.
+ *
+ * The new cloned value is not initially attached to the YAML tree, so
+ * modification to its underlying value is not reflected in the YAML; it
+ * may be inserted elsewhere in the tree later.
+ */
 ASDF_EXPORT asdf_value_t *asdf_value_clone(asdf_value_t *value);
 
 /**
@@ -258,35 +267,73 @@ ASDF_EXPORT void asdf_mapping_destroy(asdf_mapping_t *mapping);
  */
 ASDF_EXPORT asdf_value_t *asdf_mapping_get(asdf_mapping_t *mapping, const char *key);
 
-typedef struct _asdf_mapping_iter_impl _asdf_mapping_iter_impl_t;
-
-
-/** Opaque struct holding mapping iterator state */
-typedef _asdf_mapping_iter_impl_t *asdf_mapping_iter_t;
+/**
+ * Iterator handle for traversing a mapping value
+ *
+ * Initialize with `asdf_mapping_iter_init`.  After each successful call to
+ * `asdf_mapping_iter_next`, the ``key`` and ``value`` fields hold the current
+ * mapping entry and are valid until the next call to `asdf_mapping_iter_next`
+ * or `asdf_mapping_iter_destroy`.  If the value must outlive the current
+ * iteration step, clone it with `asdf_value_clone`.
+ *
+ * .. warning::
+ *
+ *   Modifying the mapping while iterating over it results in undefined
+ *   behavior.
+ */
+typedef struct {
+    /** Current key */
+    const char *key;
+    /** Current value */
+    asdf_value_t *value;
+} asdf_mapping_iter_t;
 
 /**
- * Opaque struct representing a single (key, value) pair returned when
- * iterating over a mapping with `asdf_mapping_iter`
+ * Create a new iterator over ``mapping``
  *
- * .. todo::
- *
- *   Finish documenting me.
+ * :param mapping: The `asdf_mapping_t *` to iterate over
+ * :return: A new `asdf_mapping_iter_t *` handle, or ``NULL`` on allocation failure
  */
-typedef struct _asdf_mapping_iter_impl asdf_mapping_item_t;
-
-ASDF_EXPORT asdf_mapping_iter_t asdf_mapping_iter_init(void);
-ASDF_EXPORT const char *asdf_mapping_item_key(asdf_mapping_item_t *item);
-ASDF_EXPORT asdf_value_t *asdf_mapping_item_value(asdf_mapping_item_t *item);
+ASDF_EXPORT asdf_mapping_iter_t *asdf_mapping_iter_init(asdf_mapping_t *mapping);
 
 /**
- * Iterate over a mapping value
+ * Advance the iterator to the next mapping entry
  *
- * .. todo::
+ * On success, `asdf_mapping_iter_t.key` and `asdf_mapping_iter_t.value` are
+ * updated to the current entry.  When iteration is exhausted the iterator is
+ * freed automatically and ``*iter`` is set to ``NULL``.
  *
- *   Finish documenting me.
+ * Typical usage::
+ *
+ *   asdf_mapping_iter_t *iter = asdf_mapping_iter_init(mapping);
+ *   while (asdf_mapping_iter_next(&iter)) {
+ *       // iter->key and iter->value are valid here
+ *   }
+ *
+ * For early exit call `asdf_mapping_iter_destroy` before breaking::
+ *
+ *   asdf_mapping_iter_t *iter = asdf_mapping_iter_init(mapping);
+ *   while (asdf_mapping_iter_next(&iter)) {
+ *       if (done) {
+ *           asdf_mapping_iter_destroy(iter);
+ *           break;
+ *       }
+ *   }
+ *
+ * :param iter: Pointer to the iterator handle; set to ``NULL`` on exhaustion
+ * :return: ``true`` if an entry was found; ``false`` when iteration is done
  */
-ASDF_EXPORT asdf_mapping_item_t *asdf_mapping_iter(
-    asdf_mapping_t *mapping, asdf_mapping_iter_t *iter);
+ASDF_EXPORT bool asdf_mapping_iter_next(asdf_mapping_iter_t **iter);
+
+/**
+ * Release resources held by an in-progress mapping iterator
+ *
+ * Call this only when breaking out of iteration early.  Safe to call with
+ * ``NULL``.
+ *
+ * :param iter: The `asdf_mapping_iter_t *` to destroy
+ */
+ASDF_EXPORT void asdf_mapping_iter_destroy(asdf_mapping_iter_t *iter);
 
 
 /**
@@ -376,21 +423,6 @@ typedef struct asdf_sequence asdf_sequence_t;
 
 ASDF_EXPORT asdf_value_err_t
 asdf_mapping_set_sequence(asdf_mapping_t *mapping, const char *key, asdf_sequence_t *value);
-
-
-/**
- * Release memory resources used by `asdf_mapping_item_t`
- *
- * If the iterator was run to exhaustion (i.e. `asdf_mapping_iter` called
- * until returning `NULL`) this happens automatically, but in cases where the
- * iteration is stopped early it is necessary to free these resources manually
- * once the contained value is no longer needed.
- *
- * This also destroys the contained `asdf_value_t`.
- *
- * :param item: The `asdf_mapping_item_t *` to destroy
- */
-ASDF_EXPORT void asdf_mapping_item_destroy(asdf_mapping_item_t *item);
 
 
 /** Sequences */
@@ -484,37 +516,58 @@ ASDF_EXPORT void asdf_sequence_set_style(asdf_sequence_t *sequence, asdf_yaml_no
 ASDF_EXPORT void asdf_sequence_destroy(asdf_sequence_t *sequence);
 
 
-/** Opaque struct holding sequence iterator state */
-typedef void *asdf_sequence_iter_t;
-
 /**
- * Initialize an `asdf_sequence_iter_t` to its starting state
+ * Iterator handle for traversing a sequence value
  *
- * Call this once before the first call to `asdf_sequence_iter`.
+ * Initialize with `asdf_sequence_iter_init`.  After each successful call to
+ * `asdf_sequence_iter_next`, the ``index`` and ``value`` fields hold the
+ * current element and are valid until the next call to
+ * `asdf_sequence_iter_next` or `asdf_sequence_iter_destroy`.
  *
- * :return: An initialized `asdf_sequence_iter_t`
+ * .. warning::
+ *
+ *   Modifying the sequence while iterating over it results in undefined
+ *   behavior.
  */
-ASDF_EXPORT asdf_sequence_iter_t asdf_sequence_iter_init(void);
-
+typedef struct {
+    /** Current value */
+    asdf_value_t *value;
+    /** Index of the current value */
+    int index;
+} asdf_sequence_iter_t;
 
 /**
- * Advance a sequence iterator and return the next value
+ * Create a new iterator over ``sequence``
+ *
+ * :param sequence: The `asdf_sequence_t *` to iterate over
+ * :return: A new `asdf_sequence_iter_t *` handle, or ``NULL`` on allocation failure
+ */
+ASDF_EXPORT asdf_sequence_iter_t *asdf_sequence_iter_init(asdf_sequence_t *sequence);
+
+/**
+ * Advance the iterator to the next sequence element
  *
  * Typical usage::
  *
- *   asdf_sequence_iter_t iter = asdf_sequence_iter_init();
- *   asdf_value_t *val;
- *   while ((val = asdf_sequence_iter(seq, &iter)) != NULL) {
- *       // use val ...
+ *   asdf_sequence_iter_t *iter = asdf_sequence_iter_init(sequence);
+ *   while (asdf_sequence_iter_next(&iter)) {
+ *       // iter->index and iter->value are valid here
  *   }
  *
- * Returns ``NULL`` when iteration is exhausted.
- *
- * :param sequence: The `asdf_sequence_t *` to iterate over
- * :param iter: Pointer to the iterator state; updated on each call
- * :return: The next `asdf_value_t *` in the sequence, or ``NULL`` when done
+ * :param iter: Pointer to the iterator handle; set to ``NULL`` on exhaustion
+ * :return: ``true`` if an element was found; ``false`` when iteration is done
  */
-ASDF_EXPORT asdf_value_t *asdf_sequence_iter(asdf_sequence_t *sequence, asdf_sequence_iter_t *iter);
+ASDF_EXPORT bool asdf_sequence_iter_next(asdf_sequence_iter_t **iter);
+
+/**
+ * Release resources held by an in-progress sequence iterator
+ *
+ * Call this only when breaking out of iteration early.  Safe to call with
+ * ``NULL``.
+ *
+ * :param iter: The `asdf_sequence_iter_t *` to destroy
+ */
+ASDF_EXPORT void asdf_sequence_iter_destroy(asdf_sequence_iter_t *iter);
 
 
 /**
@@ -629,101 +682,59 @@ ASDF_EXPORT asdf_value_t *asdf_sequence_pop(asdf_sequence_t *sequence, int index
 
 
 /**
- * Any container-related functions
+ * Iterator handle for traversing either a mapping or a sequence
  *
- * Here "container" means either sequence or mapping though maybe could extend
- * this interface in the future for custom container types
+ * When iterating over a mapping: ``key`` holds the current key though index
+ * also tracks the position in the mapping (taken as a sequence of
+ * key/value pairs).  When iterating over a sequence: ``index`` holds the
+ * position and ``key`` is ``NULL``.  ``value`` is always valid after a
+ * successful `asdf_container_iter_next`.
  *
- * These routines provide a convience for iterating over a container regardless
- * if it is a sequence or mapping using a common interface.
+ * .. warning::
  *
- * .. todo::
- *
- *   Document these better.
+ *   Modifying the container while iterating over it results in undefined
+ *   behavior.
  */
-
-//
-
-/** Opaque struct containing container iterator state */
-typedef void *asdf_container_iter_t;
+typedef struct {
+    /** Current key (mappings only; NULL for sequences) */
+    const char *key;
+    /** Current index */
+    int index;
+    /** Current value */
+    asdf_value_t *value;
+} asdf_container_iter_t;
 
 /**
- * Opaque struct for values returned from `asdf_container_iter`
+ * Create a new iterator over ``container`` (mapping or sequence)
  *
- * This combines the value returned from the container iteration as its key
- * (if iterating over a mapping) or index (if iterating over a sequence) as
- * well as internal iterator state.
+ * Returns ``NULL`` if ``container`` is neither a mapping nor a sequence.
  *
- * Use the functions `asdf_container_item_key`, `asdf_container_item_index`
- * and `asdf_container_item_value` to extract properties from the container
- * item.
+ * :param container: `asdf_value_t *` of mapping or sequence type
+ * :return: A new `asdf_container_iter_t *` handle, or ``NULL`` on failure
  */
-typedef struct asdf_container_item asdf_container_item_t;
-
-
-ASDF_EXPORT asdf_container_iter_t asdf_container_iter_init(void);
-
+ASDF_EXPORT asdf_container_iter_t *asdf_container_iter_init(asdf_value_t *container);
 
 /**
- * If iterating over a mapping with `asdf_container_iter`, returns the key of
- * a single item from the container
+ * Advance the generic container iterator to the next element
  *
- * :param item: The `asdf_container_item_t *` returned by `asdf_container_iter`
- * :return: The key in the mapping of the value, or NULL if the container was
- *   not a mapping
+ * In most cases `asdf_mapping_iter_next` or `asdf_sequence_iter_next` are
+ * preferred, but this is useful when the container type is not known at the
+ * call site.
+ *
+ * :param iter: Pointer to the iterator handle; set to ``NULL`` on exhaustion
+ * :return: ``true`` if an element was found; ``false`` when iteration is done
  */
-ASDF_EXPORT const char *asdf_container_item_key(asdf_container_item_t *item);
-
+ASDF_EXPORT bool asdf_container_iter_next(asdf_container_iter_t **iter);
 
 /**
- * If iterating over a sequence with `asdf_container_iter`, returns the index of
- * a single item from the container
+ * Release resources held by an in-progress container iterator
  *
- * :param item: The `asdf_container_item_t *` returned by `asdf_container_iter`
- * :return: The index of the value in a sequence, or -1 if the container was
- *   not a sequence
+ * Call this only when breaking out of iteration early.  Safe to call with
+ * ``NULL``.
+ *
+ * :param iter: The `asdf_container_iter_t *` to destroy
  */
-ASDF_EXPORT int asdf_container_item_index(asdf_container_item_t *item);
-
-
-/**
- * If iterating over a sequence with `asdf_container_iter`, returns the value
- * of that container item (where "item" is the pair of the value and its key/
- * index)
- *
- * :param item: The `asdf_container_item_t *` returned by `asdf_container_iter`
- * :return: The underling `asdf_value_t *` generic value pointer
- */
-ASDF_EXPORT asdf_value_t *asdf_container_item_value(asdf_container_item_t *item);
-
-
-/**
- * Generic container iterator
- *
- * Similar to `asdf_mapping_iter` but can be used with either a sequence or a
- * mapping
- *
- * In most cases you will want to use `asdf_mapping_iter` or
- * `asdf_sequence_iter` more specifically, but sometimes it is useful to have a
- * generic iteration method that can handle both.
- *
- * :param item: The `asdf_container_item_t *` returned by `asdf_container_iter`
- * :return: The underling `asdf_value_t *` generic value pointer
- */
-ASDF_EXPORT asdf_container_item_t *asdf_container_iter(
-    asdf_value_t *container, asdf_container_iter_t *iter);
-
-/**
- * Release memory resources used by `asdf_container_item_t`
- *
- * If the iterator was run to exhaustion (i.e. `asdf_container_iter` called
- * until returning `NULL`) this happens automatically, but in cases where the
- * iteration is stopped early it is necessary to free these resources manually
- * once the contained value is no longer needed.
- *
- * :param item: The `asdf_container_item_t *` to destroy
- */
-ASDF_EXPORT void asdf_container_item_destroy(asdf_container_item_t *item);
+ASDF_EXPORT void asdf_container_iter_destroy(asdf_container_iter_t *iter);
 
 ASDF_EXPORT bool asdf_value_is_container(asdf_value_t *value);
 
@@ -887,81 +898,31 @@ ASDF_EXPORT asdf_value_t *asdf_value_of_double(asdf_file_t *file, double value);
 typedef bool (*asdf_value_pred_t)(asdf_value_t *value);
 
 /**
- * Opaque struct representing a value found with `asdf_value_find` and friends
+ * Iterator handle for depth/breadth-first tree search
  *
- * Use `asdf_find_item_path` to return the path of the found value, and
- * `asdf_find_item_value` to return the corresponding value.
+ * After each successful call to `asdf_value_find_iter_next`, the ``value``
+ * field holds the matching value and is valid until the next call to
+ * `asdf_value_find_iter_next` or `asdf_find_iter_destroy`.  If the value must
+ * persist further, clone it with `asdf_value_clone`.
  */
-typedef struct asdf_find_item asdf_find_item_t;
+typedef struct {
+    /** Current matching value */
+    asdf_value_t *value;
+} asdf_find_iter_t;
 
 /**
- * Traverse the tree breadth-first starting from ``root`` until a value
- * matching the given predicate is found
+ * Traverse the tree breadth-first starting from ``root`` and return the first
+ * value matching ``pred``
  *
- * :param value: `asdf_value_t *` handle for the root node in which to start
- *   the search--if the value is neither a mapping or sequence this function
- *   will still return non-NULL if this value matches the predicate
+ * The caller owns the returned `asdf_value_t *` and must eventually destroy it
+ * with `asdf_value_destroy`.  Returns ``NULL`` if no matching value was found.
+ *
+ * :param root: `asdf_value_t *` handle for the root node to search from
  * :param pred: A predicate function to match the value to return; see
  *   `asdf_value_pred_t`
- * :return: An `asdf_find_item_t *` for the first matching value or NULL if the
- *   tree is exhausted without finding a matching value
+ * :return: The first matching `asdf_value_t *`, or ``NULL`` if not found
  */
-ASDF_EXPORT asdf_find_item_t *asdf_value_find(asdf_value_t *root, asdf_value_pred_t pred);
-
-/**
- * Return the path of a value found with `asdf_value_find` and friends
- *
- * :param item: `asdf_find_item_t *` result from `asdf_value_find`, `asdf_value_find_iter`
- *   `asdf_value_find_ex`
- * :return: Full path of the found value
- */
-ASDF_EXPORT const char *asdf_find_item_path(asdf_find_item_t *item);
-
-/**
- * Return the value found with `asdf_value_find` and friends
- *
- * :param item: `asdf_find_item_t *` result from `asdf_value_find`, `asdf_value_find_iter`
- *   `asdf_value_find_ex`
- * :return: The `asdf_value_t *` handle to the found value
- */
-ASDF_EXPORT asdf_value_t *asdf_find_item_value(asdf_find_item_t *item);
-
-
-/**
- * Opaque struct used to manage state across `asdf_value_find_iter` calls
- */
-typedef void *asdf_find_iter_t;
-
-
-/**
- * Traverse the tree breadth-first starting from ``root`` until a value
- * matching the given predicate is found; subsequent calls with the same
- * `asdf_find_iter_t *` handle will return all matching values until the
- * tree has been exhaustively traversed
- *
- * A typical usage pattern is similar to `asdf_mapping_iter`, like:
- *
- * .. code::
- *
- *   asdf_find_iter_t iter = asdf_find_iter_init();
- *   asdf_find_item_t *item = NULL;
- *
- *   while ((item = asdf_value_find_iter(root, pred, &iter))) {
- *     // Do something with found item
- *   }
- *
- * :param value: `asdf_value_t *` handle for the root node in which to start
- *   the search--if the value is neither a mapping or sequence this function
- *   will still return non-NULL if this value matches the predicate
- * :param pred: A predicate function to match the value to return; see
- *   `asdf_value_pred_t`
- * :param iter: A pointer to an `asdf_find_iter_t` used internally to track
- *   the iteration state
- * :return: An `asdf_find_item_t *` for the first matching value or NULL if the
- *   tree is exhausted without finding a matching value
- */
-ASDF_EXPORT asdf_find_item_t *asdf_value_find_iter(
-    asdf_value_t *root, asdf_value_pred_t pred, asdf_find_iter_t *iter);
+ASDF_EXPORT asdf_value_t *asdf_value_find(asdf_value_t *root, asdf_value_pred_t pred);
 
 /**
  * Alias for `true` for use with `asdf_value_find_ex` and
@@ -978,28 +939,22 @@ ASDF_EXPORT asdf_find_item_t *asdf_value_find_iter(
 
 
 /**
- * Extended version of `asdf_value_find` with additional options
+ * Extended version of `asdf_value_find` with additional traversal options
  *
- * :param value: `asdf_value_t *` handle for the root node in which to start
- *   the search--if the value is neither a mapping or sequence this function
- *   will still return non-NULL if this value matches the predicate
+ * Like `asdf_value_find` but allows controlling traversal order, which
+ * container types to descend into, and the maximum search depth.
+ *
+ * :param root: `asdf_value_t *` handle for the root node to search from
  * :param pred: A predicate function to match the value to return; see
  *   `asdf_value_pred_t`
- * :param depth_first: If `true` descend the tree in depth-first order;
+ * :param depth_first: If ``true`` descend the tree in depth-first order;
  *   otherwise the tree is traversed breadth-first
- * :param descend_pred: Optional predicate (NULL indicates descend into all
- *   nodes) indicating whether a given mapping or sequence should be descended
- *   during traversal
- * :param max_depth: Maximum depth into the tree to descend; -1 indicates no
- *   limit
- *
- *   There are also some built-in defaults `asdf_find_descend_mapping_only` and
- *   `asdf_find_descend_sequence_only`, as well as `asdf_find_descend_all`
- *   (which is equivalent to passing `NULL`).
- * :return: An `asdf_find_item_t *` for the first matching value or NULL if the
- *   tree is exhausted without finding a matching value
+ * :param descend_pred: Optional predicate (``NULL`` means descend into all
+ *   containers) controlling which containers are descended into
+ * :param max_depth: Maximum depth to descend; ``-1`` means no limit
+ * :return: The first matching `asdf_value_t *`, or ``NULL`` if not found
  */
-ASDF_EXPORT asdf_find_item_t *asdf_value_find_ex(
+ASDF_EXPORT asdf_value_t *asdf_value_find_ex(
     asdf_value_t *root,
     asdf_value_pred_t pred,
     bool depth_first,
@@ -1034,54 +989,74 @@ static inline bool asdf_find_descend_sequence_only(asdf_value_t *value) {
  * For use as the ``descend_pred`` argument to `asdf_value_find_ex` and
  * `asdf_find_iter_init_ex`
  *
- * Equivalent to passing this argument ``NULL``, meaning always descend
- * into nested mappings and sequences.
+ * Equivalent to passing ``NULL``, meaning always descend into nested mappings
+ * and sequences.
  */
 #define asdf_find_descend_all ((asdf_value_pred_t)NULL)
 
 
 /**
- * Instantiate an `asdf_find_iter_t` as a local variable to use with
- * `asdf_value_find_iter`
+ * Create an iterator that traverses the tree from ``root`` breadth-first,
+ * yielding values matching ``pred``
  *
- * :return: An `asdf_find_iter_t`, the address of which should be passed to
- *   to `asdf_value_find_iter`
+ * The ``root`` must be a mapping or sequence; for scalar values use
+ * `asdf_value_find` directly.
+ *
+ * :param root: Container `asdf_value_t *` to search from
+ * :param pred: Predicate selecting which values to yield; see `asdf_value_pred_t`
+ * :return: A new `asdf_find_iter_t *`, or ``NULL`` on failure
  */
-ASDF_EXPORT asdf_find_iter_t asdf_find_iter_init(void);
+ASDF_EXPORT asdf_find_iter_t *asdf_find_iter_init(asdf_value_t *root, asdf_value_pred_t pred);
 
 
 /**
- * Like `asdf_find_iter_init` but allows providing additional options for
- * the tree traversal similar to those accepted by `asdf_value_find_ex`
+ * Like `asdf_find_iter_init` with additional traversal options
  *
- * These options only need to be passed to instantiate the iterator, and not
- * in subsequent calls to `asdf_value_find`.
- *
- * :param depth_first: If `true` descend the tree in depth-first order;
- *   otherwise the tree is traversed breadth-first
- * :param descend_pred: Optional predicate (NULL indicates descend into all
- *   nodes) indicating whether a given mapping or sequence should be descended
- *   during traversal
- * :param max_depth: Maximum depth into the tree to descend; -1 indicates no
- *   limit
- * :return: An `asdf_find_iter_t`, the address of which should be passed to
- *   to `asdf_value_find_iter`
+ * :param root: Container `asdf_value_t *` to search from
+ * :param pred: Predicate selecting which values to yield
+ * :param depth_first: If ``true`` traverse depth-first; otherwise breadth-first
+ * :param descend_pred: Optional predicate controlling which containers to descend
+ * :param max_depth: Maximum search depth; ``-1`` means no limit
+ * :return: A new `asdf_find_iter_t *`, or ``NULL`` on failure
  */
-ASDF_EXPORT asdf_find_iter_t
-asdf_find_iter_init_ex(bool depth_first, asdf_value_pred_t descend_pred, ssize_t max_depth);
+ASDF_EXPORT asdf_find_iter_t *asdf_find_iter_init_ex(
+    asdf_value_t *root,
+    asdf_value_pred_t pred,
+    bool depth_first,
+    asdf_value_pred_t descend_pred,
+    ssize_t max_depth);
 
 
 /**
- * Release memory resources used by `asdf_find_item_t`
+ * Advance the find iterator to the next matching value
  *
- * If the iterator was run to exhaustion (i.e. `asdf_value_find_iter` called
- * until returning `NULL`) this happens automatically, but in cases where the
- * iteration is stopped early, or when using `asdf_value_find`, it is necessary
- * to free these resources manually once the value is no longer needed.
+ * On success, `asdf_find_iter_t.value` is updated.  When iteration is
+ * exhausted the iterator is freed and ``*iter`` is set to ``NULL``.
  *
- * :param item: The `asdf_find_item_t *` to destroy
+ * Typical usage:
+ *
+ * .. code:: c
+ *
+ *   asdf_find_iter_t *iter = asdf_find_iter_init(root, pred);
+ *   while (asdf_value_find_iter_next(&iter)) {
+ *       // iter->value is valid here; use asdf_value_clone if it must persist
+ *   }
+ *
+ * :param iter: Pointer to the iterator handle; set to ``NULL`` on exhaustion
+ * :return: ``true`` if a matching value was found; ``false`` when done
  */
-ASDF_EXPORT void asdf_find_item_destroy(asdf_find_item_t *item);
+ASDF_EXPORT bool asdf_value_find_iter_next(asdf_find_iter_t **iter);
+
+
+/**
+ * Release resources held by an in-progress find iterator
+ *
+ * Call this only when breaking out of iteration early.  Safe to call with
+ * ``NULL``.
+ *
+ * :param iter: The `asdf_find_iter_t *` to destroy
+ */
+ASDF_EXPORT void asdf_find_iter_destroy(asdf_find_iter_t *iter);
 
 ASDF_END_DECLS
 

--- a/src/core/asdf.c
+++ b/src/core/asdf.c
@@ -231,10 +231,9 @@ static asdf_extension_metadata_t **asdf_meta_extensions_deserialize(asdf_value_t
     }
 
     asdf_extension_metadata_t **extension_p = extensions;
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *val = NULL;
-    while ((val = asdf_sequence_iter(extensions_seq, &iter))) {
-        if (ASDF_VALUE_OK == asdf_value_as_extension_metadata(val, extension_p))
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(extensions_seq);
+    while (asdf_sequence_iter_next(&iter)) {
+        if (ASDF_VALUE_OK == asdf_value_as_extension_metadata(iter->value, extension_p))
             extension_p++;
         else
             ASDF_LOG(value->file, ASDF_LOG_WARN, "ignoring invalid extension_metadata");
@@ -268,10 +267,9 @@ static asdf_history_entry_t **asdf_meta_history_entries_deserialize(asdf_value_t
     }
 
     asdf_history_entry_t **entry_p = entries;
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *val = NULL;
-    while ((val = asdf_sequence_iter(history_seq, &iter))) {
-        if (ASDF_VALUE_OK == asdf_value_as_history_entry(val, entry_p))
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(history_seq);
+    while (asdf_sequence_iter_next(&iter)) {
+        if (ASDF_VALUE_OK == asdf_value_as_history_entry(iter->value, entry_p))
             entry_p++;
         else
             ASDF_LOG(value->file, ASDF_LOG_WARN, "ignoring invalid history_entry");

--- a/src/core/datatype.c
+++ b/src/core/datatype.c
@@ -249,12 +249,12 @@ asdf_value_err_t asdf_datatype_shape_parse(asdf_sequence_t *value, asdf_datatype
         goto failure;
     }
 
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *dim_val = NULL;
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(value);
     size_t dim = 0;
-    while ((dim_val = asdf_sequence_iter(value, &iter))) {
-        if (ASDF_VALUE_OK != asdf_value_as_uint64(dim_val, &shape[dim++])) {
+    while (asdf_sequence_iter_next(&iter)) {
+        if (ASDF_VALUE_OK != asdf_value_as_uint64(iter->value, &shape[dim++])) {
             warn_invalid_shape(&value->value);
+            asdf_sequence_iter_destroy(iter);
             goto failure;
         }
     }
@@ -351,12 +351,12 @@ static asdf_value_err_t asdf_structured_datatype_parse(
     datatype->nfields = (uint32_t)nfields;
     datatype->fields = fields;
 
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *item = NULL;
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(value);
     int field_idx = 0;
     asdf_value_err_t err = ASDF_VALUE_OK;
 
-    while ((item = asdf_sequence_iter(value, &iter)) != NULL) {
+    while (asdf_sequence_iter_next(&iter)) {
+        asdf_value_t *item = iter->value;
         asdf_datatype_t *field = &fields[field_idx];
         asdf_mapping_t *field_map = NULL;
 
@@ -366,7 +366,7 @@ static asdf_value_err_t asdf_structured_datatype_parse(
             err = asdf_datatype_parse(item, byteorder, field);
 
         if (UNLIKELY(err != ASDF_VALUE_OK)) {
-            // Stop processing and return an error
+            asdf_sequence_iter_destroy(iter);
             return err;
         }
 

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -56,19 +56,20 @@ static asdf_value_t *asdf_extension_metadata_serialize(
         goto cleanup;
 
     if (extension->metadata) {
-        asdf_mapping_iter_t iter = asdf_mapping_iter_init();
-        asdf_mapping_item_t *item = NULL;
-        while ((item = asdf_mapping_iter(extension->metadata, &iter))) {
-            if (strcmp(item->key, "extension_class") == 0)
+        asdf_mapping_iter_t *iter = asdf_mapping_iter_init(extension->metadata);
+        while (asdf_mapping_iter_next(&iter)) {
+            if (strcmp(iter->key, "extension_class") == 0)
                 continue;
 
-            if (strcmp(item->key, "package") == 0)
+            if (strcmp(iter->key, "package") == 0)
                 continue;
 
-            err = asdf_mapping_set(extension_map, item->key, asdf_value_clone(item->value));
+            err = asdf_mapping_set(extension_map, iter->key, asdf_value_clone(iter->value));
 
-            if (err != ASDF_VALUE_OK)
+            if (err != ASDF_VALUE_OK) {
+                asdf_mapping_iter_destroy(iter);
                 goto cleanup;
+            }
         }
     }
 

--- a/src/core/history_entry.c
+++ b/src/core/history_entry.c
@@ -135,10 +135,9 @@ static asdf_software_t **asdf_history_entry_deserialize_software(asdf_value_t *v
     }
 
     asdf_software_t **software_p = software;
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *val = NULL;
-    while (NULL != (val = asdf_sequence_iter(software_seq, &iter))) {
-        if (ASDF_VALUE_OK == asdf_value_as_software(val, software_p))
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(software_seq);
+    while (asdf_sequence_iter_next(&iter)) {
+        if (ASDF_VALUE_OK == asdf_value_as_software(iter->value, software_p))
             software_p++;
         else
             ASDF_LOG(

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -94,17 +94,18 @@ static asdf_value_err_t asdf_ndarray_strides_parse(
         goto failure;
     }
 
-    asdf_sequence_iter_t stride_iter = asdf_sequence_iter_init();
-    asdf_value_t *stride_val = NULL;
+    asdf_sequence_iter_t *stride_iter = asdf_sequence_iter_init(value);
     size_t dim = 0;
-    while ((stride_val = asdf_sequence_iter(value, &stride_iter))) {
-        if (ASDF_VALUE_OK != asdf_value_as_int64(stride_val, &strides[dim])) {
+    while (asdf_sequence_iter_next(&stride_iter)) {
+        if (ASDF_VALUE_OK != asdf_value_as_int64(stride_iter->value, &strides[dim])) {
             warn_invalid_strides(&value->value);
+            asdf_sequence_iter_destroy(stride_iter);
             goto failure;
         }
 
         if (0 == strides[dim]) {
             warn_invalid_strides(&value->value);
+            asdf_sequence_iter_destroy(stride_iter);
             goto failure;
         }
         dim++;
@@ -333,9 +334,9 @@ static asdf_value_err_t infer_inline_array_datatype(
     bool first_is_seq = (asdf_value_get_type(first) == ASDF_VALUE_SEQUENCE);
     asdf_value_destroy(first);
 
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *elem = NULL;
-    while ((elem = asdf_sequence_iter(seq, &iter)) != NULL) {
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(seq);
+    while (asdf_sequence_iter_next(&iter)) {
+        asdf_value_t *elem = iter->value;
         bool elem_is_seq = (asdf_value_get_type(elem) == ASDF_VALUE_SEQUENCE);
 
         if (elem_is_seq != first_is_seq) {
@@ -344,9 +345,7 @@ static asdf_value_err_t infer_inline_array_datatype(
                 ASDF_LOG_ERROR,
                 "inline ndarray has mixed sequence/scalar elements at depth %u",
                 depth);
-            /* Stop iteration by consuming the rest */
-            while (asdf_sequence_iter(seq, &iter) != NULL)
-                ;
+            asdf_sequence_iter_destroy(iter);
             return ASDF_VALUE_ERR_PARSE_FAILURE;
         }
 
@@ -354,14 +353,12 @@ static asdf_value_err_t infer_inline_array_datatype(
             err = infer_inline_array_datatype(
                 (asdf_sequence_t *)elem, depth + 1, shape, ndim, inf, file);
             if (ASDF_IS_ERR(err)) {
-                while (asdf_sequence_iter(seq, &iter) != NULL)
-                    ;
+                asdf_sequence_iter_destroy(iter);
                 return err;
             }
         } else {
             update_type_inference(elem, inf);
         }
-        /* elem is managed by the iterator; do not destroy it explicitly */
     }
 
     return ASDF_VALUE_OK;
@@ -459,15 +456,14 @@ static asdf_value_err_t parse_inline_array_level(
     size_t elem_size = asdf_scalar_datatype_size(dtype);
     asdf_file_t *file = ndarray->internal->file;
 
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
-    asdf_value_t *elem = NULL;
-    while ((elem = asdf_sequence_iter(seq, &iter)) != NULL) {
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(seq);
+    while (asdf_sequence_iter_next(&iter)) {
+        asdf_value_t *elem = iter->value;
         if (depth == ndarray->ndim - 1) {
             /* Leaf level: convert scalar to C value */
             err = convert_scalar_to_native(elem, dtype, buf + ((*offset) * elem_size), file);
             if (ASDF_IS_ERR(err)) {
-                while (asdf_sequence_iter(seq, &iter) != NULL)
-                    ;
+                asdf_sequence_iter_destroy(iter);
                 return err;
             }
             (*offset)++;
@@ -476,8 +472,7 @@ static asdf_value_err_t parse_inline_array_level(
             err = parse_inline_array_level(
                 (asdf_sequence_t *)elem, ndarray, buf, offset, depth + 1);
             if (ASDF_IS_ERR(err)) {
-                while (asdf_sequence_iter(seq, &iter) != NULL)
-                    ;
+                asdf_sequence_iter_destroy(iter);
                 return err;
             }
         }

--- a/src/info.c
+++ b/src/info.c
@@ -104,18 +104,18 @@ static int print_node(FILE *out, asdf_value_t *node, node_index_t *index, node_s
 
     fputc('\n', out);
     bool is_mapping = asdf_value_is_mapping(node);
-    asdf_container_iter_t iter = asdf_container_iter_init();
-    asdf_container_item_t *item = NULL;
+    asdf_container_iter_t *iter = asdf_container_iter_init(node);
     int size = asdf_container_size(node);
-    int idx = 0;
 
     if (state->depth > state->max_depth - 1) {
         // Grow the maximum depth linerally
         size_t new_max_depth = state->max_depth + INITIAL_MAX_DEPTH;
         bool *new_active_levels = realloc(state->active_levels, new_max_depth * sizeof(bool));
 
-        if (!new_active_levels)
+        if (!new_active_levels) {
+            asdf_container_iter_destroy(iter);
             return -1;
+        }
 
         state->active_levels = new_active_levels;
         state->max_depth = new_max_depth;
@@ -130,8 +130,8 @@ static int print_node(FILE *out, asdf_value_t *node, node_index_t *index, node_s
         .is_mapping = is_mapping,
         .is_leaf = false};
 
-    while ((item = asdf_container_iter(node, &iter))) {
-        if (idx == size - 1) {
+    while (asdf_container_iter_next(&iter)) {
+        if (iter->index == size - 1) {
             child_state.is_leaf = true;
             state->active_levels[state->depth] = false;
         }
@@ -139,16 +139,14 @@ static int print_node(FILE *out, asdf_value_t *node, node_index_t *index, node_s
         node_index_t child_index = {0};
 
         if (is_mapping)
-            child_index.key = asdf_container_item_key(item);
+            child_index.key = iter->key;
         else
-            child_index.index = asdf_container_item_index(item);
+            child_index.index = iter->index;
 
-        if (print_node(out, asdf_container_item_value(item), &child_index, &child_state) != 0) {
-            asdf_container_item_destroy(item);
+        if (print_node(out, iter->value, &child_index, &child_state) != 0) {
+            asdf_container_iter_destroy(iter);
             return -1;
         }
-
-        idx++;
     }
 
     return 0;

--- a/src/value.c
+++ b/src/value.c
@@ -525,33 +525,36 @@ ASDF_MAPPING_SET_CONTAINER_TYPE(mapping);
 ASDF_MAPPING_SET_CONTAINER_TYPE(sequence);
 
 
-asdf_mapping_iter_t asdf_mapping_iter_init() {
-    return NULL;
+asdf_mapping_iter_t *asdf_mapping_iter_init(asdf_mapping_t *mapping) {
+    asdf_mapping_iter_impl_t *impl = calloc(1, sizeof(asdf_mapping_iter_impl_t));
+
+    if (!impl) {
+        ASDF_ERROR_OOM(mapping->value.file);
+        return NULL;
+    }
+
+    impl->mapping = mapping;
+    return (asdf_mapping_iter_t *)impl;
 }
 
 
-const char *asdf_mapping_item_key(asdf_mapping_item_t *item) {
-    return item->key;
-}
-
-
-asdf_value_t *asdf_mapping_item_value(asdf_mapping_item_t *item) {
-    return item->value;
-}
-
-
-void asdf_mapping_item_destroy(asdf_mapping_item_t *item) {
-    if (!item)
+void asdf_mapping_iter_destroy(asdf_mapping_iter_t *iter) {
+    if (!iter)
         return;
 
-    item->key = NULL;
-    asdf_value_destroy(item->value);
-    item->value = NULL;
-    free(item);
+    asdf_mapping_iter_impl_t *impl = (asdf_mapping_iter_impl_t *)iter;
+    asdf_value_destroy(impl->pub.value);
+    free(impl);
 }
 
 
-asdf_mapping_item_t *asdf_mapping_iter(asdf_mapping_t *mapping, asdf_mapping_iter_t *iter) {
+bool asdf_mapping_iter_next(asdf_mapping_iter_t **iter_ptr) {
+    if (!iter_ptr || !*iter_ptr)
+        return false;
+
+    asdf_mapping_iter_impl_t *impl = (asdf_mapping_iter_impl_t *)*iter_ptr;
+    asdf_mapping_t *mapping = impl->mapping;
+
     if (mapping->value.raw_type != ASDF_VALUE_MAPPING) {
 #ifdef ASDF_LOG_ENABLED
         ASDF_LOG(
@@ -560,28 +563,13 @@ asdf_mapping_item_t *asdf_mapping_iter(asdf_mapping_t *mapping, asdf_mapping_ite
             "%s is not a mapping",
             asdf_value_path(&mapping->value));
 #endif
-        return NULL;
-    }
-
-    _asdf_mapping_iter_impl_t *impl = *iter;
-
-    if (NULL == impl) {
-        impl = calloc(1, sizeof(_asdf_mapping_iter_impl_t));
-
-        if (!impl) {
-            ASDF_ERROR_OOM(mapping->value.file);
-            return false;
-        }
-
-        *iter = impl;
-    }
-
-    struct fy_node_pair *pair = fy_node_mapping_iterate(mapping->value.node, &impl->iter);
-
-    if (!pair) {
-        /* Cleanup and end iteration */
         goto cleanup;
     }
+
+    struct fy_node_pair *pair = fy_node_mapping_iterate(mapping->value.node, &impl->fy_iter);
+
+    if (!pair)
+        goto cleanup;
 
     struct fy_node *key_node = fy_node_pair_key(pair);
 
@@ -595,39 +583,42 @@ asdf_mapping_item_t *asdf_mapping_iter(asdf_mapping_t *mapping, asdf_mapping_ite
             "be set to NULL",
             asdf_value_path(&mapping->value));
 #endif
-        impl->key = NULL;
+        impl->pub.key = NULL;
     } else {
-        impl->key = fy_node_get_scalar0(key_node);
+        impl->pub.key = fy_node_get_scalar0(key_node);
     }
 
     struct fy_node *value_node = fy_node_pair_value(pair);
     asdf_value_t *value = asdf_value_create_ex(
-        mapping->value.file, value_node, &mapping->value, impl->key, -1);
+        mapping->value.file, value_node, &mapping->value, impl->pub.key, -1);
 
-    if (!value) {
+    if (!value)
         goto cleanup;
-    }
 
-    // Destroy previous value if any
-    asdf_value_destroy(impl->value);
-    impl->value = value;
-    return impl;
+    asdf_value_destroy(impl->pub.value);
+    impl->pub.value = value;
+    return true;
 
 cleanup:
-    asdf_mapping_item_destroy(impl);
-    *iter = NULL;
-    return NULL;
+    asdf_mapping_iter_destroy((asdf_mapping_iter_t *)impl);
+    *iter_ptr = NULL;
+    return false;
 }
 
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 asdf_value_err_t asdf_mapping_update(asdf_mapping_t *mapping, asdf_mapping_t *update) {
-    asdf_mapping_iter_t iter = asdf_mapping_iter_init();
-    asdf_mapping_item_t *item = NULL;
+    asdf_mapping_iter_t *iter = asdf_mapping_iter_init(update);
+    if (!iter)
+        return ASDF_VALUE_ERR_OOM;
     asdf_value_err_t err = ASDF_VALUE_OK;
 
-    while ((item = asdf_mapping_iter(update, &iter))) {
-        err = asdf_mapping_set(mapping, item->key, asdf_value_clone(item->value));
+    while (asdf_mapping_iter_next(&iter)) {
+        err = asdf_mapping_set(mapping, iter->key, asdf_value_clone(iter->value));
+        if (err) {
+            asdf_mapping_iter_destroy(iter);
+            break;
+        }
     }
 
     return err;
@@ -749,12 +740,37 @@ void asdf_sequence_destroy(asdf_sequence_t *sequence) {
 }
 
 
-asdf_sequence_iter_t asdf_sequence_iter_init() {
-    return NULL;
+asdf_sequence_iter_t *asdf_sequence_iter_init(asdf_sequence_t *sequence) {
+    asdf_sequence_iter_impl_t *impl = calloc(1, sizeof(asdf_sequence_iter_impl_t));
+
+    if (UNLIKELY(!impl)) {
+        ASDF_ERROR_OOM(sequence->value.file);
+        return NULL;
+    }
+
+    impl->sequence = sequence;
+    impl->pub.index = -1;
+    return (asdf_sequence_iter_t *)impl;
 }
 
 
-asdf_value_t *asdf_sequence_iter(asdf_sequence_t *sequence, asdf_sequence_iter_t *iter) {
+void asdf_sequence_iter_destroy(asdf_sequence_iter_t *iter) {
+    if (!iter)
+        return;
+
+    asdf_sequence_iter_impl_t *impl = (asdf_sequence_iter_impl_t *)iter;
+    asdf_value_destroy(impl->pub.value);
+    free(impl);
+}
+
+
+bool asdf_sequence_iter_next(asdf_sequence_iter_t **iter_ptr) {
+    if (!iter_ptr || !*iter_ptr)
+        return false;
+
+    asdf_sequence_iter_impl_t *impl = (asdf_sequence_iter_impl_t *)*iter_ptr;
+    asdf_sequence_t *sequence = impl->sequence;
+
     if (UNLIKELY(sequence->value.raw_type != ASDF_VALUE_SEQUENCE)) {
 #ifdef ASDF_LOG_ENABLED
         ASDF_LOG(
@@ -763,49 +779,29 @@ asdf_value_t *asdf_sequence_iter(asdf_sequence_t *sequence, asdf_sequence_iter_t
             "%s is not a sequence",
             asdf_value_path(&sequence->value));
 #endif
-        return NULL;
-    }
-
-    asdf_sequence_iter_impl_t *impl = *iter;
-
-    if (NULL == impl) {
-        impl = calloc(1, sizeof(asdf_sequence_iter_impl_t));
-
-        if (UNLIKELY(!impl)) {
-            ASDF_ERROR_OOM(sequence->value.file);
-            return false;
-        }
-
-        impl->index = -1;
-        *iter = impl;
-    }
-
-    struct fy_node *value_node = fy_node_sequence_iterate(sequence->value.node, &impl->iter);
-
-    if (UNLIKELY(!value_node)) {
-        /* Cleanup and end iteration */
         goto cleanup;
     }
 
-    int index = ++impl->index;
+    struct fy_node *value_node = fy_node_sequence_iterate(sequence->value.node, &impl->fy_iter);
+
+    if (UNLIKELY(!value_node))
+        goto cleanup;
+
+    impl->pub.index++;
     asdf_value_t *value = asdf_value_create_ex(
-        sequence->value.file, value_node, &sequence->value, NULL, index);
+        sequence->value.file, value_node, &sequence->value, NULL, impl->pub.index);
 
-    if (!value) {
+    if (!value)
         goto cleanup;
-    }
 
-    // Destroy previous value if any
-    asdf_value_destroy(impl->value);
-    impl->value = value;
-    return value;
+    asdf_value_destroy(impl->pub.value);
+    impl->pub.value = value;
+    return true;
 
 cleanup:
-    asdf_value_destroy(impl->value);
-    impl->value = NULL;
-    free(impl);
-    *iter = NULL;
-    return NULL;
+    asdf_sequence_iter_destroy((asdf_sequence_iter_t *)impl);
+    *iter_ptr = NULL;
+    return false;
 }
 
 
@@ -1109,104 +1105,92 @@ asdf_value_t *asdf_sequence_pop(asdf_sequence_t *sequence, int index) {
 
 
 /** Generic container functions */
-asdf_container_iter_t asdf_container_iter_init() {
-    return NULL;
-}
-
-
-const char *asdf_container_item_key(asdf_container_item_t *item) {
-    return item->is_mapping ? item->path.key : NULL;
-}
-
-
-int asdf_container_item_index(asdf_container_item_t *item) {
-    return item->is_mapping ? -1 : item->path.index;
-}
-
-
-asdf_value_t *asdf_container_item_value(asdf_container_item_t *item) {
-    return item->value;
-}
-
-
-void asdf_container_item_destroy(asdf_container_item_t *item) {
-    if (!item)
-        return;
-
-    if (item->is_mapping) {
-        item->path.key = NULL;
-        free(item->iter.mapping);
-    } else {
-        item->path.index = -1;
-        free(item->iter.sequence);
-    }
-
-    item->value = NULL;
-    free(item);
-}
-
-
-asdf_container_item_t *asdf_container_iter(asdf_value_t *container, asdf_container_iter_t *iter) {
+asdf_container_iter_t *asdf_container_iter_init(asdf_value_t *container) {
     if (!container)
         return NULL;
 
     if (container->raw_type != ASDF_VALUE_MAPPING && container->raw_type != ASDF_VALUE_SEQUENCE) {
 #ifdef ASDF_LOG_ENABLED
-        const char *path = asdf_value_path(container);
-        ASDF_LOG(container->file, ASDF_LOG_WARN, "%s is not a container", path);
+        ASDF_LOG(
+            container->file, ASDF_LOG_WARN, "%s is not a container", asdf_value_path(container));
 #endif
         return NULL;
     }
 
-    asdf_container_item_t *impl = *iter;
+    asdf_container_iter_impl_t *impl = calloc(1, sizeof(asdf_container_iter_impl_t));
 
-    if (NULL == impl) {
-        impl = calloc(1, sizeof(asdf_container_item_t));
-
-        if (!impl) {
-            ASDF_ERROR_OOM(container->file);
-            return false;
-        }
-
-        if (ASDF_VALUE_MAPPING == container->raw_type) {
-            impl->is_mapping = true;
-            impl->iter.mapping = NULL;
-            impl->path.key = NULL;
-        } else {
-            impl->is_mapping = false;
-            impl->iter.sequence = NULL;
-            impl->path.index = -1;
-        }
-
-        *iter = impl;
+    if (!impl) {
+        ASDF_ERROR_OOM(container->file);
+        return NULL;
     }
+
+    impl->container = container;
+    impl->is_mapping = (container->raw_type == ASDF_VALUE_MAPPING);
+    impl->pub.index = -1;
 
     if (impl->is_mapping) {
-        asdf_mapping_item_t *item = asdf_mapping_iter(
-            (asdf_mapping_t *)container, &impl->iter.mapping);
-
-        if (!item)
-            goto cleanup;
-
-        impl->path.key = item->key;
-        impl->value = item->value;
-        return impl;
+        impl->iter.mapping = asdf_mapping_iter_init((asdf_mapping_t *)container);
+        if (!impl->iter.mapping) {
+            free(impl);
+            return NULL;
+        }
+    } else {
+        impl->iter.sequence = asdf_sequence_iter_init((asdf_sequence_t *)container);
+        if (!impl->iter.sequence) {
+            free(impl);
+            return NULL;
+        }
     }
 
-    // Sequence case
-    asdf_value_t *value = asdf_sequence_iter((asdf_sequence_t *)container, &impl->iter.sequence);
+    return (asdf_container_iter_t *)impl;
+}
 
-    if (!value)
+
+void asdf_container_iter_destroy(asdf_container_iter_t *iter) {
+    if (!iter)
+        return;
+
+    asdf_container_iter_impl_t *impl = (asdf_container_iter_impl_t *)iter;
+
+    if (impl->is_mapping)
+        asdf_mapping_iter_destroy(impl->iter.mapping);
+    else
+        asdf_sequence_iter_destroy(impl->iter.sequence);
+
+    /* pub.value aliases the sub-iter's value; not independently freed */
+    free(impl);
+}
+
+
+bool asdf_container_iter_next(asdf_container_iter_t **iter_ptr) {
+    if (!iter_ptr || !*iter_ptr)
+        return false;
+
+    asdf_container_iter_impl_t *impl = (asdf_container_iter_impl_t *)*iter_ptr;
+
+    if (impl->is_mapping) {
+        if (!asdf_mapping_iter_next(&impl->iter.mapping))
+            goto cleanup;
+
+        impl->pub.key = impl->iter.mapping->key;
+        impl->pub.index++;
+        impl->pub.value = impl->iter.mapping->value;
+        return true;
+    }
+
+    if (!asdf_sequence_iter_next(&impl->iter.sequence))
         goto cleanup;
 
-    impl->path.index++;
-    impl->value = value;
-    return impl;
+    impl->pub.key = NULL;
+    impl->pub.index = impl->iter.sequence->index;
+    impl->pub.value = impl->iter.sequence->value;
+    return true;
 
 cleanup:
-    asdf_container_item_destroy(impl);
-    *iter = NULL;
-    return NULL;
+    /* sub-iter already freed and nulled by its _next(); just free our wrapper */
+    free(impl);
+    *iter_ptr = NULL;
+    return false;
 }
 
 
@@ -2706,40 +2690,48 @@ ASDF_VALUE_OF_TYPE(double, double, ASDF_VALUE_DOUBLE, d, double);
 #define ASDF_VALUE_FIND_ITER_MIN_CAPACITY 8
 #define ASDF_VALUE_FIND_ITER_MAX_DEPTH 256
 
-/**
- * Implementation details for `asdf_value_find_iter_ex` which is the workhorse
- * for all the other variants (`asdf_value_find_iter`, `asdf_value_find_ex`,
- * `asdf_value_find`)
- */
-static asdf_find_item_t *asdf_value_find_iter_create(
-    bool depth_first, asdf_value_pred_t descend_pred, ssize_t max_depth) {
-    asdf_find_item_t *item = calloc(1, sizeof(asdf_find_item_t));
+static inline asdf_find_frame_t *asdf_find_iter_push_frame(
+    asdf_find_iter_impl_t *iter, asdf_value_t *container, ssize_t depth);
 
-    if (!item)
+static asdf_find_iter_impl_t *asdf_find_iter_create(
+    asdf_value_t *root,
+    asdf_value_pred_t pred,
+    bool depth_first,
+    asdf_value_pred_t descend_pred,
+    ssize_t max_depth) {
+    asdf_find_iter_impl_t *impl = calloc(1, sizeof(asdf_find_iter_impl_t));
+
+    if (!impl)
         return NULL;
 
-    item->depth_first = depth_first;
-    item->descend_pred = descend_pred;
-    item->max_depth = max_depth;
-    item->value = NULL;
-    // Initial small frame stack, though we can also use max_depth as a
-    // heuristic
-    item->frame_cap = (max_depth < 0) ? ASDF_VALUE_FIND_ITER_MIN_CAPACITY
+    impl->pred = pred;
+    impl->depth_first = depth_first;
+    impl->descend_pred = descend_pred;
+    impl->max_depth = max_depth;
+    // Initial small frame stack; use max_depth as a heuristic when available
+    impl->frame_cap = (max_depth < 0) ? ASDF_VALUE_FIND_ITER_MIN_CAPACITY
                                       : (((max_depth > ASDF_VALUE_FIND_ITER_MAX_DEPTH)
                                               ? ASDF_VALUE_FIND_ITER_MAX_DEPTH
                                               : max_depth + 1));
-    item->frames = calloc(item->frame_cap, sizeof(asdf_find_frame_t));
-    return item;
+    impl->frames = calloc(impl->frame_cap, sizeof(asdf_find_frame_t));
+
+    if (!impl->frames) {
+        free(impl);
+        return NULL;
+    }
+
+    asdf_find_iter_push_frame(impl, root, 0);
+    return impl;
 }
 
 
-/** Just doubles the frame capacity */
+/** Doubles the frame capacity when needed */
 static inline asdf_find_frame_t *asdf_find_iter_push_frame(
-    asdf_find_item_t *iter, asdf_value_t *container, ssize_t depth) {
+    asdf_find_iter_impl_t *iter, asdf_value_t *container, ssize_t depth) {
     // Refuse to push a new frame if we are already at max-depth or the new
-    // container doesn't match the descend predicate
+    // container doesn't match the descend predicate.
     // Always allow push though if frame_count == 0; that is, the root node is
-    // always searched through regardless of descend_prod
+    // always searched through regardless of descend_pred.
     if ((iter->max_depth >= 0 && depth > iter->max_depth) ||
         (iter->frame_count > 0 && iter->descend_pred && !iter->descend_pred(container)))
         return NULL;
@@ -2761,7 +2753,7 @@ static inline asdf_find_frame_t *asdf_find_iter_push_frame(
     asdf_find_frame_t *frame = &iter->frames[iter->frame_count++];
     ZERO_MEMORY(frame, sizeof(asdf_find_frame_t));
     frame->container = container;
-    frame->iter = asdf_container_iter_init();
+    frame->iter = asdf_container_iter_init(container);
     frame->is_mapping = container->raw_type == ASDF_VALUE_MAPPING;
     frame->depth = depth;
     return frame;
@@ -2772,15 +2764,13 @@ static inline asdf_find_frame_t *asdf_find_iter_push_frame(
  * Pop the idx-th frame from the stack
  *
  * Breadth-first traversal can be slightly more expensive here since we have
- * to shift all the frames down
+ * to shift all the frames down.
  */
-static inline void asdf_find_iter_pop_frame(asdf_find_item_t *iter, size_t idx) {
+static inline void asdf_find_iter_pop_frame(asdf_find_iter_impl_t *iter, size_t idx) {
     asdf_find_frame_t *frame = &iter->frames[idx];
 
-    asdf_container_item_destroy(frame->iter);
+    asdf_container_iter_destroy(frame->iter);
 
-    // Hack needed for BFS
-    // TODO: Should be fixed
     if (frame->owns_container)
         asdf_value_destroy(frame->container);
 
@@ -2799,8 +2789,8 @@ static inline void asdf_find_iter_pop_frame(asdf_find_item_t *iter, size_t idx) 
 }
 
 
-/** DFS strategy for `asdf_find_iter_next` */
-static asdf_value_t *asdf_find_iter_next_dfs(asdf_find_item_t *iter) {
+/** DFS strategy for the find iterator */
+static asdf_value_t *asdf_find_iter_next_dfs(asdf_find_iter_impl_t *iter) {
     assert(iter->frame_count > 0);
     asdf_find_frame_t *frame = &iter->frames[iter->frame_count - 1];
 
@@ -2809,22 +2799,22 @@ static asdf_value_t *asdf_find_iter_next_dfs(asdf_find_item_t *iter) {
         return frame->container;
     }
 
-    asdf_container_item_t *item = NULL;
-    while ((item = asdf_container_iter(frame->container, &frame->iter))) {
-        if (asdf_value_is_container(item->value)) {
-            asdf_find_iter_push_frame(iter, item->value, frame->depth + 1);
+    while (asdf_container_iter_next(&frame->iter)) {
+        asdf_value_t *child = frame->iter->value;
+        if (asdf_value_is_container(child)) {
+            asdf_find_iter_push_frame(iter, child, frame->depth + 1);
             return NULL;
         }
 
-        return item->value;
+        return child;
     }
     asdf_find_iter_pop_frame(iter, iter->frame_count - 1);
     return NULL;
 }
 
 
-/** BFS strategy for `asdf_find_iter_next` */
-static asdf_value_t *asdf_find_iter_next_bfs(asdf_find_item_t *iter) {
+/** BFS strategy for the find iterator */
+static asdf_value_t *asdf_find_iter_next_bfs(asdf_find_iter_impl_t *iter) {
     assert(iter->frame_count > 0);
     asdf_find_frame_t *frame = &iter->frames[0];
 
@@ -2833,17 +2823,13 @@ static asdf_value_t *asdf_find_iter_next_bfs(asdf_find_item_t *iter) {
         return frame->container;
     }
 
-    asdf_container_item_t *item = NULL;
-    while ((item = asdf_container_iter(frame->container, &frame->iter))) {
-        if (asdf_value_is_container(item->value)) {
-            // In the BFS case it is important to *clone* the value before
-            // pushing it onto the stack, because the next call of
-            // asdf_container_iter will destroy the original; a design
-            // choice that makes sense most of the time but is a foot-gun
-            // here.  Would be better if we boxed values with reference
-            // counting
+    while (asdf_container_iter_next(&frame->iter)) {
+        asdf_value_t *child = frame->iter->value;
+        if (asdf_value_is_container(child)) {
+            // In BFS, clone the child before pushing: the next container_iter_next
+            // call will destroy the original value wrapper.
             asdf_find_frame_t *new_frame = asdf_find_iter_push_frame(
-                iter, asdf_value_clone(item->value), frame->depth + 1);
+                iter, asdf_value_clone(child), frame->depth + 1);
 
             if (!new_frame)
                 return NULL;
@@ -2852,30 +2838,21 @@ static asdf_value_t *asdf_find_iter_next_bfs(asdf_find_item_t *iter) {
             new_frame->owns_container = true;
         }
 
-        return item->value;
+        return child;
     }
     asdf_find_iter_pop_frame(iter, 0);
     return NULL;
 }
 
+
 /**
- * The core of asdf_value_find_iter_ex
+ * The core of the find iterator
  *
  * We maintain our own little stack of values being descended into (similar
  * to the implementation of `asdf_info`) so that we can traverse the tree
  * to arbitrary (modulo system resource) depths without blowing the C stack.
- *
- * This is probably unnecessary for most files though may be useful in some
- * cases.  In any case I usually prefer such an approach over brute recursion.
- *
- * In fact, `asdf_info` could, and later should, be rewritten on top of this
- * if possible. `asdf_info` was written very early in the project when I was
- * just trying to get a handle on libfyaml.
  */
-static asdf_value_t *asdf_find_iter_next(asdf_find_item_t *iter) {
-    if (iter->value && !asdf_value_is_container(iter->value))
-        return iter->value;
-
+static asdf_value_t *asdf_find_iter_step(asdf_find_iter_impl_t *iter) {
     if (!iter->frame_count)
         return NULL;
 
@@ -2889,100 +2866,90 @@ static asdf_value_t *asdf_find_iter_next(asdf_find_item_t *iter) {
 }
 
 
-asdf_find_iter_t asdf_find_iter_init_ex(
-    bool depth_first, asdf_value_pred_t descend_pred, ssize_t max_depth) {
-    asdf_find_item_t *iter = asdf_value_find_iter_create(depth_first, descend_pred, max_depth);
-    return iter;
-}
-
-
-asdf_find_iter_t asdf_find_iter_init(void) {
-    return asdf_find_iter_init_ex(false, NULL, -1);
-}
-
-
-void asdf_find_item_destroy(asdf_find_item_t *item) {
-    if (!item)
-        return;
-
-    asdf_value_destroy(item->value);
-
-    // Pop all remaining frames off the stack if any
-    // This is important to do before freeing item->frames since sometimes
-    // individual frames need cleanup too
-    while (item->frame_count > 0)
-        asdf_find_iter_pop_frame(item, item->frame_count - 1);
-
-    free(item->frames);
-    free(item);
-}
-
-
-asdf_find_item_t *asdf_value_find_iter(
-    asdf_value_t *root, asdf_value_pred_t pred, asdf_find_iter_t *iter) {
-
-    asdf_find_item_t *item = *iter;
-
-    if (!item) {
-        ASDF_ERROR_OOM(root->file);
-        return NULL;
-    }
-
-    if (item->frame_count == 0) {
-        // Subsequent calls with the same iterator but a different root result
-        // in undefined behavior.  Push the root node onto the stack to begin
-        if (asdf_value_is_container(root))
-            asdf_find_iter_push_frame(item, root, 0);
-        else
-            // Special case when we are given a scalar "root" value
-            item->value = root;
-    } else {
-        item->value = NULL;
-    }
-
-    asdf_value_t *current = NULL;
-
-    while (item->frame_count > 0 || item->value) {
-        current = asdf_find_iter_next(item);
-        if (current && (!pred || pred(current))) {
-            // wrap in find_item_t and return
-            item->value = current;
-            // TODO: Build path
-            return item;
-        }
-        item->value = NULL;
-    }
-    asdf_find_item_destroy(item);
-    return NULL;
-}
-
-
-asdf_find_item_t *asdf_value_find_ex(
+asdf_find_iter_t *asdf_find_iter_init_ex(
     asdf_value_t *root,
     asdf_value_pred_t pred,
     bool depth_first,
     asdf_value_pred_t descend_pred,
     ssize_t max_depth) {
-    asdf_find_iter_t iter = asdf_find_iter_init_ex(depth_first, descend_pred, max_depth);
-    return asdf_value_find_iter(root, pred, &iter);
-}
-
-
-asdf_find_item_t *asdf_value_find(asdf_value_t *root, asdf_value_pred_t pred) {
-    return asdf_value_find_ex(root, pred, false, NULL, -1);
-}
-
-
-const char *asdf_find_item_path(asdf_find_item_t *item) {
-    if (!item->value)
+    if (!asdf_value_is_container(root))
         return NULL;
 
-    return asdf_value_path(item->value);
+    return (asdf_find_iter_t *)asdf_find_iter_create(
+        root, pred, depth_first, descend_pred, max_depth);
 }
 
 
-asdf_value_t *asdf_find_item_value(asdf_find_item_t *item) {
-    return item->value;
+asdf_find_iter_t *asdf_find_iter_init(asdf_value_t *root, asdf_value_pred_t pred) {
+    return asdf_find_iter_init_ex(root, pred, false, NULL, -1);
+}
+
+
+void asdf_find_iter_destroy(asdf_find_iter_t *iter) {
+    if (!iter)
+        return;
+
+    asdf_find_iter_impl_t *impl = (asdf_find_iter_impl_t *)iter;
+
+    while (impl->frame_count > 0)
+        asdf_find_iter_pop_frame(impl, impl->frame_count - 1);
+
+    free(impl->frames);
+    free(impl);
+}
+
+
+bool asdf_value_find_iter_next(asdf_find_iter_t **iter_ptr) {
+    if (!iter_ptr || !*iter_ptr)
+        return false;
+
+    asdf_find_iter_impl_t *impl = (asdf_find_iter_impl_t *)*iter_ptr;
+    impl->pub.value = NULL;
+
+    asdf_value_t *current = NULL;
+
+    while (impl->frame_count > 0) {
+        current = asdf_find_iter_step(impl);
+        if (current && (!impl->pred || impl->pred(current))) {
+            impl->pub.value = current;
+            return true;
+        }
+    }
+
+    asdf_find_iter_destroy((asdf_find_iter_t *)impl);
+    *iter_ptr = NULL;
+    return false;
+}
+
+
+asdf_value_t *asdf_value_find_ex(
+    asdf_value_t *root,
+    asdf_value_pred_t pred,
+    bool depth_first,
+    asdf_value_pred_t descend_pred,
+    ssize_t max_depth) {
+    if (!asdf_value_is_container(root)) {
+        if (!pred || pred(root))
+            return asdf_value_clone(root);
+        return NULL;
+    }
+
+    asdf_find_iter_t *iter = asdf_find_iter_init_ex(
+        root, pred, depth_first, descend_pred, max_depth);
+    if (!iter)
+        return NULL;
+
+    if (!asdf_value_find_iter_next(&iter))
+        return NULL;
+
+    asdf_value_t *result = asdf_value_clone(iter->value);
+    asdf_find_iter_destroy(iter);
+    return result;
+}
+
+
+asdf_value_t *asdf_value_find(asdf_value_t *root, asdf_value_pred_t pred) {
+    return asdf_value_find_ex(root, pred, false, NULL, -1);
 }
 
 

--- a/src/value.h
+++ b/src/value.h
@@ -48,81 +48,63 @@ typedef struct asdf_mapping {
 } asdf_mapping_t;
 
 
-typedef struct _asdf_mapping_iter_impl {
-    const char *key;
-    asdf_value_t *value;
-    void *iter;
-} _asdf_mapping_iter_impl_t;
+typedef struct asdf_mapping_iter_impl {
+    /** Must first member -- cast to/from asdf_mapping_iter_t * is valid */
+    asdf_mapping_iter_t pub;
+    asdf_mapping_t *mapping;
+    void *fy_iter;
+} asdf_mapping_iter_impl_t;
 
-
-typedef _asdf_mapping_iter_impl_t *asdf_mapping_iter_t;
-
-
-typedef struct _asdf_mapping_iter_impl asdf_mapping_item_t;
 
 typedef struct asdf_sequence {
     asdf_value_t value;
 } asdf_sequence_t;
 
+
 typedef struct asdf_sequence_iter_impl {
-    asdf_value_t *value;
-    int index;
-    void *iter;
+    /** Must first member -- cast to/from asdf_sequence_iter_t * is valid */
+    asdf_sequence_iter_t pub;
+    asdf_sequence_t *sequence;
+    void *fy_iter;
 } asdf_sequence_iter_impl_t;
 
 
-typedef void *asdf_sequence_iter_t;
-
-
-/**
- * Contains both the iterator state and the current item of the iterator
- */
-typedef struct asdf_container_item {
-    union {
-        const char *key;
-        int index;
-    } path;
-    asdf_value_t *value;
+typedef struct asdf_container_iter_impl {
+    /** Must first member -- cast to/from asdf_container_iter_t * is valid */
+    asdf_container_iter_t pub;
+    asdf_value_t *container;
     bool is_mapping;
     union {
-        asdf_mapping_iter_t mapping;
-        asdf_sequence_iter_t sequence;
+        asdf_mapping_iter_t *mapping;
+        asdf_sequence_iter_t *sequence;
     } iter;
-} asdf_container_item_t;
-
-
-typedef void *asdf_container_iter_t;
+} asdf_container_iter_impl_t;
 
 
 ASDF_LOCAL asdf_value_t *asdf_value_create(asdf_file_t *file, struct fy_node *node);
 
 
-typedef struct {
+typedef struct asdf_find_frame {
     asdf_value_t *container;
-    // Really an ugly hack that should be fixed
-    // We need versions of the mapping/sequence/container_iter routines that
-    // don't destroy values between iterations, and/or better memory management
-    // for values maybe with reference counting
     bool owns_container;
     bool visited;
     bool is_mapping;
     ssize_t depth;
-    asdf_container_iter_t iter;
+    asdf_container_iter_t *iter;
 } asdf_find_frame_t;
 
 
-typedef struct asdf_find_item {
-    asdf_value_t *value;
+typedef struct asdf_find_iter_impl {
+    /** Must first member -- cast to/from asdf_find_iter_t * is valid */
+    asdf_find_iter_t pub;
+    asdf_value_pred_t pred;
     bool depth_first;
     asdf_value_pred_t descend_pred;
     ssize_t max_depth;
     asdf_find_frame_t *frames;
     size_t frame_count;
     size_t frame_cap;
-} asdf_find_item_t;
-
-
-typedef void *asdf_find_iter_t;
+} asdf_find_iter_impl_t;
 
 
 /**

--- a/tests/test-core-extensions.c
+++ b/tests/test-core-extensions.c
@@ -89,28 +89,24 @@ static void assert_extension_metadata_equal(const asdf_extension_metadata_t *ext
     size_t size_diff = size0 > size1 ? size0 - size1 : size1 - size0;
     assert_int(size_diff, <=, 2);
 
-    asdf_mapping_iter_t iter = asdf_mapping_iter_init();
-    asdf_mapping_item_t *item = NULL;
-    while ((item = asdf_mapping_iter(extension0->metadata, &iter))) {
+    asdf_mapping_iter_t *iter = asdf_mapping_iter_init(extension0->metadata);
+    while (asdf_mapping_iter_next(&iter)) {
         // TODO: Definitely could use a generic value comparison function
         // without this we can't generally compare two mappings or sequences
         // For the purposes of this test just compare strings
-        const char *key = asdf_mapping_item_key(item);
-
-        if (strcmp(key, "extension_class") == 0)
+        if (strcmp(iter->key, "extension_class") == 0)
             continue;
 
-        if (strcmp(key, "package") == 0)
+        if (strcmp(iter->key, "package") == 0)
             continue;
 
-        asdf_value_t *value = asdf_mapping_item_value(item);
-        asdf_value_t *other = asdf_mapping_get(extension1->metadata, key);
+        asdf_value_t *other = asdf_mapping_get(extension1->metadata, iter->key);
         assert_not_null(other);
-        assert_int(asdf_value_get_type(value), ==, asdf_value_get_type(other));
-        if (asdf_value_is_string(value)) {
+        assert_int(asdf_value_get_type(iter->value), ==, asdf_value_get_type(other));
+        if (asdf_value_is_string(iter->value)) {
             const char *str = NULL;
             const char *other_str = NULL;
-            assert_int(asdf_value_as_string0(value, &str), ==, ASDF_VALUE_OK);
+            assert_int(asdf_value_as_string0(iter->value, &str), ==, ASDF_VALUE_OK);
             assert_int(asdf_value_as_string0(other, &other_str), ==, ASDF_VALUE_OK);
             assert_string_equal(str, other_str);
         }

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -991,8 +991,11 @@ MU_TEST(test_asdf_mapping_create) {
 }
 
 
-MU_TEST(test_asdf_mapping_item_destroy) {
-    asdf_mapping_item_destroy(NULL); // OK
+MU_TEST(test_asdf_iter_destroy_null) {
+    asdf_mapping_iter_destroy(NULL);
+    asdf_sequence_iter_destroy(NULL);
+    asdf_container_iter_destroy(NULL);
+    asdf_find_iter_destroy(NULL);
     return MUNIT_OK;
 }
 
@@ -1005,30 +1008,26 @@ MU_TEST(test_asdf_mapping_iter) {
     asdf_value_err_t err = asdf_get_mapping(file, "mapping", &mapping);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_int(asdf_mapping_size(mapping), ==, 2);
-    asdf_mapping_iter_t iter = asdf_mapping_iter_init();
+    asdf_mapping_iter_t *iter = asdf_mapping_iter_init(mapping);
 
-    asdf_mapping_item_t *item = asdf_mapping_iter(mapping, &iter);
-    assert_not_null(item);
-    assert_not_null(asdf_mapping_item_key(item));
-    assert_string_equal(asdf_mapping_item_key(item), "foo");
-    asdf_value_t *value = asdf_mapping_item_value(item);
-    assert_not_null(value);
+    assert_true(asdf_mapping_iter_next(&iter));
+    assert_not_null(iter->key);
+    assert_string_equal(iter->key, "foo");
+    assert_not_null(iter->value);
     const char *s = NULL;
-    assert_int(asdf_value_as_string0(value, &s), ==, ASDF_VALUE_OK);
+    assert_int(asdf_value_as_string0(iter->value, &s), ==, ASDF_VALUE_OK);
     assert_string_equal(s, "foo");
 
-    item = asdf_mapping_iter(mapping, &iter);
-    assert_not_null(item);
-    assert_not_null(asdf_mapping_item_key(item));
-    assert_string_equal(asdf_mapping_item_key(item), "bar");
-    value = asdf_mapping_item_value(item);
-    assert_not_null(value);
+    assert_true(asdf_mapping_iter_next(&iter));
+    assert_not_null(iter->key);
+    assert_string_equal(iter->key, "bar");
+    assert_not_null(iter->value);
     s = NULL;
-    assert_int(asdf_value_as_string0(value, &s), ==, ASDF_VALUE_OK);
+    assert_int(asdf_value_as_string0(iter->value, &s), ==, ASDF_VALUE_OK);
     assert_string_equal(s, "bar");
 
-    assert_null(asdf_mapping_iter(mapping, &iter));
-    assert_null((void *)iter);
+    assert_false(asdf_mapping_iter_next(&iter));
+    assert_null(iter);
     asdf_mapping_destroy(mapping);
     asdf_close(file);
     return MUNIT_OK;
@@ -1329,21 +1328,21 @@ MU_TEST(test_asdf_sequence_iter) {
     asdf_value_err_t err = asdf_get_sequence(file, "sequence", &sequence);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_int(asdf_sequence_size(sequence), ==, 2);
-    asdf_sequence_iter_t iter = asdf_sequence_iter_init();
+    asdf_sequence_iter_t *iter = asdf_sequence_iter_init(sequence);
 
-    asdf_value_t *item = asdf_sequence_iter(sequence, &iter);
-    assert_not_null(item);
     int8_t i8 = -1;
-    assert_int(asdf_value_as_int8(item, &i8), ==, ASDF_VALUE_OK);
+    assert_true(asdf_sequence_iter_next(&iter));
+    assert_not_null(iter->value);
+    assert_int(asdf_value_as_int8(iter->value, &i8), ==, ASDF_VALUE_OK);
     assert_int(i8, ==, 0);
 
-    item = asdf_sequence_iter(sequence, &iter);
-    assert_not_null(item);
-    assert_int(asdf_value_as_int8(item, &i8), ==, ASDF_VALUE_OK);
+    assert_true(asdf_sequence_iter_next(&iter));
+    assert_not_null(iter->value);
+    assert_int(asdf_value_as_int8(iter->value, &i8), ==, ASDF_VALUE_OK);
     assert_int(i8, ==, 1);
 
-    assert_null(asdf_sequence_iter(sequence, &iter));
-    assert_null((void *)iter);
+    assert_false(asdf_sequence_iter_next(&iter));
+    assert_null(iter);
     asdf_sequence_destroy(sequence);
     asdf_close(file);
     return MUNIT_OK;
@@ -1461,19 +1460,16 @@ MU_TEST(test_asdf_container_iter) {
     asdf_value_t *container = asdf_get_value(file, "sequence");
     assert_not_null(container);
 
-    asdf_container_iter_t iter = asdf_container_iter_init();
-    asdf_container_item_t *item = NULL;
+    asdf_container_iter_t *iter = asdf_container_iter_init(container);
     int8_t i8 = -1;
-
-    for (int idx = 0; idx < 2; idx++) {
-        item = asdf_container_iter(container, &iter);
-        assert_not_null(item);
-        assert_int(asdf_container_item_index(item), ==, idx);
-        assert_int(asdf_value_as_int8(asdf_container_item_value(item), &i8), ==, ASDF_VALUE_OK);
+    int idx = 0;
+    while (asdf_container_iter_next(&iter)) {
+        assert_int(iter->index, ==, idx);
+        assert_int(asdf_value_as_int8(iter->value, &i8), ==, ASDF_VALUE_OK);
         assert_int(i8, ==, idx);
+        idx++;
     }
-
-    assert_null(asdf_container_iter(container, &iter));
+    assert_null(iter);
     asdf_value_destroy(container);
 
     // Test on a mapping now
@@ -1481,14 +1477,16 @@ MU_TEST(test_asdf_container_iter) {
     assert_not_null(container);
     const char *s = NULL;
     const char *expected[] = {"foo", "bar"};
-    for (int idx = 0; idx < 2; idx++) {
-        item = asdf_container_iter(container, &iter);
-        assert_not_null(item);
-        assert_string_equal(asdf_container_item_key(item), expected[idx]);
-        assert_int(asdf_value_as_string0(asdf_container_item_value(item), &s), ==, ASDF_VALUE_OK);
+    iter = asdf_container_iter_init(container);
+    idx = 0;
+    while (asdf_container_iter_next(&iter)) {
+        assert_string_equal(iter->key, expected[idx]);
+        assert_int(iter->index, ==, idx);
+        assert_int(asdf_value_as_string0(iter->value, &s), ==, ASDF_VALUE_OK);
         assert_string_equal(s, expected[idx]);
+        idx++;
     }
-    assert_null(asdf_container_iter(container, &iter));
+    assert_null(iter);
 
     asdf_value_destroy(container);
     asdf_close(file);
@@ -1594,31 +1592,27 @@ MU_TEST(test_asdf_value_find_iter_ex_descend_mapping_only) {
     assert_not_null(root);
     assert_true(asdf_value_is_mapping(root));
 
-    asdf_find_iter_t iter = asdf_find_iter_init_ex(true, asdf_find_descend_mapping_only, 1);
-    asdf_find_item_t *item = NULL;
-
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    assert_not_null(item);
+    asdf_find_iter_t *iter = asdf_find_iter_init_ex(
+        root, value_find_pred_a, true, asdf_find_descend_mapping_only, 1);
     const char *str = NULL;
-    const char *path = asdf_find_item_path(item);
-    assert_string_equal(path, "/a");
-    asdf_value_t *val = asdf_find_item_value(item);
-    asdf_value_err_t err = asdf_value_as_string0(val, &str);
+    asdf_value_err_t err;
+
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/a");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
 
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    assert_not_null(item);
-    path = asdf_find_item_path(item);
-    assert_string_equal(path, "/c/a");
-    val = asdf_find_item_value(item);
-    err = asdf_value_as_string0(val, &str);
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/c/a");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
 
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    // Found all values matching the predicate
-    assert_null(item);
+    assert_false(asdf_value_find_iter_next(&iter));
+    assert_null(iter);
 
     asdf_value_destroy(root);
     asdf_close(file);
@@ -1634,31 +1628,27 @@ MU_TEST(test_asdf_value_find_iter_ex_descend_sequence_only) {
     assert_not_null(root);
     assert_true(asdf_value_is_mapping(root));
 
-    asdf_find_iter_t iter = asdf_find_iter_init_ex(true, asdf_find_descend_sequence_only, 1);
-    asdf_find_item_t *item = NULL;
-    
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    assert_not_null(item);
+    asdf_find_iter_t *iter = asdf_find_iter_init_ex(
+        root, value_find_pred_a, true, asdf_find_descend_sequence_only, 1);
     const char *str = NULL;
-    const char *path = asdf_find_item_path(item);
-    assert_string_equal(path, "/a");
-    asdf_value_t *val = asdf_find_item_value(item);
-    asdf_value_err_t err = asdf_value_as_string0(val, &str);
+    asdf_value_err_t err;
+
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/a");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
 
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    assert_not_null(item);
-    path = asdf_find_item_path(item);
-    assert_string_equal(path, "/d/0");
-    val = asdf_find_item_value(item);
-    err = asdf_value_as_string0(val, &str);
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/d/0");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
 
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    // Found all values matching the predicate
-    assert_null(item);
+    assert_false(asdf_value_find_iter_next(&iter));
+    assert_null(iter);
 
     asdf_value_destroy(root);
     asdf_close(file);
@@ -1677,22 +1667,20 @@ MU_TEST(test_asdf_value_find_iter_max_depth) {
     // When iteration is set with max_depth = 0 it should never descend into
     // any sub-collections, but should still find values at the top-level of
     // the input root collection
-    asdf_find_iter_t iter = asdf_find_iter_init_ex(true, asdf_find_descend_all, 0);
-    asdf_find_item_t *item = NULL;
-
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    assert_not_null(item);
+    asdf_find_iter_t *iter = asdf_find_iter_init_ex(
+        root, value_find_pred_a, true, asdf_find_descend_all, 0);
     const char *str = NULL;
-    const char *path = asdf_find_item_path(item);
-    assert_string_equal(path, "/a");
-    asdf_value_t *val = asdf_find_item_value(item);
-    asdf_value_err_t err = asdf_value_as_string0(val, &str);
+    asdf_value_err_t err;
+
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/a");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
 
-    item = asdf_value_find_iter(root, value_find_pred_a, &iter);
-    // Found all values matching the predicate
-    assert_null(item);
+    assert_false(asdf_value_find_iter_next(&iter));
+    assert_null(iter);
 
     asdf_value_destroy(root);
     asdf_close(file);
@@ -1708,19 +1696,17 @@ MU_TEST(test_asdf_value_find_ex) {
     assert_not_null(root);
     assert_true(asdf_value_is_mapping(root));
 
-    asdf_find_item_t *item = asdf_value_find_ex(
+    asdf_value_t *val = asdf_value_find_ex(
         root, value_find_pred_a, true, asdf_find_descend_all, 1);
-    assert_not_null(item);
+    assert_not_null(val);
     const char *str = NULL;
 
-    const char *path = asdf_find_item_path(item);
-    assert_string_equal(path, "/a");
-    asdf_value_t *val = asdf_find_item_value(item);
+    assert_string_equal(asdf_value_path(val), "/a");
     asdf_value_err_t err = asdf_value_as_string0(val, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
 
-    asdf_find_item_destroy(item);
+    asdf_value_destroy(val);
     asdf_value_destroy(root);
     asdf_close(file);
     return MUNIT_OK;
@@ -1735,39 +1721,34 @@ MU_TEST(test_asdf_value_find_iter) {
     assert_not_null(root);
     assert_true(asdf_value_is_mapping(root));
 
-    asdf_find_iter_t iter = asdf_find_iter_init();
-    asdf_find_item_t *item = NULL;
-
-    item = asdf_value_find_iter(root, value_find_pred_b, &iter);
-    assert_not_null(item);
+    asdf_find_iter_t *iter = asdf_find_iter_init(root, value_find_pred_b);
     const char *str = NULL;
-    const char *path = asdf_find_item_path(item);
+    asdf_value_err_t err;
+
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
     // BFS should find the value "b" at the top-level first
-    assert_string_equal(path, "/b");
-    asdf_value_t *val = asdf_find_item_value(item);
-    asdf_value_err_t err = asdf_value_as_string0(val, &str);
+    assert_string_equal(asdf_value_path(iter->value), "/b");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "b");
 
-    item = asdf_value_find_iter(root, value_find_pred_b, &iter);
-    path = asdf_find_item_path(item);
-    assert_string_equal(path, "/c/b");
-    val = asdf_find_item_value(item);
-    err = asdf_value_as_string0(val, &str);
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/c/b");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "b");
 
-    item = asdf_value_find_iter(root, value_find_pred_b, &iter);
-    path = asdf_find_item_path(item);
-    assert_string_equal(path, "/d/1");
-    val = asdf_find_item_value(item);
-    err = asdf_value_as_string0(val, &str);
+    assert_true(asdf_value_find_iter_next(&iter));
+    assert_not_null(iter);
+    assert_string_equal(asdf_value_path(iter->value), "/d/1");
+    err = asdf_value_as_string0(iter->value, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "b");
 
-    // Should be no more values found
-    item = asdf_value_find_iter(root, value_find_pred_b, &iter);
-    assert_null(item);
+    assert_false(asdf_value_find_iter_next(&iter));
+    assert_null(iter);
 
     asdf_value_destroy(root);
     asdf_close(file);
@@ -1783,17 +1764,15 @@ MU_TEST(test_asdf_value_find) {
     assert_not_null(root);
     assert_true(asdf_value_is_mapping(root));
 
-    asdf_find_item_t *item = asdf_value_find(root, value_find_pred_b);
-    assert_not_null(item);
+    asdf_value_t *val = asdf_value_find(root, value_find_pred_b);
+    assert_not_null(val);
     const char *str = NULL;
-    const char *path = asdf_find_item_path(item);
     // BFS should find the value "b" at the top-level first
-    assert_string_equal(path, "/b");
-    asdf_value_t *val = asdf_find_item_value(item);
+    assert_string_equal(asdf_value_path(val), "/b");
     asdf_value_err_t err = asdf_value_as_string0(val, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "b");
-    asdf_find_item_destroy(item);
+    asdf_value_destroy(val);
 
     asdf_value_destroy(root);
     asdf_close(file);
@@ -1801,6 +1780,13 @@ MU_TEST(test_asdf_value_find) {
 }
 
 
+/**
+ * Note: calling value find on a scalar *is* allowed, but it will simply
+ * return the scalar value itself if it matches the predicate.
+ *
+ * In this case it is also a new copy of the original value so both need
+ * to be freed.
+ */
 MU_TEST(test_asdf_value_find_on_scalar) {
     const char *filename = get_fixture_file_path("nested.asdf");
     asdf_file_t *file = asdf_open(filename, "r");
@@ -1809,22 +1795,21 @@ MU_TEST(test_asdf_value_find_on_scalar) {
     assert_not_null(root);
     assert_true(asdf_value_is_scalar(root));
 
-    asdf_find_item_t *item = asdf_value_find(root, value_find_pred_a);
-    assert_not_null(item);
+    asdf_value_t *val = asdf_value_find(root, value_find_pred_a);
+    assert_not_null(val);
     const char *str = NULL;
-    const char *path = asdf_find_item_path(item);
-    assert_string_equal(path, "/a");
-    asdf_value_t *val = asdf_find_item_value(item);
+    assert_string_equal(asdf_value_path(val), "/a");
     asdf_value_err_t err = asdf_value_as_string0(val, &str);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_string_equal(str, "a");
-    asdf_find_item_destroy(item);
+    asdf_value_destroy(val);
+    asdf_value_destroy(root);
 
     root = asdf_get_value(file, "/b");
     assert_not_null(root);
     assert_true(asdf_value_is_scalar(root));
-    item = asdf_value_find(root, value_find_pred_a);
-    assert_null(item);
+    val = asdf_value_find(root, value_find_pred_a);
+    assert_null(val);
 
     asdf_value_destroy(root);
     asdf_close(file);
@@ -1916,13 +1901,11 @@ MU_TEST(test_raw_value_type_preserved_after_type_resolution) {
     // It can still be iterated over too, etc
     asdf_mapping_t *root_map = NULL;
     assert_int(asdf_value_as_mapping(root, &root_map), ==, ASDF_VALUE_OK);
-    asdf_mapping_iter_t iter = asdf_mapping_iter_init();
-    asdf_mapping_item_t *item = asdf_mapping_iter(root_map, &iter);
-    assert_not_null(item);
-    asdf_value_t *a = asdf_mapping_item_value(item);
+    asdf_mapping_iter_t *iter = asdf_mapping_iter_init(root_map);
+    assert_true(asdf_mapping_iter_next(&iter));
+    asdf_value_t *a = iter->value;
     assert_string_equal(asdf_value_path(a), "/a");
-    asdf_value_destroy(a);
-    free(item);
+    asdf_mapping_iter_destroy(iter);
     asdf_meta_destroy(meta);
     asdf_value_destroy(root);
     asdf_close(file);
@@ -2010,7 +1993,7 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_value_of_type),
     MU_RUN_TEST(test_value_tagged_strings),
     MU_RUN_TEST(test_asdf_mapping_create),
-    MU_RUN_TEST(test_asdf_mapping_item_destroy),
+    MU_RUN_TEST(test_asdf_iter_destroy_null),
     MU_RUN_TEST(test_asdf_mapping_iter),
     MU_RUN_TEST(test_asdf_mapping_get),
     MU_RUN_TEST(test_asdf_mapping_pop),


### PR DESCRIPTION
Resolves #73 

For libasdf-gwcs I want to add an iterator interface for WCS steps as well, so doing this first made sense, and the WCS step iterator can follow the same pattern.

I like this implementation a lot better; feels cleaner and less cumbersome to use.