### PR TITLE
Basic support for reading aliases

### DIFF
--- a/changes/35.feature
+++ b/changes/35.feature
@@ -1,0 +1,1 @@
+Basic support for reading YAML aliases.

--- a/src/value.c
+++ b/src/value.c
@@ -76,8 +76,11 @@ static asdf_value_t *asdf_value_create_ex(
     if (fy_node_is_alias(node)) {
 #ifdef ASDF_LOG_ENABLED
         const char *anchor = fy_node_get_scalar0(node);
-        const char *value_path = path ? path : fy_node_get_path(node);
+        char *value_path = path ? path : fy_node_get_path(node);
         ASDF_LOG(file, ASDF_LOG_DEBUG, "value at %s is an alias for %s", value_path, anchor);
+
+        if (!path)
+            free(value_path);
 #endif
         node = fy_node_resolve_alias(node);
 

--- a/src/value.c
+++ b/src/value.c
@@ -49,11 +49,45 @@ static asdf_value_type_t asdf_value_type_from_node(struct fy_node *node) {
  */
 static asdf_value_t *asdf_value_create_ex(
     asdf_file_t *file, struct fy_node *node, asdf_value_t *parent, const char *key, int index) {
+    assert(node);
     asdf_value_t *value = calloc(1, sizeof(asdf_value_t));
+    char *path = NULL;
 
     if (!value) {
         ASDF_ERROR_OOM(file);
         return NULL;
+    }
+
+    if (parent && parent->path) {
+        if (key) {
+            if (asprintf(&path, "%s/%s", parent->path, key) == -1) {
+                ASDF_LOG(file, ASDF_LOG_WARN, "failure to build value path for %s (OOM?)", key);
+            }
+        } else if (index >= 0) {
+            if (asprintf(&path, "%s/%d", parent->path, index) == -1) {
+                ASDF_LOG(file, ASDF_LOG_WARN, "failure to build value path for %d (OOM?)", index);
+            }
+        }
+    }
+
+    // Check if the node is an alias -- if so resolve it immediately
+    // More fine-grained control over aliases isn't supported yet so for now
+    // we just treat them transparently
+    if (fy_node_is_alias(node)) {
+#ifdef ASDF_LOG_ENABLED
+        const char *anchor = fy_node_get_scalar0(node);
+        const char *value_path = path ? path : fy_node_get_path(node);
+        ASDF_LOG(file, ASDF_LOG_DEBUG, "value at %s is an alias for %s", value_path, anchor);
+#endif
+        node = fy_node_resolve_alias(node);
+
+        if (!node) {
+            // May be null if the node led to a graph cycle, but not clear if we
+            // can distinguish that case from a genuine OOM
+            ASDF_ERROR_OOM(file);
+            free(value);
+            return NULL;
+        }
     }
 
     value->file = file;
@@ -65,25 +99,7 @@ static asdf_value_t *asdf_value_create_ex(
     value->shallow = false;
     value->explicit_tag_checked = false;
     value->extension_checked = false;
-    value->path = NULL;
-
-    if (parent && parent->path) {
-        char *path = NULL;
-        if (key) {
-            if (asprintf(&path, "%s/%s", parent->path, key) == -1) {
-                ASDF_LOG(file, ASDF_LOG_WARN, "failure to build value path for %s (OOM?)", key);
-            } else {
-                value->path = path;
-            }
-        } else if (index >= 0) {
-            if (asprintf(&path, "%s/%d", parent->path, index) == -1) {
-                ASDF_LOG(file, ASDF_LOG_WARN, "failure to build value path for %d (OOM?)", index);
-            } else {
-                value->path = path;
-            }
-        }
-    }
-
+    value->path = path;
     return value;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -339,6 +339,7 @@ EXTRA_DIST += \
     fixtures/255-out.asdf \
     fixtures/255-padding-after-header.asdf \
     fixtures/255-padding-after-tree.asdf \
+    fixtures/anchors.asdf \
     fixtures/byteorder.asdf \
     fixtures/compressed.asdf \
     fixtures/cube.asdf \

--- a/tests/fixtures/anchors.asdf
+++ b/tests/fixtures/anchors.asdf
@@ -1,0 +1,12 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.6.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+string: &id001 string
+string_alias: *id001
+software: &id002 !core/software-1.0.0
+  name: libasdf
+  version: 1.0.0
+software_alias: *id002
+...

--- a/tests/fixtures/info/anchor.info.txt
+++ b/tests/fixtures/info/anchor.info.txt
@@ -17,4 +17,5 @@
 [2m│       └─[0m[1mversion[0m (scalar): 4.1.0
 [2m├─[0m[1ma[0m (mapping)
 [2m│ └─[0m[1mabc[0m (scalar): 123
-[2m└─[0m[1mb[0m (scalar): id001
+[2m└─[0m[1mb[0m (mapping)
+[2m  └─[0m[1mabc[0m (scalar): 123

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -1912,6 +1912,36 @@ MU_TEST(test_raw_value_type_preserved_after_type_resolution) {
     return MUNIT_OK;
 }
 
+
+/** Test alias/anchor resolution -- for asdf_value_t it should be transparent */
+MU_TEST(anchors) {
+    const char *filename = get_fixture_file_path("anchors.asdf");
+    asdf_file_t *file = asdf_open(filename, "r");
+    assert_not_null(file);
+
+    asdf_value_t *value = asdf_get_value(file, "string_alias");
+    const char *string = NULL;
+    assert_not_null(value);
+    assert_true(asdf_value_is_string(value));
+    assert_int(asdf_value_as_string0(value, &string), ==, ASDF_VALUE_OK);
+    assert_string_equal(string, "string");
+    asdf_value_destroy(value);
+
+    // Test for an extension type
+    value = asdf_get_value(file, "software_alias");
+    asdf_software_t *software = NULL;
+    assert_not_null(value);
+    assert_true(asdf_value_is_software(value));
+    assert_int(asdf_value_as_software(value, &software), ==, ASDF_VALUE_OK);
+    assert_string_equal(software->name, "libasdf");
+    assert_string_equal(software->version->version, "1.0.0");
+    asdf_value_destroy(value);
+    asdf_software_destroy(software);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 /** Regression test for double-free bug on cloned extension values */
 MU_TEST(regression_clone_extension_value) {
     const char *path = get_reference_file_path("1.6.0/basic.asdf");
@@ -2019,6 +2049,7 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_value_parent),
     MU_RUN_TEST(test_asdf_value_type_string),
     MU_RUN_TEST(test_raw_value_type_preserved_after_type_resolution),
+    MU_RUN_TEST(anchors),
     // TODO: Maybe set up a separate test suite for regression tests
     MU_RUN_TEST(regression_clone_extension_value),
     MU_RUN_TEST(regression_read_min_int),


### PR DESCRIPTION
This is the bare minimum needed for #35, though I think I will leave that issue open to think about it a little more carefully later, especially w.r.t. assigning anchors to values and writing aliases.

For now this simply resolves aliases transparently when reading values out of the YAML.  At least this much as needed for asdf-format/libasdf-gwcs#1 since the Roman WCS's make use of anchors and aliases.