### PR TITLE
fix: misc fixes to the main library needed for libasdf-gwcs

### DIFF
--- a/include/asdf/value.h
+++ b/include/asdf/value.h
@@ -230,7 +230,7 @@ ASDF_EXPORT const char *asdf_value_tag(asdf_value_t *value);
 typedef struct asdf_file asdf_file_t;
 
 /** Get the `asdf_file_t *` handle to the file to which a value belongs */
-ASDF_EXPORT const asdf_file_t *asdf_value_file(asdf_value_t *value);
+ASDF_EXPORT asdf_file_t *asdf_value_file(asdf_value_t *value);
 
 /** Mappings */
 

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -64,7 +64,15 @@ static asdf_value_t *asdf_extension_metadata_serialize(
             if (strcmp(iter->key, "package") == 0)
                 continue;
 
-            err = asdf_mapping_set(extension_map, iter->key, asdf_value_clone(iter->value));
+            // Make a deep copy of the metadata mapping's value since inserting
+            // it into a new mapping steals ownership of the value
+            asdf_value_t *val = asdf_value_clone_deep(iter->value);
+
+            if (iter->value && !val) {
+                err = ASDF_VALUE_ERR_OOM;
+            } else {
+                err = asdf_mapping_set(extension_map, iter->key, val);
+            }
 
             if (err != ASDF_VALUE_OK) {
                 asdf_mapping_iter_destroy(iter);

--- a/src/extension_util.c
+++ b/src/extension_util.c
@@ -93,6 +93,14 @@ static bool is_equivalent_type(asdf_value_type_t type, asdf_value_type_t expecte
         switch (type) {
         case ASDF_VALUE_DOUBLE:
         case ASDF_VALUE_FLOAT:
+        case ASDF_VALUE_INT64:
+        case ASDF_VALUE_INT32:
+        case ASDF_VALUE_INT16:
+        case ASDF_VALUE_INT8:
+        case ASDF_VALUE_UINT64:
+        case ASDF_VALUE_UINT32:
+        case ASDF_VALUE_UINT16:
+        case ASDF_VALUE_UINT8:
             return true;
         default:
             return false;

--- a/src/value.c
+++ b/src/value.c
@@ -215,7 +215,81 @@ static asdf_value_t *asdf_value_clone_impl(asdf_value_t *value, bool raw_shallow
 }
 
 
+/* Shallow clone that preserves all type information from the source value
+ *
+ * Only valid for nodes that are attached to a document (where the document owns
+ * the fy_node); fy_node_free() is a no-op on attached nodes so the shallow
+ * reference is always safe.
+ *
+ * Unlike asdf_value_clone_impl(value, true) ("raw shallow"), this preserves the
+ * computed type, extension type information, and scalar cache so the clone is
+ * immediately usable without re-inferring anything.  Extension values get a new
+ * ext wrapper struct that shares the already-deserialized object pointer; only
+ * the wrapper is freed on destroy, not the object itself (consistent with the
+ * normal ownership rules for extension objects).
+ *
+ * .. todo::
+ *
+ *   Merge this into asdf_value_clone_impl
+ */
+static asdf_value_t *asdf_value_clone_shallow(asdf_value_t *value) {
+    if (!value)
+        return NULL;
+
+    asdf_value_t *new_value = malloc(sizeof(asdf_value_t));
+    if (!new_value) {
+        ASDF_ERROR_OOM(value->file);
+        return NULL;
+    }
+
+    new_value->file = value->file;
+    new_value->node = value->node;
+    new_value->type = value->type;
+    new_value->raw_type = value->raw_type;
+    new_value->err = value->err;
+    new_value->shallow = true;
+    new_value->explicit_tag_checked = value->explicit_tag_checked;
+    new_value->extension_checked = value->extension_checked;
+    new_value->tag = value->tag ? strdup(value->tag) : NULL;
+    new_value->path = value->path ? strdup(value->path) : fy_node_get_path(value->node);
+
+    if (value->type == ASDF_VALUE_EXTENSION && value->scalar.ext) {
+        asdf_extension_value_t *new_ext = malloc(sizeof(asdf_extension_value_t));
+        if (!new_ext) {
+            free((char *)new_value->path);
+            free((char *)new_value->tag);
+            free(new_value);
+            ASDF_ERROR_OOM(value->file);
+            return NULL;
+        }
+        *new_ext = *value->scalar.ext;
+        new_value->scalar.ext = new_ext;
+    } else {
+        new_value->scalar = value->scalar;
+    }
+
+    return new_value;
+}
+
+
 asdf_value_t *asdf_value_clone(asdf_value_t *value) {
+    if (!value)
+        return NULL;
+
+    // For nodes owned by a document (attached or document root), use a shallow
+    // clone: the document manages the fy_node lifetime, fy_node_free() is a
+    // no-op, and avoiding a full deep copy prevents failures on deeply nested
+    // structures (libfyaml has a hard limit on recursive copy depth).
+    if (value->node && (fy_node_is_attached(value->node) || is_root_node(value->node)))
+        return asdf_value_clone_shallow(value);
+
+    return asdf_value_clone_impl(value, false);
+}
+
+
+// Deep-clone variant for when an independent (detached) copy is truly needed,
+// e.g. when moving a value from one document/container into another.
+asdf_value_t *asdf_value_clone_deep(asdf_value_t *value) {
     return asdf_value_clone_impl(value, false);
 }
 
@@ -265,8 +339,8 @@ const char *asdf_value_tag(asdf_value_t *value) {
 }
 
 
-const asdf_file_t *asdf_value_file(asdf_value_t *value) {
-    return (const asdf_file_t *)value->file;
+asdf_file_t *asdf_value_file(asdf_value_t *value) {
+    return value->file;
 }
 
 
@@ -410,7 +484,7 @@ void asdf_mapping_set_style(asdf_mapping_t *mapping, asdf_yaml_node_style_t styl
 
 
 asdf_mapping_t *asdf_mapping_clone(asdf_mapping_t *mapping) {
-    asdf_value_t *clone = asdf_value_clone(&mapping->value);
+    asdf_value_t *clone = asdf_value_clone_deep(&mapping->value);
     return (asdf_mapping_t *)clone;
 }
 
@@ -439,11 +513,13 @@ static inline asdf_value_err_t asdf_mapping_set_node(
 
     // If the key already exists in the mapping, replace its value
     if (pair) {
+        fy_node_free(key_node);
+
         if (fy_node_pair_set_value(pair, value) != 0) {
             return ASDF_VALUE_ERR_OOM;
         }
-        fy_node_free(key_node);
     } else if (fy_node_mapping_append(mapping->value.node, key_node, value) != 0) {
+        fy_node_free(key_node);
         return ASDF_VALUE_ERR_OOM;
     }
 
@@ -633,7 +709,12 @@ asdf_value_err_t asdf_mapping_update(asdf_mapping_t *mapping, asdf_mapping_t *up
     asdf_value_err_t err = ASDF_VALUE_OK;
 
     while (asdf_mapping_iter_next(&iter)) {
-        err = asdf_mapping_set(mapping, iter->key, asdf_value_clone(iter->value));
+        asdf_value_t *clone = asdf_value_clone_deep(iter->value);
+        if (!clone) {
+            asdf_mapping_iter_destroy(iter);
+            return ASDF_VALUE_ERR_OOM;
+        }
+        err = asdf_mapping_set(mapping, iter->key, clone);
         if (err) {
             asdf_mapping_iter_destroy(iter);
             break;
@@ -1349,8 +1430,10 @@ asdf_value_t *asdf_value_of_extension_type(
 
     // TODO: Might be better if serialize also returned an asdf_value_t so we
     // can report serialization errors better
-    if (!value)
+    if (!value) {
+        free(new_ext);
         return NULL;
+    }
 
     // serialize *may* return NULL if an error occurred in the serializer
     // in this case the serializer should the serializer be responsible for setting an error?
@@ -2499,6 +2582,20 @@ asdf_value_err_t asdf_value_as_double(asdf_value_t *value, double *out) {
     case ASDF_VALUE_FLOAT:
         if (LIKELY(out))
             *out = value->scalar.d;
+        return ASDF_VALUE_OK;
+    case ASDF_VALUE_INT64:
+    case ASDF_VALUE_INT32:
+    case ASDF_VALUE_INT16:
+    case ASDF_VALUE_INT8:
+        if (LIKELY(out))
+            *out = (double)value->scalar.i;
+        return ASDF_VALUE_OK;
+    case ASDF_VALUE_UINT64:
+    case ASDF_VALUE_UINT32:
+    case ASDF_VALUE_UINT16:
+    case ASDF_VALUE_UINT8:
+        if (LIKELY(out))
+            *out = (double)value->scalar.u;
         return ASDF_VALUE_OK;
     default:
         return ASDF_VALUE_ERR_TYPE_MISMATCH;

--- a/src/value.h
+++ b/src/value.h
@@ -176,5 +176,9 @@ ASDF_NODE_OF_FLOAT_VALUE_TYPE(double, double, "%.17g")
  */
 ASDF_LOCAL struct fy_node *asdf_value_normalize_node(asdf_value_t *value);
 
+/**
+ * Additional internal functions not yet exposed in the public API
+ */
+ASDF_LOCAL asdf_value_t *asdf_value_clone_deep(asdf_value_t *value);
 ASDF_LOCAL asdf_value_err_t asdf_node_insert_at(
     struct fy_document *doc, const char *path, struct fy_node *node, bool materialize);

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -795,6 +795,59 @@ MU_TEST(test_asdf_value_as_double) {
 }
 
 
+MU_TEST(test_asdf_value_as_double_from_int) {
+    /* Integer-typed values should be coercible to double */
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+
+    double out = 0.0;
+    asdf_value_t *v;
+
+    v = asdf_value_of_int8(file, 42);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, 42.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_int16(file, -1000);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, -1000.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_int32(file, 100000);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, 100000.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_int64(file, -1);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, -1.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_uint8(file, 255);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, 255.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_uint16(file, 1000);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, 1000.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_uint32(file, 1);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, 1.0);
+    asdf_value_destroy(v);
+
+    v = asdf_value_of_uint64(file, 0);
+    assert_int(asdf_value_as_double(v, &out), ==, ASDF_VALUE_OK);
+    assert_double(out, ==, 0.0);
+    asdf_value_destroy(v);
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST(test_asdf_value_as_type) {
     const char *path = get_fixture_file_path("scalars.asdf");
     asdf_file_t *file = asdf_open(path, "r");
@@ -1985,6 +2038,40 @@ MU_TEST(regression_read_flt_max) {
 }
 
 
+// asdf_value_clone on an attached node should use a shallow reference rather
+// than a full deep copy.  This is important for deeply nested structures (e.g.
+// GWCS pipeline transform trees) which would otherwise exceed libfyaml's
+// hard-coded recursive copy depth limit.
+MU_TEST(test_asdf_value_clone_attached_shallow) {
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+
+    // Create a 20-level deep nested mapping by setting a value at a long path.
+    // Each slash-separated component materialises an intermediate mapping node.
+    assert_int(asdf_set_int32(
+        file,
+        "a0/a1/a2/a3/a4/a5/a6/a7/a8/a9/a10/a11/a12/a13/a14/a15/a16/a17/a18/a19",
+        42), ==, ASDF_VALUE_OK);
+
+    // Retrieve the root-level mapping -- it is now attached to the document and
+    // has a subtree 20 levels deep.
+    asdf_value_t *root = asdf_get_value(file, "a0");
+    assert_not_null(root);
+    assert_true(asdf_value_is_mapping(root));
+
+    // Clone should succeed even though the subtree exceeds the libfyaml deep-copy
+    // depth limit; for attached nodes we take a shallow reference instead.
+    asdf_value_t *clone = asdf_value_clone(root);
+    assert_not_null(clone);
+    assert_true(asdf_value_is_mapping(clone));
+
+    asdf_value_destroy(clone);
+    asdf_value_destroy(root);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     value,
     MU_RUN_TEST(test_asdf_value_get_type),
@@ -2016,6 +2103,7 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_value_as_float),
     MU_RUN_TEST(test_asdf_value_is_float),
     MU_RUN_TEST(test_asdf_value_as_double),
+    MU_RUN_TEST(test_asdf_value_as_double_from_int),
     MU_RUN_TEST(test_asdf_value_as_type),
     MU_RUN_TEST(test_asdf_value_is_type),
     MU_RUN_TEST(test_asdf_value_of_mapping),
@@ -2053,7 +2141,8 @@ MU_TEST_SUITE(
     // TODO: Maybe set up a separate test suite for regression tests
     MU_RUN_TEST(regression_clone_extension_value),
     MU_RUN_TEST(regression_read_min_int),
-    MU_RUN_TEST(regression_read_flt_max)
+    MU_RUN_TEST(regression_read_flt_max),
+    MU_RUN_TEST(test_asdf_value_clone_attached_shallow)
 );
 
 


### PR DESCRIPTION
Specifically for asdf-format/libasdf-gwcs#5

- Clearer distinction between shallow copy and deep copy of asdf_value_t; for already attached nodes generally prefer a shallow copy (should be a significant performance improvement, but also elides problems with libfyaml; see explanation below)

- Allow coercion of integer scalar values to doubles; this was always intended to be possible but just never tested the case; of course the converse is not always allowed

While working on large WCS objects I found out that libfyaml's fy_node_copy actually imposes a hard-coded limit (currently 16) on how deeply-nested a node structure it can copy.  I'm...not really sure why it does this.  Certainly it should avoid cycles in the case where there are aliases, but otherwise it feels to make like an arbitrary restriction. On the other hand, forcing us to be more careful about this I think led to some optimization of avoiding a lot of node copying when it wasn't really necessary.  For certain APIs though it could still be a foot-gun, so we need a longer-term workaround for this.  That will be #182