### PR TITLE
fix: small memory leak in asdf_extension_get

### DIFF
--- a/src/extension_registry.c
+++ b/src/extension_registry.c
@@ -26,6 +26,7 @@ const asdf_extension_t *asdf_extension_get(asdf_file_t *file, const char *tag) {
 
     if (!ext) {
         ASDF_LOG(file, ASDF_LOG_TRACE, "no extension registered for tag %s", full_tag);
+        free(full_tag);
         return NULL;
     }
 

--- a/tests/test-extension.c
+++ b/tests/test-extension.c
@@ -146,6 +146,17 @@ MU_TEST(extension_registered) {
 }
 
 
+MU_TEST(extension_get_unregistered) {
+    const char *path = get_fixture_file_path("trivial-extension.asdf");
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+    const asdf_extension_t *ext = asdf_extension_get(file, "unregistered-tag");
+    assert_null(ext);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST(test_asdf_value_is_foo) {
     const char *path = get_fixture_file_path("trivial-extension.asdf");
     asdf_file_t *file = asdf_open(path, "r");
@@ -255,6 +266,7 @@ MU_TEST(test_asdf_foo_array_clone) {
 MU_TEST_SUITE(
     extension,
     MU_RUN_TEST(extension_registered),
+    MU_RUN_TEST(extension_get_unregistered),
     MU_RUN_TEST(test_asdf_value_is_foo),
     MU_RUN_TEST(test_asdf_value_as_foo),
     MU_RUN_TEST(test_asdf_value_of_foo),


### PR DESCRIPTION
Only occurs when the looked up tag does not have a registered extension associated, which was not tested before now.  This came up in the tests for asdf-format/libasdf-gwcs#5