### PR TITLE
Fix time format guessing and misc memory leaks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,18 @@ libasdf_la_CFLAGS = $(AM_CFLAGS) $(FYAML_CFLAGS) $(STATGRAB_CFLAGS) $(LZ4_CFLAGS
 libasdf_la_LDFLAGS = $(CODE_COVERAGE_LDFLAGS)
 libasdf_la_LIBADD =  third_party/libstc.la $(ASDF_LIBS)
 
+# Static convenience library for malloc-wrap tests; built only when the
+# linker supports --wrap.  Linking test-malloc-fail.unit against this archive
+# (rather than against the shared libasdf) lets --wrap intercept allocations
+# made anywhere inside the library without having to compile individual
+# translation units directly into the test binary.
+if HAVE_LINKER_WRAP
+noinst_LTLIBRARIES = libasdf_static.la
+libasdf_static_la_SOURCES = $(src_files)
+libasdf_static_la_CFLAGS = $(libasdf_la_CFLAGS)
+libasdf_static_la_LIBADD = third_party/libstc.la $(ASDF_LIBS)
+endif # HAVE_LINKER_WRAP
+
 # The asdf command line tool
 if ASDF_BUILD_TOOL
 bin_PROGRAMS = asdf

--- a/include/asdf/core/time.h
+++ b/include/asdf/core/time.h
@@ -2,8 +2,10 @@
 #ifndef ASDF_CORE_TIME_H
 #define ASDF_CORE_TIME_H
 
-#include <asdf/extension.h>
 #include <sys/time.h>
+#include <time.h>
+
+#include <asdf/extension.h>
 
 
 ASDF_BEGIN_DECLS

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -127,8 +127,10 @@ static asdf_value_err_t asdf_extension_metadata_deserialize(
 
     asdf_extension_metadata_t *metadata = calloc(1, sizeof(asdf_extension_metadata_t));
 
-    if (!metadata)
+    if (!metadata) {
+        asdf_software_destroy(package);
         return ASDF_VALUE_ERR_OOM;
+    }
 
     metadata->extension_class = strdup(extension_class);
     metadata->package = package;

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -434,12 +434,16 @@ static asdf_value_err_t asdf_time_deserialize(
         if (asdf_value_as_mapping(value, &mapping) != ASDF_VALUE_OK)
             goto failure;
         prop = asdf_mapping_get(mapping, "value");
+        if (!prop)
+            goto failure;
     } else {
         prop = value;
     }
 
     time->value = calloc(ASDF_TIME_TIMESTR_MAXLEN, sizeof(*time->value));
     if (!time->value) {
+        if (prop && prop != value)
+            asdf_value_destroy(prop);
         free(time);
         return ASDF_VALUE_ERR_OOM;
     }
@@ -500,12 +504,23 @@ static asdf_value_err_t asdf_time_deserialize(
         /* jyear */
         "J[0-9]+(.[0-9]+)?",
         /* yday */
+        /** FIXME: This regexp actually fails to compile due to surpassing the
+         * built-in character class limit; need to find workaround to this */
         "[0-9]{4}:(00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3[0-5][0-9])|(36[0-5]):([0-1][0-9])|"
         "([0-1][0-9])|(2[0-4]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?"};
 
     time->format.is_base_format = true;
     for (size_t idx = 0; idx < sizeof(time_auto_patterns) / sizeof(time_auto_patterns[0]); idx++) {
         cregex re = cregex_make(time_auto_patterns[idx], CREG_DEFAULT);
+
+        if (UNLIKELY(re.error == CREG_OUTOFMEMORY)) {
+            err = ASDF_VALUE_ERR_OOM;
+            goto failure;
+        } else if (UNLIKELY(re.error != CREG_OK)) {
+            err = ASDF_VALUE_ERR_PARSE_FAILURE;
+            goto failure;
+        }
+
         if (cregex_is_match(&re, time->value) == true) {
             const char *fmt_have = format_s ? format_s : time_auto_keys[idx];
             if (!strcmp(fmt_have, "iso_time")) {

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -2,18 +2,98 @@
 #include "config.h"
 #endif
 
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
+#include "stc/cregex.h"
+
+#include "./time.h"
 #include "asdf.h"
-#include "time.h"
 
 #include "../extension_registry.h"
 #include "../log.h"
 #include "../util.h"
 #include "../value.h"
-#include "stc/cregex.h"
+
+/**
+ * Auto-detect patterns -- compiled once upon first use
+ *
+ * Each pattern uses capture groups for all date/time fields so that
+ * out-of-range values can be flagged.  Patterns deliberately avoid
+ * digit-range sub-expressions (e.g. ``[0-5][0-9]`` for minutes) because STC
+ * cregex has a hard limit of ``CREG_MAX_CLASSES`` (16) character-class slots
+ * per compiled pattern.  Range validation is done manually after the match.
+ *
+ * Capture group layout per pattern index:
+ *   TIME_AUTO_IDX_ISO_TIME:
+ *     [1]=year [2]=month [3]=day
+ *     [4]=optional "T/space + time" [5]=hour [6]=minute [7]=second [8]=frac
+ *   TIME_AUTO_IDX_BYEAR:
+ *     [1]=integer-part [2]=optional fractional
+ *   TIME_AUTO_IDX_JYEAR:
+ *     [1]=integer-part [2]=optional fractional
+ *   TIME_AUTO_IDX_YDAY:
+ *     [1]=year [2]=day-of-year [3]=hour [4]=minute [5]=second [6]=optional frac
+ */
+enum {
+    TIME_AUTO_IDX_ISO_TIME = 0,
+    TIME_AUTO_IDX_BYEAR,
+    TIME_AUTO_IDX_JYEAR,
+    TIME_AUTO_IDX_YDAY,
+    TIME_AUTO_COUNT,
+};
+
+static const struct {
+    asdf_time_base_format_t type;
+    const char *pattern;
+} time_auto_patterns[TIME_AUTO_COUNT] = {
+    [TIME_AUTO_IDX_ISO_TIME] =
+        {
+            ASDF_TIME_FORMAT_ISO_TIME,
+            "^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)([T ](\\d\\d):(\\d\\d):(\\d\\d)(.\\d+)?)?",
+        },
+    [TIME_AUTO_IDX_BYEAR] =
+        {
+            ASDF_TIME_FORMAT_BYEAR,
+            "^B(\\d+)(.\\d+)?",
+        },
+    [TIME_AUTO_IDX_JYEAR] =
+        {
+            ASDF_TIME_FORMAT_JYEAR,
+            "^J(\\d+)(.\\d+)?",
+        },
+    [TIME_AUTO_IDX_YDAY] =
+        {
+            ASDF_TIME_FORMAT_YDAY,
+            "^(\\d\\d\\d\\d):(\\d\\d\\d):(\\d\\d):(\\d\\d):(\\d\\d)(.\\d+)?",
+        },
+};
+
+
+static cregex time_auto_regexes[TIME_AUTO_COUNT];
+static atomic_bool time_auto_regexes_compiled = false;
+
+
+static void compile_time_auto_regexes(void) {
+    if (atomic_load_explicit(&time_auto_regexes_compiled, memory_order_acquire))
+        return;
+    for (size_t jdx = 0; jdx < TIME_AUTO_COUNT; jdx++)
+        time_auto_regexes[jdx] = cregex_make(time_auto_patterns[jdx].pattern, CREG_DEFAULT);
+    atomic_store_explicit(&time_auto_regexes_compiled, true, memory_order_release);
+}
+
+
+ASDF_DESTRUCTOR static void drop_time_auto_regexes(void) {
+    if (atomic_load_explicit(&time_auto_regexes_compiled, memory_order_acquire)) {
+        for (size_t jdx = 0; jdx < TIME_AUTO_COUNT; jdx++) {
+            if (time_auto_regexes[jdx].prog)
+                cregex_drop(&time_auto_regexes[jdx]);
+        }
+        atomic_store_explicit(&time_auto_regexes_compiled, false, memory_order_release);
+    }
+}
 
 #ifdef HAVE_STRPTIME
 static const char *ASDF_TIME_SFMT_ISO_TIME[] = {"%Y-%m-%d %H:%M:%S", "%Y-%m-%d"};
@@ -225,6 +305,8 @@ static int asdf_time_parse_mjd(const char *s, struct asdf_time_info_t *out) {
 
 
 int asdf_time_parse_byear(const char *s, struct asdf_time_info_t *out) {
+    if (s && (*s == 'B' || *s == 'b'))
+        s++; /* strip optional B prefix from bare-scalar Besselian epoch notation */
     const double byear = strtod(s, NULL);
     const double jd = besselian_to_julian(byear);
     struct tm tm;
@@ -333,6 +415,127 @@ static const char *const asdf_time_scale_names[] = {
 };
 
 
+/* Helpers for format detection and range validation */
+
+static bool format_name_to_type(const char *name, asdf_time_base_format_t *out) {
+    for (size_t idx = 0; idx < sizeof(asdf_time_format_names) / sizeof(asdf_time_format_names[0]);
+         idx++) {
+        if (asdf_time_format_names[idx] && !strcmp(name, asdf_time_format_names[idx])) {
+            *out = (asdf_time_base_format_t)idx;
+            return true;
+        }
+    }
+    return false;
+}
+
+
+/* Return the auto-detect pattern index whose type matches, or -1 if none. */
+static int find_auto_pattern_idx(asdf_time_base_format_t type) {
+    for (size_t idx = 0; idx < TIME_AUTO_COUNT; idx++) {
+        if (time_auto_patterns[idx].type == type)
+            return (int)idx;
+    }
+    return -1;
+}
+
+
+/* Actually should be 10 but use 16 to be word-aligned */
+#define MAX_INT_DIGITS 16
+
+
+/* Extract an integer from a non-null-terminated csview. */
+static inline int csview_to_int(csview csv) {
+    char buf[MAX_INT_DIGITS];
+    size_t n = csv.size < (int)sizeof(buf) - 1 ? csv.size : (int)sizeof(buf) - 1;
+    memcpy(buf, csv.buf, n);
+    buf[n] = '\0';
+    // Should be able to get away with atoi here since already checked by
+    // the regexps
+    return atoi(buf);
+}
+
+
+static void validate_iso_time_ranges(asdf_file_t *file, const char *cvs, csview *mat) {
+    /* m[2]=month, m[3]=day, m[5]=hour, m[6]=minute, m[7]=second */
+    if (mat[2].buf) {
+        int mon = csview_to_int(mat[2]);
+        if (mon < 1 || mon > 12)
+            ASDF_LOG(
+                file,
+                ASDF_LOG_WARN,
+                "iso_time value '%s': month %d out of range [01,12]",
+                cvs,
+                mon);
+    }
+
+    if (mat[3].buf) {
+        // TODO: More calendar logic?
+        int day = csview_to_int(mat[3]);
+        if (day < 1 || day > 31)
+            ASDF_LOG(
+                file, ASDF_LOG_WARN, "iso_time value '%s': day %d out of range [01,31]", cvs, day);
+    }
+
+    if (mat[5].buf && csview_to_int(mat[5]) > 23)
+        ASDF_LOG(file, ASDF_LOG_WARN, "iso_time value '%s': hour out of range [00,23]", cvs);
+
+    if (mat[6].buf && csview_to_int(mat[6]) > 59)
+        ASDF_LOG(file, ASDF_LOG_WARN, "iso_time value '%s': minute out of range [00,59]", cvs);
+
+    if (mat[7].buf && csview_to_int(mat[7]) > 60)
+        ASDF_LOG(file, ASDF_LOG_WARN, "iso_time value '%s': second out of range [00,60]", cvs);
+}
+
+
+static inline bool is_leap_year(int year) {
+    return year % 4 == 0 && ((year % 100 != 0) || (year % 400 == 0));
+}
+
+
+static void validate_yday_ranges(asdf_file_t *file, const char *cvs, csview *mat) {
+    /* m[1]=year, m[2]=day-of-year, m[3]=hour, m[4]=minute, m[5]=second */
+    int year = 0;
+
+    if (mat[1].buf)
+        year = csview_to_int(mat[1]);
+
+    if (mat[2].buf) {
+        int yday = csview_to_int(mat[2]);
+        if (yday < 1 || (is_leap_year(year) ? yday > 366 : yday > 365))
+            ASDF_LOG(
+                file,
+                ASDF_LOG_WARN,
+                "yday value '%s': day-of-year %d out of range [001,366]",
+                cvs,
+                yday);
+    }
+
+    if (mat[3].buf && csview_to_int(mat[3]) > 23)
+        ASDF_LOG(file, ASDF_LOG_WARN, "yday value '%s': hour out of range [00,23]", cvs);
+
+    if (mat[4].buf && csview_to_int(mat[4]) > 59)
+        ASDF_LOG(file, ASDF_LOG_WARN, "yday value '%s': minute out of range [00,59]", cvs);
+
+    if (mat[5].buf && csview_to_int(mat[5]) > 60)
+        ASDF_LOG(file, ASDF_LOG_WARN, "yday value '%s': second out of range [00,60]", cvs);
+}
+
+
+/* Run capture-group range checks for patterns that support them. */
+static void validate_datetime_ranges(asdf_file_t *file, int pat_idx, const char *vs, csview *m) {
+    switch (pat_idx) {
+    case TIME_AUTO_IDX_ISO_TIME:
+        validate_iso_time_ranges(file, vs, m);
+        break;
+    case TIME_AUTO_IDX_YDAY:
+        validate_yday_ranges(file, vs, m);
+        break;
+    default:
+        break;
+    }
+}
+
+
 static asdf_value_t *asdf_time_serialize(
     asdf_file_t *file, const void *obj, UNUSED(const void *userdata)) {
 
@@ -416,8 +619,63 @@ cleanup:
 }
 
 
+static asdf_time_base_format_t validate_or_guess_time_base_format(
+    asdf_value_t *value, const char *time_s, const char *format_s) {
+
+    asdf_time_base_format_t format = -1;
+    compile_time_auto_regexes();
+
+    if (!format_s) {
+        /* No explicit format: auto-detect from the value string. */
+        for (size_t idx = 0; idx < TIME_AUTO_COUNT; idx++) {
+            if (UNLIKELY(time_auto_regexes[idx].error != CREG_OK))
+                continue;
+            csview match[CREG_MAX_CAPTURES] = {0};
+            if (cregex_match(&time_auto_regexes[idx], time_s, match) != CREG_OK)
+                continue;
+            validate_datetime_ranges(value->file, (int)idx, time_s, match);
+            format = time_auto_patterns[idx].type;
+            break;
+        }
+
+        if (format < 0)
+            ASDF_LOG(
+                value->file,
+                ASDF_LOG_WARN,
+                "could not guess format of time without explicit format '%s'",
+                time_s);
+
+        return format;
+    }
+
+    /* Explicit format: look up the type by name directly. */
+    if (!format_name_to_type(format_s, &format))
+        ASDF_LOG(value->file, ASDF_LOG_WARN, "unrecognized time format '%s'", format_s);
+
+    /* Validate the value string against the format's auto-detect pattern,
+     * if one exists.  This is informational only -- a mismatch is a
+     * warning, not an error. */
+    int pat_idx = find_auto_pattern_idx(format);
+    if (pat_idx >= 0 && time_auto_regexes[pat_idx].error == CREG_OK) {
+        csview match[CREG_MAX_CAPTURES] = {0};
+        if (cregex_match(&time_auto_regexes[pat_idx], time_s, match) != CREG_OK)
+            ASDF_LOG(
+                value->file,
+                ASDF_LOG_WARN,
+                "time value '%s' does not match expected format '%s'",
+                time_s,
+                format_s);
+        else
+            validate_datetime_ranges(value->file, pat_idx, time_s, match);
+    }
+
+    return format;
+}
+
+
 static asdf_value_err_t asdf_time_deserialize(
     asdf_value_t *value, UNUSED(const void *userdata), void **out) {
+
     const char *value_s = NULL;
     const char *format_s = NULL;
 
@@ -426,9 +684,9 @@ static asdf_value_err_t asdf_time_deserialize(
     asdf_value_err_t err = ASDF_VALUE_ERR_PARSE_FAILURE;
 
     asdf_time_t *time = calloc(1, sizeof(asdf_time_t));
-    if (!time) {
+
+    if (!time)
         return ASDF_VALUE_ERR_OOM;
-    }
 
     if (asdf_value_is_mapping(value)) {
         if (asdf_value_as_mapping(value, &mapping) != ASDF_VALUE_OK)
@@ -441,6 +699,7 @@ static asdf_value_err_t asdf_time_deserialize(
     }
 
     time->value = calloc(ASDF_TIME_TIMESTR_MAXLEN, sizeof(*time->value));
+
     if (!time->value) {
         if (prop && prop != value)
             asdf_value_destroy(prop);
@@ -449,6 +708,7 @@ static asdf_value_err_t asdf_time_deserialize(
     }
 
     const asdf_value_type_t type = asdf_value_get_type(prop);
+
     switch (type) {
     case ASDF_VALUE_INT64: {
         time_t value_tmp = 0;
@@ -480,74 +740,27 @@ static asdf_value_err_t asdf_time_deserialize(
     }
 
     if (mapping) {
+        /* format key is optional in a time mapping */
         prop = asdf_mapping_get(mapping, "format");
-        if (ASDF_VALUE_OK != asdf_value_as_string0(prop, &format_s)) {
-            goto failure;
+        if (prop) {
+            if (ASDF_VALUE_OK != asdf_value_as_string0(prop, &format_s))
+                goto failure;
+            asdf_value_destroy(prop);
+            prop = NULL;
         }
-        asdf_value_destroy(prop);
-        prop = NULL;
     }
 
-    const char *time_auto_keys[] = {
-        "iso_time",
-        "byear",
-        "jyear",
-        "yday",
-    };
+    asdf_time_base_format_t format = validate_or_guess_time_base_format(
+        value, time->value, format_s);
 
-    const char *time_auto_patterns[] = {
-        /* iso_time */
-        "[0-9]{4}-(0[1-9])|(1[0-2])-(0[1-9])|([1-2][0-9])|(3[0-1])"
-        "[T ]([0-1][0-9])|(2[0-4]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?",
-        /* byear */
-        "B[0-9]+(.[0-9]+)?",
-        /* jyear */
-        "J[0-9]+(.[0-9]+)?",
-        /* yday */
-        /** FIXME: This regexp actually fails to compile due to surpassing the
-         * built-in character class limit; need to find workaround to this */
-        "[0-9]{4}:(00[1-9])|(0[1-9][0-9])|([1-2][0-9][0-9])|(3[0-5][0-9])|(36[0-5]):([0-1][0-9])|"
-        "([0-1][0-9])|(2[0-4]):[0-5][0-9]:[0-5][0-9](.[0-9]+)?"};
-
-    time->format.is_base_format = true;
-    for (size_t idx = 0; idx < sizeof(time_auto_patterns) / sizeof(time_auto_patterns[0]); idx++) {
-        cregex re = cregex_make(time_auto_patterns[idx], CREG_DEFAULT);
-
-        if (UNLIKELY(re.error == CREG_OUTOFMEMORY)) {
-            err = ASDF_VALUE_ERR_OOM;
-            goto failure;
-        } else if (UNLIKELY(re.error != CREG_OK)) {
-            err = ASDF_VALUE_ERR_PARSE_FAILURE;
-            goto failure;
-        }
-
-        if (cregex_is_match(&re, time->value) == true) {
-            const char *fmt_have = format_s ? format_s : time_auto_keys[idx];
-            if (!strcmp(fmt_have, "iso_time")) {
-                time->format.type = ASDF_TIME_FORMAT_ISO_TIME;
-            } else if (!strcmp(fmt_have, "byear") || !strncmp(time->value, "B", 1)) {
-                time->format.type = ASDF_TIME_FORMAT_BYEAR;
-            } else if (!strcmp(fmt_have, "jd")) {
-                time->format.type = ASDF_TIME_FORMAT_JD;
-            } else if (!strcmp(fmt_have, "mjd")) {
-                time->format.type = ASDF_TIME_FORMAT_MJD;
-            } else if (!strcmp(fmt_have, "jyear") || !strncmp(time->value, "J", 1)) {
-                time->format.type = ASDF_TIME_FORMAT_JYEAR;
-            } else if (!strcmp(fmt_have, "yday")) {
-                time->format.type = ASDF_TIME_FORMAT_YDAY;
-            } else if (!strcmp(fmt_have, "unix")) {
-                time->format.type = ASDF_TIME_FORMAT_UNIX;
-            }
-            time->scale = ASDF_TIME_SCALE_UTC;
-            cregex_drop(&re);
-            break;
-        }
-        cregex_drop(&re);
+    if (format < 0) {
+        err = ASDF_VALUE_ERR_PARSE_FAILURE;
+        goto failure;
     }
 
-    if (time->format.type > ASDF_TIME_FORMAT_RESERVED1) {
-        time->format.is_base_format = false;
-    }
+    time->format.type = format;
+    time->format.is_base_format = (time->format.type <= ASDF_TIME_FORMAT_RESERVED1);
+    time->scale = ASDF_TIME_SCALE_UTC;
 
     asdf_time_parse_time(time->value, &time->format, &time->info);
 
@@ -566,23 +779,23 @@ static void *asdf_time_copy(const void *obj) {
     if (!obj)
         return NULL;
 
-    const asdf_time_t *t = obj;
+    const asdf_time_t *tm = obj;
     asdf_time_t *copy = calloc(1, sizeof(asdf_time_t));
 
     if (!copy)
         return NULL;
 
-    *copy = *t;
-    copy->value = t->value ? strdup(t->value) : NULL;
+    *copy = *tm;
+    copy->value = tm->value ? strdup(tm->value) : NULL;
 
     return copy;
 }
 
 
 static void asdf_time_dealloc(void *value) {
-    asdf_time_t *t = (asdf_time_t *)value;
-    free(t->value);
-    free(t);
+    asdf_time_t *tm = (asdf_time_t *)value;
+    free(tm->value);
+    free(tm);
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -333,6 +333,7 @@ EXTRA_DIST += \
     fixtures/events/complex.events.txt \
     fixtures/events/compressed.events.txt \
     fixtures/events/int.events.txt \
+    fixtures/extension-metadata-with-package.asdf \
     fixtures/info/anchor.info.txt \
     fixtures/info/ascii.info.txt \
     fixtures/info/basic.info.txt \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,7 +66,7 @@ unit_test_cflags += -DMUNIT_NO_FORK
 unit_test_ldflags += -rdynamic
 endif
 
-unit_test_ldflags = $(LDFLAGS) $(CODE_COVERAGE_LDFLAGS)
+unit_test_ldflags += $(LDFLAGS) $(CODE_COVERAGE_LDFLAGS)
 unit_test_ldadd = $(munit_ldflags) $(top_builddir)/libasdf.la $(ASDF_LIBS)
 
 # Unit tests
@@ -149,37 +149,19 @@ test_parse_util_unit_LDADD = libmunit.a $(FYAML_LIBS) $(STATGRAB_LIBS) $(MD5_LIB
 
 if HAVE_LINKER_WRAP
 # test-malloc-fail.unit
-# NOTE: This test is a bit of a pain to compile since for --wrap to work
-# we can't rely on dynamic linking to libasdf, and have to compile all the
-# necessary translation units directly into the test, similar to
-# test-parse-util.c; for now it's not too many though.
-#
-# An alternative approach could also be to use a static libasdf if we
-# configured to build one, and only build this test in that case; or always
-# build a static lib if running `make check`...
+# Links against libasdf_static.la, a static convenience archive of the full
+# library built at the top level under HAVE_LINKER_WRAP.  Linking against a
+# static archive (rather than the shared libasdf) lets the --wrap flags
+# intercept malloc/calloc/strdup/strndup calls anywhere in the library, not
+# just in a hand-maintained subset of translation units.
 check_PROGRAMS += test-malloc-fail.unit
-test_malloc_fail_unit_SOURCES = \
-    test-malloc-fail.c \
-    $(top_srcdir)/src/block.c \
-    $(top_srcdir)/src/compression/compressor_registry.c \
-    $(top_srcdir)/src/context.c \
-    $(top_srcdir)/src/tag.c \
-    $(top_srcdir)/src/error.c \
-    $(top_srcdir)/src/event.c \
-    $(top_srcdir)/src/log.c \
-    $(top_srcdir)/src/parse_util.c \
-    $(top_srcdir)/src/parser.c \
-    $(top_srcdir)/src/stream.c \
-    $(top_srcdir)/src/util.c \
-    $(top_srcdir)/src/version.c \
-    $(top_srcdir)/src/yaml.c \
-    $(top_srcdir)/third_party/STC/src/cstr_core.c
+test_malloc_fail_unit_SOURCES = test-malloc-fail.c
 test_malloc_fail_unit_CPPFLAGS = $(unit_test_cppflags)
 test_malloc_fail_unit_CFLAGS = $(unit_test_cflags)
 test_malloc_fail_unit_LDFLAGS = \
     $(unit_test_ldflags) \
     -Wl,--wrap=malloc,--wrap=calloc,--wrap=strdup,--wrap=strndup
-test_malloc_fail_unit_LDADD = libmunit.a $(FYAML_LIBS) $(STATGRAB_LIBS) $(MD5_LIBS) $(ASDF_LIBS)
+test_malloc_fail_unit_LDADD = libmunit.a $(top_builddir)/libasdf_static.la
 endif
 
 # test-stream.unit

--- a/tests/fixtures/extension-metadata-with-package.asdf
+++ b/tests/fixtures/extension-metadata-with-package.asdf
@@ -1,0 +1,13 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.6.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+  name: asdf, version: 1.0.0}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.testing.MockExtension
+    package: !core/software-1.0.0 {name: mock-package, version: 1.0.0}
+...

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -19,4 +19,9 @@ t_jd: !time/time-1.4.0 {format: jd, value: '2460963.060197'}
 t_mjd: !time/time-1.4.0 {format: mjd, value: '60962.560196'}
 t_unix: !time/time-1.4.0 {format: unix, value: '1760462801.00'}
 t_yday: !time/time-1.4.0 {format: yday, value: '2025:287:13:26:41.0000'}
+t_byear_bare: !time/time-1.4.0 'B2025.78707178'
+t_iso_time_bare: !time/time-1.4.0 '2025-10-14T13:26:41.0000'
+t_jyear_bare: !time/time-1.4.0 'J2025.78707178'
+t_yday_bare: !time/time-1.4.0 '2025:287:13:26:41.0000'
+t_yday_map_no_format: !time/time-1.4.0 {value: '2025:287:13:26:41.0000'}
 ...

--- a/tests/test-malloc-fail.c
+++ b/tests/test-malloc-fail.c
@@ -22,6 +22,7 @@
 #include "util.h"
 
 #include "asdf/core/extension_metadata.h"
+#include "asdf/core/time.h"
 
 #include "event.h"
 #include "file.h"
@@ -313,6 +314,48 @@ MU_TEST(oom_extension_metadata_deserialize) {
 }
 
 
+/**
+ * ``asdf_time_deserialize`` -- ``asdf_value_destroy(prop)`` missing on
+ * ``calloc(time->value)`` failure when the input is a mapping.
+ *
+ * Same sweep strategy: iterate OOM injection points with a fresh file+value
+ * each time.  Uses a time value that is a flow mapping (``{format: ...,
+ * value: ...}``) so that ``asdf_mapping_get(mapping, "value")`` allocates
+ * ``prop`` before the ``time->value`` calloc is attempted.  Without the fix
+ * that iteration leaks ``prop``; LSAN catches it.
+ */
+MU_TEST(oom_time_deserialize) {
+    for (int idx = 0; idx < 200; idx++) {
+        const char *path = get_fixture_file_path("time.asdf");
+        asdf_file_t *file = asdf_open(path, "r");
+        if (!file)
+            munit_error("failed to open fixture");
+        /* t_byear is a flow mapping: {format: byear, value: '...'} */
+        asdf_value_t *value = asdf_get_value(file, "t_byear");
+        if (!value) {
+            asdf_close(file);
+            munit_error("failed to get value at t_byear");
+        }
+
+        asdf_time_t *out = NULL;
+        malloc_fail_after(idx);
+        asdf_value_err_t err = asdf_value_as_time(value, &out);
+        malloc_fail_reset();
+
+        if (err == ASDF_VALUE_OK) {
+            asdf_time_destroy(out);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            break;
+        }
+
+        asdf_value_destroy(value);
+        asdf_close(file);
+    }
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     malloc_fail,
     MU_RUN_TEST(oom_parse_asdf_version),
@@ -322,7 +365,8 @@ MU_TEST_SUITE(
     MU_RUN_TEST(oom_tag_parse_name_only),
     MU_RUN_TEST(oom_tag_parse_name_strndup),
     MU_RUN_TEST(oom_tag_parse_version_strdup),
-    MU_RUN_TEST(oom_extension_metadata_deserialize)
+    MU_RUN_TEST(oom_extension_metadata_deserialize),
+    MU_RUN_TEST(oom_time_deserialize)
 );
 
 

--- a/tests/test-malloc-fail.c
+++ b/tests/test-malloc-fail.c
@@ -21,9 +21,13 @@
 #include "munit.h"
 #include "util.h"
 
+#include "asdf/core/extension_metadata.h"
+
 #include "event.h"
+#include "file.h"
 #include "parser.h"
 #include "tag.h"
+#include "value.h"
 
 
 /** malloc injection */
@@ -266,6 +270,49 @@ MU_TEST(oom_tag_parse_version_strdup) {
 }
 
 
+/**
+ * ``asdf_extension_metadata_deserialize`` -- ``asdf_software_destroy(package)``
+ * missing on ``calloc(metadata)`` failure.
+ *
+ * Iterates all OOM injection points through the full deserialization path.
+ * Each iteration opens a fresh file and value to avoid extension-type caching.
+ * The fixture has a ``package`` field so that ``asdf_value_as_software``
+ * allocates the package before the metadata struct calloc is attempted.
+ * Without the fix, the iteration that fails exactly at ``calloc(metadata)``
+ * while ``package != NULL`` leaks the package; LSAN catches it at subprocess
+ * exit.
+ */
+MU_TEST(oom_extension_metadata_deserialize) {
+    for (int idx = 0; idx < 200; idx++) {
+        const char *path = get_fixture_file_path("extension-metadata-with-package.asdf");
+        asdf_file_t *file = asdf_open(path, "r");
+        if (!file)
+            munit_error("failed to open fixture");
+        asdf_value_t *value = asdf_get_value(file, "history/extensions/0");
+        if (!value) {
+            asdf_close(file);
+            munit_error("failed to get value at history/extensions/0");
+        }
+
+        asdf_extension_metadata_t *out = NULL;
+        malloc_fail_after(idx);
+        asdf_value_err_t err = asdf_value_as_extension_metadata(value, &out);
+        malloc_fail_reset();
+
+        if (err == ASDF_VALUE_OK) {
+            asdf_extension_metadata_destroy(out);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            break;
+        }
+
+        asdf_value_destroy(value);
+        asdf_close(file);
+    }
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     malloc_fail,
     MU_RUN_TEST(oom_parse_asdf_version),
@@ -274,7 +321,8 @@ MU_TEST_SUITE(
     MU_RUN_TEST(oom_emit_tree_start),
     MU_RUN_TEST(oom_tag_parse_name_only),
     MU_RUN_TEST(oom_tag_parse_name_strndup),
-    MU_RUN_TEST(oom_tag_parse_version_strdup)
+    MU_RUN_TEST(oom_tag_parse_version_strdup),
+    MU_RUN_TEST(oom_extension_metadata_deserialize)
 );
 
 

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -32,7 +32,8 @@ MU_TEST(test_asdf_time) {
         "t_byear",
     };
 
-    asdf_time_t *t = NULL;
+    asdf_time_t *tm = NULL;
+
     for (size_t idx = 0; idx < sizeof(fixture_keys) / sizeof(fixture_keys[0]); idx++) {
         const char *key = fixture_keys[idx];
         assert_true(asdf_is_time(file, key));
@@ -40,24 +41,24 @@ MU_TEST(test_asdf_time) {
         value = asdf_get_value(file, key);
         assert_not_null(value);
 
-        asdf_value_err_t err = asdf_value_as_time(value, &t);
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
         if (err != ASDF_VALUE_OK) {
             munit_logf(MUNIT_LOG_ERROR, "asdf_value_as_time failed: %s\n", key);
-            asdf_time_destroy(t);
+            asdf_time_destroy(tm);
             asdf_value_destroy(value);
             asdf_close(file);
             return MUNIT_FAIL;
         }
 
-        assert_not_null(t);
-        assert_not_null(t->value);
+        assert_not_null(tm);
+        assert_not_null(tm->value);
 
-        time_t x = t->info.ts.tv_sec;
-        strftime(time_str, sizeof(time_str), "%m/%d/%Y %T %Z", gmtime(&x));
-        printf("[%zu] key: %10s, value: %30s,  time: %10s\n", idx, key, t->value, time_str);
+        time_t tmt = tm->info.ts.tv_sec;
+        strftime(time_str, sizeof(time_str), "%m/%d/%Y %T %Z", gmtime(&tmt));
+        printf("[%zu] key: %10s, value: %30s,  time: %10s\n", idx, key, tm->value, time_str);
 
-        asdf_time_destroy(t);
-        t = NULL;
+        asdf_time_destroy(tm);
+        tm = NULL;
         memset(time_str, 0, sizeof(time_str));
         asdf_value_destroy(value);
         value = NULL;
@@ -111,10 +112,140 @@ MU_TEST(test_asdf_time_serialize) {
 }
 
 
+/**
+ * Check that bare scalar time values (no explicit ``format`` key) have their
+ * format auto-detected correctly, and that the parsed time info is sensible.
+ * Also checks a mapping that has ``value`` but no ``format`` key.
+ *
+ * This test is expected to fail before the format-detection fixes are applied.
+ */
+MU_TEST(test_asdf_time_format_detection) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const struct {
+        const char *key;
+        asdf_time_base_format_t expected_format;
+        const char *expected_value;
+        bool check_ts;
+    } cases[] = {
+        /* bare scalars: format must be inferred from value string */
+        {"t_iso_time_bare", ASDF_TIME_FORMAT_ISO_TIME,  "2025-10-14T13:26:41.0000", true},
+        {"t_byear_bare",    ASDF_TIME_FORMAT_BYEAR,     "B2025.78707178",           true},
+        {"t_jyear_bare",    ASDF_TIME_FORMAT_JYEAR,     "J2025.78707178",           false},
+        {"t_yday_bare",     ASDF_TIME_FORMAT_YDAY ,     "2025:287:13:26:41.0000",   true},
+        /* mapping without explicit format key */
+        {"t_yday_map_no_format", ASDF_TIME_FORMAT_YDAY, "2025:287:13:26:41.0000",   true}
+    };
+
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        const char *key = cases[idx].key;
+
+        asdf_value_t *value = asdf_get_value(file, key);
+
+        if (!value) {
+            munit_logf(MUNIT_LOG_ERROR, "failed to get value at '%s'", key);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+
+        if (err != ASDF_VALUE_OK) {
+            munit_logf(MUNIT_LOG_ERROR, "asdf_value_as_time failed for '%s'", key);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        assert_not_null(tm);
+        assert_not_null(tm->value);
+        assert_string_equal(tm->value, cases[idx].expected_value);
+        assert_int(tm->format.type, ==, cases[idx].expected_format);
+
+        if (cases[idx].check_ts)
+            assert_true(tm->info.ts.tv_sec > 0);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Check that time values with an explicit ``format`` key produce the correct
+ * ``format.type`` enum value after deserialization.
+ *
+ * This test is expected to fail before the explicit-format lookup fix is
+ * applied (the old code only set ``format.type`` when a regex pattern matched
+ * the value string, so formats like ``byear`` whose values lack a ``B`` prefix
+ * were silently mis-classified).
+ */
+MU_TEST(test_asdf_time_explicit_format_types) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const struct {
+        const char *key;
+        asdf_time_base_format_t expected_format;
+    } cases[] = {
+        {"t_iso_time", ASDF_TIME_FORMAT_ISO_TIME},
+        {"t_datetime", ASDF_TIME_FORMAT_DATETIME},
+        {"t_yday",     ASDF_TIME_FORMAT_YDAY},
+        {"t_byear",    ASDF_TIME_FORMAT_BYEAR},
+        {"t_unix",     ASDF_TIME_FORMAT_UNIX},
+        {"t_jd",       ASDF_TIME_FORMAT_JD},
+        {"t_mjd",      ASDF_TIME_FORMAT_MJD},
+    };
+
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        const char *key = cases[idx].key;
+
+        asdf_value_t *value = asdf_get_value(file, key);
+        if (!value) {
+            munit_logf(MUNIT_LOG_ERROR, "failed to get value at '%s'", key);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+
+        if (err != ASDF_VALUE_OK) {
+            munit_logf(MUNIT_LOG_ERROR, "asdf_value_as_time failed for '%s'", key);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        assert_not_null(tm);
+        assert_int(tm->format.type, ==, cases[idx].expected_format);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     test_asdf_time_extension,
     MU_RUN_TEST(test_asdf_time),
-    MU_RUN_TEST(test_asdf_time_serialize)
+    MU_RUN_TEST(test_asdf_time_serialize),
+    MU_RUN_TEST(test_asdf_time_format_detection),
+    MU_RUN_TEST(test_asdf_time_explicit_format_types)
 );
 
 


### PR DESCRIPTION
Started out as trying to search out any other untested memory leaks in the same class of error as #184.  Found one such leak in the time parsing, but writing a test for it revealed more problems with the time parsing that weren't previously caught by the tests.  This ended up being a rabbit hole of improving the test coverage and support for `!core/time` scalars.