### PR TITLE
Array storage settings

### DIFF
--- a/changes/62.feature
+++ b/changes/62.feature
@@ -1,1 +1,1 @@
-Support for inline ndarray data: inline data is parsed when reading the ndarray data (e.g. with `asdf_ndarray_data_raw`) and can also be set to be written inline with `asdf_ndarray_inline_set(ndarray, true)`.
+Support for inline ndarray data: inline data is parsed when reading the ndarray data (e.g. with `asdf_ndarray_data_raw`) and can also be set to be written inline with `asdf_ndarray_storage_set(ndarray, ASDF_ARRAY_STORAGE_INLINE)`.

--- a/docs/api/asdf/emitter.h.rst
+++ b/docs/api/asdf/emitter.h.rst
@@ -1,0 +1,5 @@
+asdf/emitter.h
+================
+
+.. autodoc:: include/asdf/emitter.h
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,15 +42,17 @@ including ``asdf.h``.  This in turn includes the following headers:
 Additional less commonly used APIs can be used by including the relevant
 headers.
 
-.. todo::
-
-   Document lower-level APIs.
-
 .. toctree::
   :maxdepth: 2
 
+  api/asdf/emitter.h
   api/asdf/extension.h
   api/asdf/yaml.h
+
+
+.. todo::
+
+   Document lower-level APIs.
 
 
 Resources

--- a/include/asdf/core/ndarray.h
+++ b/include/asdf/core/ndarray.h
@@ -43,11 +43,11 @@
 #ifndef ASDF_CORE_NDARRAY_H
 #define ASDF_CORE_NDARRAY_H
 
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <asdf/core/datatype.h>
+#include <asdf/emitter.h>
 #include <asdf/extension.h>
 #include <asdf/util.h>
 
@@ -243,31 +243,37 @@ ASDF_EXPORT int asdf_ndarray_compression_set(asdf_ndarray_t *ndarray, const char
 
 
 /**
- * Test if the ndarray is serialized inline
+ * Return the storage mode that will be used when the ndarray is written.
  *
- * If the ndarray was read from a file this will indicate whether or not it
- * was serialized inline originally, otherwise indicates if it has been
- * explicitly set inline with `asdf_ndarray_inline_set`
+ * If the ndarray was read from a file this reflects how it was originally
+ * stored.  For a newly constructed ndarray this reflects whatever was last
+ * passed to `asdf_ndarray_storage_set`, or ``ASDF_ARRAY_STORAGE_INTERNAL``
+ * if the storage was never explicitly set.
  *
  * :param ndarray: An `asdf_ndarray_t *`
- * :return: True if the ndarray was or will be serialized inline
+ * :return: The `asdf_array_storage_t` for this ndarray.
  */
-ASDF_EXPORT bool asdf_ndarray_inline(asdf_ndarray_t *ndarray);
+ASDF_EXPORT asdf_array_storage_t asdf_ndarray_storage(asdf_ndarray_t *ndarray);
 
 
 /**
- * Mark the ndarray for inline YAML storage when written
+ * Set the storage mode used when the ndarray is written.
  *
- * When set to ``true``, the ndarray's data will be serialized as a nested
- * YAML sequence under the ``data`` key rather than in a binary block.  A
- * warning is logged if the number of elements exceeds the configured
- * threshold (see ``asdf_emitter_cfg_t.inline_ndarray_warning_thresh``).
+ * ``ASDF_ARRAY_STORAGE_INLINE`` serializes the data as a nested YAML
+ * sequence under the ``data`` key.  A warning is logged if the number of
+ * elements exceeds the configured threshold (see
+ * ``asdf_emitter_cfg_t.inline_ndarray_warning_thresh``).
+ *
+ * ``ASDF_ARRAY_STORAGE_INTERNAL`` writes the data in a binary block (the
+ * default when no storage mode is set).
+ *
+ * ``ASDF_ARRAY_STORAGE_EXTERNAL`` is not yet supported; calling this function
+ * with that value logs an error and leaves the storage mode unchanged.
  *
  * :param ndarray: An `asdf_ndarray_t *`
- * :param is_inline: Pass ``true`` to enable inline writing, ``false`` to
- *   revert to binary block storage
+ * :param storage: The desired `asdf_array_storage_t`
  */
-ASDF_EXPORT void asdf_ndarray_inline_set(asdf_ndarray_t *ndarray, bool is_inline);
+ASDF_EXPORT void asdf_ndarray_storage_set(asdf_ndarray_t *ndarray, asdf_array_storage_t storage);
 
 
 /**

--- a/include/asdf/emitter.h
+++ b/include/asdf/emitter.h
@@ -39,6 +39,24 @@ typedef uint64_t asdf_emitter_optflags_t;
 
 
 /**
+ * Controls where an ndarray's data is stored when written.
+ *
+ * Used both as a per-array setting (see `asdf_ndarray_storage_set`) and as a
+ * file-level override in `asdf_emitter_cfg_t`.
+ */
+typedef enum {
+    /** Use the file-level ``array_storage`` emitter setting (default). */
+    ASDF_ARRAY_STORAGE_DEFAULT = 0,
+    /** Store the array as inline YAML data under the ``data`` key. */
+    ASDF_ARRAY_STORAGE_INLINE = 1,
+    /** Store the array in an internal binary block. */
+    ASDF_ARRAY_STORAGE_INTERNAL = 2,
+    /** Store the array in an external file (reserved; not yet supported). */
+    ASDF_ARRAY_STORAGE_EXTERNAL = 3,
+} asdf_array_storage_t;
+
+
+/**
  * Low-level emitter configuration
  *
  * Currently just consists of a bitset of flags that are used internally by
@@ -53,6 +71,12 @@ typedef struct asdf_emitter_cfg {
      * Set to SIZE_MAX to suppress the warning entirely.
      */
     size_t inline_ndarray_warning_thresh;
+    /**
+     * Override where all ndarray data is written; see `asdf_array_storage_t`.
+     * Defaults to ``ASDF_ARRAY_STORAGE_DEFAULT`` (0), which respects the
+     * per-array storage mode set via `asdf_ndarray_storage_set`.
+     */
+    asdf_array_storage_t array_storage;
 } asdf_emitter_cfg_t;
 
 ASDF_END_DECLS

--- a/include/asdf/util.h
+++ b/include/asdf/util.h
@@ -2,22 +2,22 @@
 #define ASDF_UTIL_H
 
 #if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 4)
-    #define ASDF_EXPORT __attribute__ ((visibility ("default")))
-    #define ASDF_LOCAL __attribute__ ((visibility ("hidden")))
+#define ASDF_EXPORT __attribute__((visibility("default")))
+#define ASDF_LOCAL __attribute__((visibility("hidden")))
 #else
-    #define ASDF_EXPORT
-    #define ASDF_LOCAL
+#define ASDF_EXPORT
+#define ASDF_LOCAL
 #endif
 
 
 #ifdef __cplusplus
-    #define ASDF_BEGIN_DECLS extern "C" {
-    #define ASDF_END_DECLS   }
-    #define ASDF_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
+#define ASDF_BEGIN_DECLS extern "C" {
+#define ASDF_END_DECLS }
+#define ASDF_STATIC_ASSERT(cond, msg) static_assert(cond, msg)
 #else
-    #define ASDF_BEGIN_DECLS
-    #define ASDF_END_DECLS
-    #define ASDF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
+#define ASDF_BEGIN_DECLS
+#define ASDF_END_DECLS
+#define ASDF_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
 
 
@@ -26,4 +26,4 @@
 #define ASDF_DESTRUCTOR __attribute__((destructor))
 
 
-#endif  /* ASDF_UTIL_H */
+#endif /* ASDF_UTIL_H */

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -620,9 +620,8 @@ static asdf_value_err_t asdf_ndarray_deserialize_inline(
         goto cleanup;
     }
 
-    /* Set the write_inline flag implicitly so the same ndarray is
-     * re-serialized inline unless otherwise specified later */
-    ndarray->internal->write_inline = true;
+    /* Mark as inline so the same ndarray re-serializes inline by default */
+    ndarray->internal->array_storage = ASDF_ARRAY_STORAGE_INLINE;
 
     *out = ndarray;
     err = ASDF_VALUE_OK;
@@ -743,6 +742,7 @@ static asdf_value_err_t asdf_ndarray_deserialize(
 
     ndarray->source = source;
     internal->file = value->file;
+    internal->array_storage = ASDF_ARRAY_STORAGE_INTERNAL;
     *out = ndarray;
     err = ASDF_VALUE_OK;
 cleanup:
@@ -783,23 +783,30 @@ static void asdf_ndarray_dealloc(void *value) {
 }
 
 
-bool asdf_ndarray_inline(asdf_ndarray_t *ndarray) {
+asdf_array_storage_t asdf_ndarray_storage(asdf_ndarray_t *ndarray) {
     if (UNLIKELY(!ndarray))
-        return false;
+        return ASDF_ARRAY_STORAGE_INTERNAL;
 
     asdf_ndarray_internal_t *internal = asdf_ndarray_internal(ndarray, false);
-    return internal && internal->write_inline;
+    return internal ? internal->array_storage : ASDF_ARRAY_STORAGE_INTERNAL;
 }
 
 
-void asdf_ndarray_inline_set(asdf_ndarray_t *ndarray, bool is_inline) {
+void asdf_ndarray_storage_set(asdf_ndarray_t *ndarray, asdf_array_storage_t storage) {
     if (UNLIKELY(!ndarray))
         return;
 
-    asdf_ndarray_internal_t *internal = asdf_ndarray_internal(ndarray, is_inline);
+    if (storage == ASDF_ARRAY_STORAGE_EXTERNAL) {
+        void *log_ctx = ndarray->internal ? (void *)ndarray->internal->file : NULL;
+        ASDF_LOG(log_ctx, ASDF_LOG_ERROR, "ASDF_ARRAY_STORAGE_EXTERNAL is not yet supported");
+        return;
+    }
+
+    bool create = (storage == ASDF_ARRAY_STORAGE_INLINE);
+    asdf_ndarray_internal_t *internal = asdf_ndarray_internal(ndarray, create);
 
     if (internal)
-        internal->write_inline = is_inline;
+        internal->array_storage = storage;
 }
 
 
@@ -1153,7 +1160,14 @@ static asdf_value_t *asdf_ndarray_serialize(
     }
 
     bool has_data = ndarray->internal && ndarray->internal->data;
-    bool write_inline_flag = ndarray->internal && ndarray->internal->write_inline;
+
+    asdf_array_storage_t per_array = ndarray->internal ? ndarray->internal->array_storage
+                                                       : ASDF_ARRAY_STORAGE_DEFAULT;
+    asdf_array_storage_t file_level = file->config ? file->config->emitter.array_storage
+                                                   : ASDF_ARRAY_STORAGE_DEFAULT;
+    asdf_array_storage_t effective = (file_level != ASDF_ARRAY_STORAGE_DEFAULT) ? file_level
+                                                                                : per_array;
+    bool write_inline_flag = (effective == ASDF_ARRAY_STORAGE_INLINE);
 
     if (!has_data) {
         ASDF_LOG(

--- a/src/core/ndarray.h
+++ b/src/core/ndarray.h
@@ -20,8 +20,8 @@ typedef struct {
     asdf_sequence_t *inline_data;
     /* True iff data was malloc'd during lazy inline parsing (not mmap'd) */
     bool data_is_inline;
-    /* True iff this ndarray should be written as inline YAML data */
-    bool write_inline;
+    /* Storage mode to use when writing this ndarray */
+    asdf_array_storage_t array_storage;
 } asdf_ndarray_internal_t;
 
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -35,6 +35,7 @@ asdf_emitter_t *asdf_emitter_create(asdf_file_t *file, asdf_emitter_cfg_t *confi
     emitter->config = config ? *config : asdf_emitter_cfg_default;
     emitter->state = ASDF_EMITTER_STATE_INITIAL;
     emitter->done = false;
+    file->emitter = emitter;
     return emitter;
 }
 
@@ -751,6 +752,9 @@ asdf_emitter_state_t asdf_emitter_emit(asdf_emitter_t *emitter) {
 void asdf_emitter_destroy(asdf_emitter_t *emitter) {
     if (!emitter)
         return;
+
+    if (emitter->file && emitter->file->emitter == emitter)
+        emitter->file->emitter = NULL;
 
     if (emitter->stream)
         asdf_stream_close(emitter->stream);

--- a/src/file.c
+++ b/src/file.c
@@ -73,6 +73,7 @@ static asdf_config_t *asdf_config_build(asdf_config_t *user_config) {
         ASDF_CONFIG_OVERRIDE(config, user_config, emitter.flags, 0);
         ASDF_CONFIG_OVERRIDE(config, user_config, emitter.tag_handles, NULL);
         ASDF_CONFIG_OVERRIDE(config, user_config, emitter.inline_ndarray_warning_thresh, 0);
+        ASDF_CONFIG_OVERRIDE(config, user_config, emitter.array_storage, 0);
         ASDF_CONFIG_OVERRIDE(config, user_config, decomp.mode, ASDF_BLOCK_DECOMP_MODE_AUTO);
         ASDF_CONFIG_OVERRIDE(config, user_config, decomp.max_memory_bytes, 0);
         ASDF_CONFIG_OVERRIDE(config, user_config, decomp.max_memory_threshold, 0.0);

--- a/tests/test-ndarray.c
+++ b/tests/test-ndarray.c
@@ -623,7 +623,7 @@ MU_TEST(ndarray_write_empty_inline_data) {
     // although not strictly the case it's particlarly needed for use with a
     // parallel data_dealloc or will result in memory leaks;
     (void)asdf_ndarray_data_alloc(&ndarray);
-    asdf_ndarray_inline_set(&ndarray, true);
+    asdf_ndarray_storage_set(&ndarray, ASDF_ARRAY_STORAGE_INLINE);
 
     asdf_file_t *file = asdf_open(NULL);
     assert_not_null(file);
@@ -639,7 +639,7 @@ MU_TEST(ndarray_write_empty_inline_data) {
     assert_int(asdf_get_ndarray(file, "empty", &ndarray_in), ==, ASDF_VALUE_OK);
     assert_not_null(ndarray_in);
     assert_int(ndarray_in->ndim, ==, 0);
-    assert_true(asdf_ndarray_inline(ndarray_in));
+    assert_int(asdf_ndarray_storage(ndarray_in), ==, ASDF_ARRAY_STORAGE_INLINE);
     asdf_ndarray_destroy(ndarray_in);
     asdf_close(file);
     return MUNIT_OK;
@@ -661,7 +661,7 @@ MU_TEST(ndarray_write_inline_data) {
     assert_not_null(impl_data);
     for (int idx = 0; idx < 9; idx++)
         impl_data[idx] = (uint8_t)idx;
-    asdf_ndarray_inline_set(&implicit_nd, true);
+    asdf_ndarray_storage_set(&implicit_nd, ASDF_ARRAY_STORAGE_INLINE);
 
     /* Build float64 3x3 ndarray with values 0.0-8.0 for the "explicit" key */
     asdf_ndarray_t explicit_nd = {
@@ -674,7 +674,7 @@ MU_TEST(ndarray_write_inline_data) {
     assert_not_null(expl_data);
     for (int idx = 0; idx < 9; idx++)
         expl_data[idx] = (double)idx;
-    asdf_ndarray_inline_set(&explicit_nd, true);
+    asdf_ndarray_storage_set(&explicit_nd, ASDF_ARRAY_STORAGE_INLINE);
 
     /* Write both ndarrays to a temp file */
     asdf_file_t *file = asdf_open(NULL);
@@ -704,7 +704,7 @@ MU_TEST(ndarray_write_inline_data) {
     assert_int((int)ndarray->shape[0], ==, 3);
     assert_int((int)ndarray->shape[1], ==, 3);
     assert_int(ndarray->datatype.type, ==, ASDF_DATATYPE_UINT8);
-    assert_true(asdf_ndarray_inline(ndarray));
+    assert_int(asdf_ndarray_storage(ndarray), ==, ASDF_ARRAY_STORAGE_INLINE);
 
     size_t size = 0;
     const void *data = asdf_ndarray_data_raw(ndarray, &size);
@@ -721,7 +721,7 @@ MU_TEST(ndarray_write_inline_data) {
     assert_int((int)ndarray->shape[0], ==, 3);
     assert_int((int)ndarray->shape[1], ==, 3);
     assert_int(ndarray->datatype.type, ==, ASDF_DATATYPE_FLOAT64);
-    assert_true(asdf_ndarray_inline(ndarray));
+    assert_int(asdf_ndarray_storage(ndarray), ==, ASDF_ARRAY_STORAGE_INLINE);
 
     size = 0;
     data = asdf_ndarray_data_raw(ndarray, &size);
@@ -746,7 +746,7 @@ MU_TEST(ndarray_inline_warning_thresh) {
     uint8_t *data = asdf_ndarray_data_alloc(&ndarray);
     assert_not_null(data);
     memset(data, 0, (size_t)shape[0]);
-    asdf_ndarray_inline_set(&ndarray, true);
+    asdf_ndarray_storage_set(&ndarray, ASDF_ARRAY_STORAGE_INLINE);
 
     /* Redirect warnings to a temp log file.  get_temp_file_path returns a
      * static buffer, so duplicate the path before calling it again. */
@@ -832,6 +832,73 @@ MU_TEST(heap_use_after_free_issue_63) {
 }
 
 
+static char *array_storage_param_values[] = {"inline", "internal", NULL};
+static MunitParameterEnum ndarray_array_storage_params[] = {
+    {"storage", array_storage_param_values},
+    {NULL, NULL}
+};
+
+
+/* Round-trip test for the file-level array_storage emitter override.
+ *
+ * Sets the per-array storage to the opposite of the file-level setting to
+ * verify that the file-level config wins in both directions. */
+MU_TEST(ndarray_array_storage_override) {
+    const char *storage_str = munit_parameters_get(params, "storage");
+    bool is_inline = strcmp(storage_str, "inline") == 0;
+    asdf_array_storage_t storage =
+        is_inline ? ASDF_ARRAY_STORAGE_INLINE : ASDF_ARRAY_STORAGE_INTERNAL;
+    asdf_array_storage_t opposite =
+        is_inline ? ASDF_ARRAY_STORAGE_INTERNAL : ASDF_ARRAY_STORAGE_INLINE;
+
+    const char *out_path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
+    uint64_t shape[1] = {4};
+
+    asdf_ndarray_t nd = {
+        .datatype = {.type = ASDF_DATATYPE_UINT8, .size = 1},
+        .byteorder = ASDF_BYTEORDER_LITTLE,
+        .ndim = 1,
+        .shape = shape,
+    };
+    uint8_t *data = asdf_ndarray_data_alloc(&nd);
+    assert_not_null(data);
+    for (int idx = 0; idx < 4; idx++)
+        data[idx] = (uint8_t)(idx + 1);
+    asdf_ndarray_storage_set(&nd, opposite);
+
+    asdf_config_t cfg = {.emitter = {.array_storage = storage}};
+    asdf_file_t *file = asdf_open_mem_ex(NULL, 0, &cfg);
+    assert_not_null(file);
+
+    asdf_value_t *val = asdf_value_of_ndarray(file, &nd);
+    assert_not_null(val);
+    assert_int(asdf_set_value(file, "arr", val), ==, ASDF_VALUE_OK);
+    assert_int(asdf_write_to(file, out_path), ==, 0);
+    asdf_close(file);
+    asdf_ndarray_data_dealloc(&nd);
+
+    file = asdf_open(out_path, "r");
+    assert_not_null(file);
+    assert_size(asdf_block_count(file), ==, is_inline ? 0 : 1);
+
+    asdf_ndarray_t *ndarray_in = NULL;
+    assert_int(asdf_get_ndarray(file, "arr", &ndarray_in), ==, ASDF_VALUE_OK);
+    assert_not_null(ndarray_in);
+    assert_int(asdf_ndarray_storage(ndarray_in), ==, storage);
+
+    size_t size = 0;
+    const void *raw = asdf_ndarray_data_raw(ndarray_in, &size);
+    assert_not_null(raw);
+    assert_size(size, ==, 4);
+    for (int idx = 0; idx < 4; idx++)
+        assert_int(((const uint8_t *)raw)[idx], ==, idx + 1);
+
+    asdf_ndarray_destroy(ndarray_in);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     ndarray,
     MU_RUN_TEST(ndarray_read_1d_tile_contiguous),
@@ -844,6 +911,7 @@ MU_TEST_SUITE(
     MU_RUN_TEST(ndarray_write_empty_inline_data),
     MU_RUN_TEST(ndarray_write_inline_data),
     MU_RUN_TEST(ndarray_inline_warning_thresh),
+    MU_RUN_TEST(ndarray_array_storage_override, ndarray_array_storage_params),
     MU_RUN_TEST(heap_use_after_free_issue_63)
 );
 


### PR DESCRIPTION
New config setting to globally force the storage mode for all ndarrays.  Will be useful for asdf-format/libasdf-gwcs#1