### PR TITLE
Fixes for memory stream writing

### DIFF
--- a/src/emitter.c
+++ b/src/emitter.c
@@ -102,67 +102,56 @@ static bool asdf_emitter_should_emit(asdf_emitter_t *emitter) {
 }
 
 
+int asdf_emitter_set_output(asdf_emitter_t *emitter, asdf_stream_t *stream) {
+    assert(emitter);
+    if (emitter->stream)
+        asdf_stream_close(emitter->stream);
+    emitter->stream = stream;
+    return 0;
+}
+
+
 int asdf_emitter_set_output_file(asdf_emitter_t *emitter, const char *filename) {
     assert(emitter);
-    emitter->stream = asdf_stream_from_file(emitter->base.ctx, filename, true);
-
-    if (!emitter->stream) {
-        // TODO: Better error handling for file opening errors
-        // For now just use this generic error
+    asdf_stream_t *stream = asdf_stream_from_file(emitter->base.ctx, filename, true);
+    if (!stream) {
         ASDF_ERROR_COMMON(emitter, ASDF_ERR_STREAM_INIT_FAILED);
         return -1;
     }
-
-    emitter->state = ASDF_EMITTER_STATE_INITIAL;
-    return 0;
+    return asdf_emitter_set_output(emitter, stream);
 }
 
 
 int asdf_emitter_set_output_fp(asdf_emitter_t *emitter, FILE *fp) {
     assert(emitter);
-    emitter->stream = asdf_stream_from_fp(emitter->base.ctx, fp, NULL, true);
-
-    if (!emitter->stream) {
-        // TODO: Better error handling for file opening errors
-        // For now just use this generic error
+    asdf_stream_t *stream = asdf_stream_from_fp(emitter->base.ctx, fp, NULL, true);
+    if (!stream) {
         ASDF_ERROR_COMMON(emitter, ASDF_ERR_STREAM_INIT_FAILED);
         return -1;
     }
-
-    emitter->state = ASDF_EMITTER_STATE_INITIAL;
-    return 0;
+    return asdf_emitter_set_output(emitter, stream);
 }
 
 
 int asdf_emitter_set_output_mem(asdf_emitter_t *emitter, const void *buf, size_t size) {
     assert(emitter);
-    emitter->stream = asdf_stream_from_memory(emitter->base.ctx, buf, size);
-
-    if (!emitter->stream) {
-        // TODO: Better error handling for file opening errors
-        // For now just use this generic error
+    asdf_stream_t *stream = asdf_stream_from_memory(emitter->base.ctx, buf, size);
+    if (!stream) {
         ASDF_ERROR_COMMON(emitter, ASDF_ERR_STREAM_INIT_FAILED);
         return -1;
     }
-
-    emitter->state = ASDF_EMITTER_STATE_INITIAL;
-    return 0;
+    return asdf_emitter_set_output(emitter, stream);
 }
 
 
-int asdf_emitter_set_output_malloc(asdf_emitter_t *emitter, const void *buf, size_t size) {
+int asdf_emitter_set_output_malloc(asdf_emitter_t *emitter, void **buf, size_t *size) {
     assert(emitter);
-    emitter->stream = asdf_stream_from_malloc(emitter->base.ctx, buf, size);
-
-    if (!emitter->stream) {
-        // TODO: Better error handling for file opening errors
-        // For now just use this generic error
+    asdf_stream_t *stream = asdf_stream_from_malloc(emitter->base.ctx, buf, size);
+    if (!stream) {
         ASDF_ERROR_COMMON(emitter, ASDF_ERR_STREAM_INIT_FAILED);
         return -1;
     }
-
-    emitter->state = ASDF_EMITTER_STATE_INITIAL;
-    return 0;
+    return asdf_emitter_set_output(emitter, stream);
 }
 
 

--- a/src/emitter.h
+++ b/src/emitter.h
@@ -68,11 +68,11 @@ ASDF_LOCAL void asdf_emitter_destroy(asdf_emitter_t *emitter);
 ASDF_LOCAL asdf_emitter_state_t asdf_emitter_emit(asdf_emitter_t *emit);
 ASDF_LOCAL asdf_emitter_state_t
 asdf_emitter_emit_until(asdf_emitter_t *emit, asdf_emitter_state_t state);
+ASDF_LOCAL int asdf_emitter_set_output(asdf_emitter_t *emitter, asdf_stream_t *stream);
 ASDF_LOCAL int asdf_emitter_set_output_file(asdf_emitter_t *emitter, const char *filename);
 ASDF_LOCAL int asdf_emitter_set_output_fp(asdf_emitter_t *emitter, FILE *fp);
 ASDF_LOCAL int asdf_emitter_set_output_mem(asdf_emitter_t *emitter, const void *buf, size_t size);
-ASDF_LOCAL int asdf_emitter_set_output_malloc(
-    asdf_emitter_t *emitter, const void *buf, size_t size);
+ASDF_LOCAL int asdf_emitter_set_output_malloc(asdf_emitter_t *emitter, void **buf, size_t *size);
 
 
 // Mouthful but coherent...

--- a/src/file.c
+++ b/src/file.c
@@ -360,6 +360,8 @@ static size_t asdf_file_estimate_blocks_size(asdf_file_t *file) {
 
     for (isize idx = 0; idx < n_blocks; idx++) {
         const asdf_block_info_t *block_info = asdf_block_info_vec_at(&file->blocks, idx);
+        if (block_info->write_compressor != NULL)
+            continue; /* compressed size unknown upfront; stream handles reallocs */
         n_bytes += block_info->header.allocated_size + ASDF_BLOCK_MAGIC_SIZE + 2;
     }
 
@@ -400,12 +402,9 @@ int asdf_write_to_mem(asdf_file_t *file, void **buf, size_t *size) {
          * Then we write up through the tree--that will give us some idea
          * of how much we really need and immediately reallocate if needed
          *
-         * TODO: In order to reasonably estimate the size to reserve for each
-         * block we also need to know it's *compressed* size if compression is
-         * enabled on that block.  We haven't implemented compressed writing
-         * yet so fix that later.  Probably we'll need to compress each block
-         * individually first in order to do that; lots of refactoring
-         * involved...
+         * TODO: In the case of compressed blocks we don't currently make any estimate;
+         * that could be fixed later, maybe, within the emitter, especially if we
+         * gave it more information about what stream type it's using.
          */
         bool emit_block_index = (file->config->emitter.flags & ASDF_EMITTER_OPT_NO_BLOCK_INDEX) !=
                                 ASDF_EMITTER_OPT_NO_BLOCK_INDEX;
@@ -422,16 +421,16 @@ int asdf_write_to_mem(asdf_file_t *file, void **buf, size_t *size) {
     }
 
     if (do_alloc) {
-        ret = asdf_emitter_set_output_malloc(emitter, alloc_buf, alloc_size);
+        /* alloc_buf and alloc_size are kept in sync by the malloc stream on
+         * every internal realloc, so they always reflect the live buffer */
+        ret = asdf_emitter_set_output_malloc(emitter, &alloc_buf, &alloc_size);
         if (asdf_emitter_emit_until(emitter, ASDF_EMITTER_STATE_BLOCKS) ==
             ASDF_EMITTER_STATE_BLOCKS) {
             off_t offset = asdf_stream_tell(emitter->stream);
             // How much did we really write?
             if (offset >= 0 && (alloc_size - (size_t)offset) < blocks_size) {
                 // Go ahead and realloc again with enough additional space for the blocks
-                // TODO: We should also take into account the block index here; ideally have
-                // a separate routine for just pre-rendering the block index to a buffer
-                size_t new_size = alloc_size + blocks_size - offset;
+                size_t new_size = alloc_size + blocks_size - (size_t)offset;
                 void *new_buf = realloc(alloc_buf, new_size);
 
                 if (!new_buf) {
@@ -442,7 +441,11 @@ int asdf_write_to_mem(asdf_file_t *file, void **buf, size_t *size) {
 
                 alloc_buf = new_buf;
                 alloc_size = new_size;
-                ret = asdf_emitter_set_output_malloc(emitter, alloc_buf, alloc_size);
+                ret = asdf_emitter_set_output_malloc(emitter, &alloc_buf, &alloc_size);
+                /* Seek to offset so blocks are appended after the already-written YAML
+                 * rather than overwriting it from position 0 */
+                if (ret == 0)
+                    ret = asdf_stream_seek(emitter->stream, offset, SEEK_SET);
             }
         }
     } else {
@@ -462,7 +465,7 @@ int asdf_write_to_mem(asdf_file_t *file, void **buf, size_t *size) {
     off_t offset = asdf_stream_tell(emitter->stream);
 
     if (offset >= 0 && (size_t)offset < alloc_size)
-        memset(alloc_buf + offset, 0, alloc_size - offset);
+        memset((uint8_t *)alloc_buf + offset, 0, alloc_size - offset);
 
     ret = 0;
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -832,6 +832,12 @@ static size_t mem_write(asdf_stream_t *stream, const void *buf, size_t count) {
 
         data->buf = new_buf;
         data->size = data->size + count;
+
+        if (data->out_buf)
+            *data->out_buf = (uint8_t *)new_buf;
+
+        if (data->out_size)
+            *data->out_size = data->size;
     }
 
     size_t avail = data->size - data->pos;
@@ -924,6 +930,9 @@ asdf_stream_t *asdf_stream_from_memory(asdf_context_t *ctx, const void *buf, siz
     data->buf = buf;
     data->size = size;
     data->pos = 0;
+    data->is_resizeable = false;
+    data->out_buf = NULL;
+    data->out_size = NULL;
 
     asdf_stream_t *stream = malloc(sizeof(asdf_stream_t));
 
@@ -973,13 +982,20 @@ asdf_stream_t *asdf_stream_from_memory(asdf_context_t *ctx, const void *buf, siz
 }
 
 
-asdf_stream_t *asdf_stream_from_malloc(asdf_context_t *ctx, const void *buf, size_t size) {
-    asdf_stream_t *stream = asdf_stream_from_memory(ctx, buf, size);
+/*
+ * buf and size are kept in sync with the stream's internal buffer on every
+ * realloc, so the caller's pointers remain valid even after writes that grow
+ * the buffer.  Both must remain valid for the lifetime of the stream.
+ */
+asdf_stream_t *asdf_stream_from_malloc(asdf_context_t *ctx, void **buf, size_t *size) {
+    asdf_stream_t *stream = asdf_stream_from_memory(ctx, *buf, *size);
 
     if (UNLIKELY(!stream))
         return stream;
 
     mem_userdata_t *userdata = stream->userdata;
     userdata->is_resizeable = true;
+    userdata->out_buf = (uint8_t **)buf;
+    userdata->out_size = size;
     return stream;
 }

--- a/src/stream.h
+++ b/src/stream.h
@@ -173,8 +173,7 @@ ASDF_LOCAL asdf_stream_t *asdf_stream_from_fp(
     asdf_context_t *ctx, FILE *file, const char *filename, bool is_writeable);
 ASDF_LOCAL asdf_stream_t *asdf_stream_from_memory(
     asdf_context_t *ctx, const void *buf, size_t size);
-ASDF_LOCAL asdf_stream_t *asdf_stream_from_malloc(
-    asdf_context_t *ctx, const void *buf, size_t size);
+ASDF_LOCAL asdf_stream_t *asdf_stream_from_malloc(asdf_context_t *ctx, void **buf, size_t *size);
 
 ASDF_LOCAL void asdf_stream_set_capture(
     asdf_stream_t *stream, uint8_t **buf, size_t *size, size_t capacity);

--- a/src/stream_intern.h
+++ b/src/stream_intern.h
@@ -42,4 +42,8 @@ typedef struct {
     size_t size;
     size_t pos;
     bool is_resizeable;
+    /* When non-NULL, kept in sync with buf/size after every internal realloc.
+     * Set by asdf_stream_from_malloc so the caller's pointer stays valid. */
+    uint8_t **out_buf;
+    size_t *out_size;
 } mem_userdata_t;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -162,6 +162,16 @@ test_malloc_fail_unit_LDFLAGS = \
     $(unit_test_ldflags) \
     -Wl,--wrap=malloc,--wrap=calloc,--wrap=strdup,--wrap=strndup
 test_malloc_fail_unit_LDADD = libmunit.a $(top_builddir)/libasdf_static.la
+
+# test-emitter.unit
+# Also links against libasdf_static.la so that ASDF_LOCAL (hidden-visibility)
+# emitter internals are accessible from the test binary.
+check_PROGRAMS += test-emitter.unit
+test_emitter_unit_SOURCES = test-emitter.c
+test_emitter_unit_CPPFLAGS = $(unit_test_cppflags)
+test_emitter_unit_CFLAGS = $(unit_test_cflags)
+test_emitter_unit_LDFLAGS = $(unit_test_ldflags)
+test_emitter_unit_LDADD = libmunit.a $(top_builddir)/libasdf_static.la
 endif
 
 # test-stream.unit

--- a/tests/test-compression.c
+++ b/tests/test-compression.c
@@ -832,6 +832,161 @@ MU_TEST(verify_checksum) {
 }
 
 
+/**
+ * Write a compressed ndarray to a memory buffer and verify the round-trip
+ */
+MU_TEST(write_compressed_to_mem) {
+    const char *comp = munit_parameters_get(params, "comp");
+    const size_t n = 4096;
+
+    uint8_t *ref = malloc(n);
+    if (!ref)
+        return MUNIT_ERROR;
+    for (size_t idx = 0; idx < n; idx++)
+        ref[idx] = (uint8_t)(idx % 4);
+
+    const uint64_t shape[] = {n};
+    asdf_ndarray_t ndarray = {
+        .datatype = (asdf_datatype_t){.type = ASDF_DATATYPE_UINT8},
+        .byteorder = ASDF_BYTEORDER_BIG,
+        .ndim = 1,
+        .shape = shape,
+    };
+    uint8_t *data = asdf_ndarray_data_alloc(&ndarray);
+
+    if (!data) {
+        free(ref);
+        return MUNIT_ERROR;
+    }
+
+    memcpy(data, ref, n);
+    assert_int(asdf_ndarray_compression_set(&ndarray, comp), ==, 0);
+
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+    asdf_value_t *value = asdf_value_of_ndarray(file, &ndarray);
+    assert_not_null(value);
+    assert_int(asdf_set_value(file, "data", value), ==, ASDF_VALUE_OK);
+
+    void *buf = NULL;
+    size_t size = 0;
+    assert_int(asdf_write_to(file, &buf, &size), ==, 0);
+    asdf_close(file);
+    asdf_ndarray_data_dealloc(&ndarray);
+
+    assert_not_null(buf);
+    assert_size(size, >, 0);
+
+    asdf_file_t *rfile = asdf_open_mem_ex(buf, size, NULL);
+    assert_not_null(rfile);
+    const char *error = asdf_error(rfile);
+    if (error)
+        munit_logf(MUNIT_LOG_ERROR, "error opening file from buffer: %s", error);
+    assert_null(error);
+    asdf_ndarray_t *rndarray = NULL;
+    assert_int(asdf_get_ndarray(rfile, "data", &rndarray), ==, ASDF_VALUE_OK);
+    assert_not_null(rndarray);
+    size_t rsize = 0;
+    const uint8_t *rdata = asdf_ndarray_data_raw(rndarray, &rsize);
+    assert_not_null(rdata);
+    assert_size(rsize, ==, n);
+    assert_memory_equal(n, rdata, ref);
+    asdf_ndarray_destroy(rndarray);
+    asdf_close(rfile);
+    free(buf);
+    free(ref);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Regression test for the asdf_write_to_mem stream-switch + realloc optimization (issue #187)
+ *
+ * A large YAML tree (> 2 * _SC_PAGE_SIZE, i.e. > 8 KiB) combined with a
+ * non-compressed block that makes blocks_size > 0 will trigger the code path in
+ * asdf_write_to_mem that reallocates the buffer and switches the emitter stream
+ * mid-emission.  Before the fix the emitter state was reset to INITIAL causing
+ * the blocks to overwrite the YAML in the buffer, producing a corrupt file.
+ */
+MU_TEST(write_to_mem_large_tree_realloc) {
+    /* 16 KiB uncompressed block so blocks_size > 0, which is needed for the
+     * realloc optimisation to trigger.  Initial allocation will be
+     * 2*PAGE (8 KiB) + blocks_size (~16 KiB) = ~24 KiB.  The YAML tree
+     * of ~14 KiB fits within the initial allocation, but the remaining space
+     * after writing the tree (~10 KiB) is less than blocks_size (~16 KiB),
+     * so the realloc path is taken. */
+    const size_t n = 16384;
+    const uint64_t shape[] = {n};
+
+    uint8_t *ref = malloc(n);
+    if (!ref)
+        return MUNIT_ERROR;
+    for (size_t idx = 0; idx < n; idx++)
+        ref[idx] = (uint8_t)(idx % 251);
+
+    asdf_ndarray_t ndarray = {
+        .datatype = (asdf_datatype_t){.type = ASDF_DATATYPE_UINT8},
+        .byteorder = ASDF_BYTEORDER_BIG,
+        .ndim = 1,
+        .shape = shape,
+    };
+    uint8_t *data = asdf_ndarray_data_alloc(&ndarray);
+
+    if (!data) {
+        free(ref);
+        return MUNIT_ERROR;
+    }
+
+    memcpy(data, ref, n);
+
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+    asdf_value_t *value = asdf_value_of_ndarray(file, &ndarray);
+    assert_not_null(value);
+    assert_int(asdf_set_value(file, "rawdata", value), ==, ASDF_VALUE_OK);
+
+    /* Add 100 padding entries of 127 bytes each to push YAML past 2 * PAGE (8 KiB) */
+    char key[32];
+    char val[128];
+    memset(val, 'x', sizeof(val) - 1);
+    val[sizeof(val) - 1] = '\0';
+
+    for (int idx = 0; idx < 100; idx++) {
+        snprintf(key, sizeof(key), "padding_%03d", idx);
+        assert_int(asdf_set_string0(file, key, val), ==, ASDF_VALUE_OK);
+    }
+
+    void *buf = NULL;
+    size_t size = 0;
+    assert_int(asdf_write_to(file, &buf, &size), ==, 0);
+    asdf_ndarray_data_dealloc(&ndarray);
+    asdf_close(file);
+
+    assert_not_null(buf);
+    assert_size(size, >, 0);
+
+    asdf_file_t *rfile = asdf_open_mem_ex(buf, size, NULL);
+    assert_not_null(rfile);
+    const char *error = asdf_error(rfile);
+    if (error)
+        munit_logf(MUNIT_LOG_ERROR, "error opening file from buffer: %s", error);
+    assert_null(error);
+    asdf_ndarray_t *rndarray = NULL;
+    assert_int(asdf_get_ndarray(rfile, "rawdata", &rndarray), ==, ASDF_VALUE_OK);
+    assert_not_null(rndarray);
+    size_t rsize = 0;
+    const uint8_t *rdata = asdf_ndarray_data_raw(rndarray, &rsize);
+    assert_not_null(rdata);
+    assert_size(rsize, ==, n);
+    assert_memory_equal(n, rdata, ref);
+    asdf_ndarray_destroy(rndarray);
+    asdf_close(rfile);
+    free(buf);
+    free(ref);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     compression,
     MU_RUN_TEST(write_compressed_ndarray, comp_test_params),
@@ -844,7 +999,9 @@ MU_TEST_SUITE(
     MU_RUN_TEST(compressed_block_no_hang_on_segfault, comp_mode_test_params),
     MU_RUN_TEST(reemit_compressed_verbatim, comp_test_params),
     MU_RUN_TEST(recompress_block),
-    MU_RUN_TEST(access_then_write, comp_test_params)
+    MU_RUN_TEST(access_then_write, comp_test_params),
+    MU_RUN_TEST(write_compressed_to_mem, comp_test_params),
+    MU_RUN_TEST(write_to_mem_large_tree_realloc)
 );
 
 

--- a/tests/test-emitter.c
+++ b/tests/test-emitter.c
@@ -1,0 +1,140 @@
+/**
+ * Emitter internal tests
+ *
+ * These tests exercise emitter internals (``ASDF_LOCAL`` functions) and must
+ * therefore link against ``libasdf_static.la`` rather than the shared library.
+ */
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "asdf/core/ndarray.h"
+#include "asdf/emitter.h"
+#include "asdf/file.h"
+#include "asdf/value.h"
+
+#include "emitter.h"
+#include "file.h"
+#include "stream.h"
+
+#include "munit.h"
+#include "util.h"
+
+
+/**
+ * Test that switching the emitter output stream mid-emission preserves state
+ *
+ * Regression test for issue #187: asdf_emitter_set_output_* functions used to
+ * reset emitter->state to ASDF_EMITTER_STATE_INITIAL, breaking the realloc
+ * optimization in asdf_write_to_mem and any other mid-emission stream switch.
+ *
+ * Write YAML to buf_yaml, switch stream to buf_blocks, write the rest
+ * (blocks).  Verify that concatenating the two halves matches a reference
+ * single-pass write.  Both sides use ASDF_EMITTER_OPT_NO_BLOCK_INDEX so that
+ * no position-dependent block index is emitted, making byte-for-byte
+ * comparison meaningful.
+ */
+MU_TEST(test_emitter_stream_switch) {
+    const size_t n = 1024;
+    const uint64_t shape[] = {n};
+
+    uint8_t ref_data[n];
+    for (size_t idx = 0; idx < n; idx++)
+        ref_data[idx] = (uint8_t)(idx % 256);
+
+    /* Large buffers; a simple 1 KiB ndarray needs only a few KiB total */
+    const size_t cap = 64 * 1024;
+    uint8_t *buf_yaml = calloc(1, cap);
+    uint8_t *buf_blocks = calloc(1, cap);
+    if (!buf_yaml || !buf_blocks) {
+        free(buf_yaml);
+        free(buf_blocks);
+        return MUNIT_ERROR;
+    }
+
+    /* split emission */
+    asdf_ndarray_t nd1 = {
+        .datatype = (asdf_datatype_t){.type = ASDF_DATATYPE_UINT8},
+        .byteorder = ASDF_BYTEORDER_BIG,
+        .ndim = 1,
+        .shape = shape,
+    };
+    uint8_t *d1 = asdf_ndarray_data_alloc(&nd1);
+    assert_not_null(d1);
+    memcpy(d1, ref_data, n);
+
+    asdf_file_t *file1 = asdf_open_ex(NULL, 0, NULL);
+    assert_not_null(file1);
+    asdf_value_t *v1 = asdf_value_of_ndarray(file1, &nd1);
+    assert_not_null(v1);
+    assert_int(asdf_set_value(file1, "data", v1), ==, ASDF_VALUE_OK);
+
+    asdf_emitter_cfg_t ecfg = ASDF_EMITTER_CFG_DEFAULT;
+    ecfg.flags |= ASDF_EMITTER_OPT_NO_BLOCK_INDEX;
+    asdf_emitter_t *emitter = asdf_emitter_create(file1, &ecfg);
+    assert_not_null(emitter);
+
+    /* Write YAML section to buf_yaml */
+    assert_int(asdf_emitter_set_output_mem(emitter, buf_yaml, cap), ==, 0);
+    asdf_emitter_state_t mid = asdf_emitter_emit_until(emitter, ASDF_EMITTER_STATE_BLOCKS);
+    assert_int(mid, ==, ASDF_EMITTER_STATE_BLOCKS);
+    off_t n_yaml = asdf_stream_tell(emitter->stream);
+    assert_true(n_yaml > 0);
+
+    /* Switch stream -- after the fix this must NOT reset the emitter state */
+    assert_int(asdf_emitter_set_output_mem(emitter, buf_blocks, cap), ==, 0);
+    asdf_emitter_state_t final_state = asdf_emitter_emit(emitter);
+    assert_int(final_state, ==, ASDF_EMITTER_STATE_END);
+    off_t n_blocks = asdf_stream_tell(emitter->stream);
+    assert_true(n_blocks > 0);
+
+    asdf_emitter_destroy(emitter);
+    asdf_ndarray_data_dealloc(&nd1);
+    asdf_close(file1);
+
+    /* single-pass reference emission */
+    asdf_ndarray_t nd2 = {
+        .datatype = (asdf_datatype_t){.type = ASDF_DATATYPE_UINT8},
+        .byteorder = ASDF_BYTEORDER_BIG,
+        .ndim = 1,
+        .shape = shape,
+    };
+    uint8_t *d2 = asdf_ndarray_data_alloc(&nd2);
+    assert_not_null(d2);
+    memcpy(d2, ref_data, n);
+
+    asdf_config_t cfg2 = {.emitter = {.flags = ASDF_EMITTER_OPT_NO_BLOCK_INDEX}};
+    asdf_file_t *file2 = asdf_open_mem_ex(NULL, 0, &cfg2);
+    assert_not_null(file2);
+    asdf_value_t *v2 = asdf_value_of_ndarray(file2, &nd2);
+    assert_not_null(v2);
+    assert_int(asdf_set_value(file2, "data", v2), ==, ASDF_VALUE_OK);
+
+    void *single_buf = NULL;
+    size_t single_size = 0;
+    assert_int(asdf_write_to_mem(file2, &single_buf, &single_size), ==, 0);
+    asdf_ndarray_data_dealloc(&nd2);
+    asdf_close(file2);
+
+    /* single_size is the allocated buffer size (includes trailing zeros), so it
+     * will be >= the actual content; verify both halves of the split output
+     * match the corresponding positions in the reference buffer */
+    assert_size((size_t)n_yaml + (size_t)n_blocks, <=, single_size);
+    assert_memory_equal((size_t)n_yaml, buf_yaml, single_buf);
+    assert_memory_equal((size_t)n_blocks, buf_blocks, (uint8_t *)single_buf + n_yaml);
+
+    free(buf_yaml);
+    free(buf_blocks);
+    free(single_buf);
+    return MUNIT_OK;
+}
+
+
+MU_TEST_SUITE(
+    emitter,
+    MU_RUN_TEST(test_emitter_stream_switch)
+);
+
+
+MU_RUN_SUITE(emitter);


### PR DESCRIPTION
Adds fixes for the major issues raised in #187 and regression tests.

This is a prerequisite for asdf-format/libasdf-gwcs#6