### PR TITLE
fix: bug in lz4 decompression handling on multiple compression blocks

### DIFF
--- a/src/compression/lz4.c
+++ b/src/compression/lz4.c
@@ -220,6 +220,7 @@ static int asdf_compresser_lz4_read_block(asdf_compressor_lz4_userdata_t *lz4) {
     }
 
     lz4->pos += lz4->header.block_size;
+    lz4->header.pos = 0;
     return 0;
 }
 

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -1606,7 +1606,7 @@ asdf_ndarray_err_t asdf_ndarray_read_tile_ndim(
     size_t src_tile_size = src_elsize * tile_nelems;
     size_t tile_size = dst_elsize * tile_nelems;
     size_t data_size = 0;
-    const void *data = asdf_ndarray_data_raw(ndarray, &data_size);
+    const void *data = asdf_ndarray_data(ndarray, &data_size);
 
     if (data_size < src_tile_size)
         return ASDF_NDARRAY_ERR_OUT_OF_BOUNDS;


### PR DESCRIPTION
Did not reset the position of the header read to zero between block reads.  That's a bit of a foot-gun; should maybe refactor this a bit later.