### PR TITLE
fix: handling of larger asdf info outputs

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -28,13 +28,26 @@
 /** Determines how much indentation to reserve initially, but can be increased */
 #define INITIAL_MAX_DEPTH 16
 
+/** Maximum number of display columns of a scalar value shown in the tree preview */
+#define SCALAR_PREVIEW_MAX 64
+
+
+// Growable indentation bookkeeping shared by every recursion frame.  This is
+// held once (owned by asdf_info) and referenced via a pointer by all frames so
+// that when a deeply-nested node grows active_levels every ancestor frame sees
+// the new buffer; copying it per-frame would leave ancestors with dangling
+// pointers once the buffer is reallocated (see issue #191).
+typedef struct {
+    bool *active_levels;
+    size_t max_depth;
+} node_indent_t;
+
 
 typedef struct {
     size_t depth;
-    size_t max_depth;
-    bool *active_levels;
     bool is_mapping;
     bool is_leaf;
+    node_indent_t *indent;
 } node_state_t;
 
 
@@ -54,7 +67,7 @@ static void print_indent(FILE *out, node_state_t *state) {
         if (idx == state->depth - 1) {
             fputs(state->is_leaf ? "└─" : "├─", out);
         } else {
-            if (state->active_levels[idx])
+            if (state->indent->active_levels[idx])
                 fputs("│ ", out);
             else
                 fputs("  ", out);
@@ -62,6 +75,63 @@ static void print_indent(FILE *out, node_state_t *state) {
     }
 
     fputs(ANSI_RESET, out);
+}
+
+
+// Print a single-line, column-limited preview of a scalar value, prefixed by
+// ": ".  Scalar values in ASDF may be arbitrarily long and may contain embedded
+// newlines (e.g. multi-line log strings); printed verbatim these wrap the
+// terminal and break up the tree drawing (see issue #191).  Here any run of
+// control/whitespace characters (newlines, tabs, etc.) is collapsed into a
+// single space and the preview is truncated at SCALAR_PREVIEW_MAX display
+// columns (counting a UTF-8 character as one column, matching visible_strlen),
+// with an ellipsis appended when content is dropped.
+static void print_scalar_value(FILE *out, const char *value) {
+    fputs(": ", out);
+
+    if (!value)
+        return;
+
+    size_t cols = 0;
+    bool pending_space = false;
+    bool any = false;
+
+    for (const char *cur = value; *cur;) {
+        unsigned char chr = (unsigned char)*cur;
+
+        if (chr < 0x20 || chr == 0x7f) {
+            // Collapse control/whitespace; a run before any output is dropped.
+            if (any)
+                pending_space = true;
+            cur++;
+            continue;
+        }
+
+        if (cols >= SCALAR_PREVIEW_MAX) {
+            fputs("...", out);
+            return;
+        }
+
+        if (pending_space) {
+            fputc(' ', out);
+            pending_space = false;
+            any = true;
+            if (++cols >= SCALAR_PREVIEW_MAX) {
+                // A real character still follows, so the value is truncated.
+                fputs("...", out);
+                return;
+            }
+        }
+
+        // Emit one full UTF-8 character (leading byte plus continuation bytes).
+        fputc((char)chr, out);
+        cur++;
+        while ((*cur & UTF8_LEADING_PREFIX) == UTF8_CONTINUATION_PREFIX)
+            fputc(*cur++, out);
+
+        cols++;
+        any = true;
+    }
 }
 
 
@@ -97,7 +167,7 @@ static int print_node(FILE *out, asdf_value_t *node, node_index_t *index, node_s
     if (!asdf_value_is_container(node)) {
         const char *value = NULL;
         asdf_value_as_scalar0(node, &value);
-        fprintf(out, ": %s", value);
+        print_scalar_value(out, value);
         fputc('\n', out);
         return 0;
     }
@@ -107,33 +177,33 @@ static int print_node(FILE *out, asdf_value_t *node, node_index_t *index, node_s
     asdf_container_iter_t *iter = asdf_container_iter_init(node);
     int size = asdf_container_size(node);
 
-    if (state->depth > state->max_depth - 1) {
+    if (state->depth > state->indent->max_depth - 1) {
         // Grow the maximum depth linerally
-        size_t new_max_depth = state->max_depth + INITIAL_MAX_DEPTH;
-        bool *new_active_levels = realloc(state->active_levels, new_max_depth * sizeof(bool));
+        size_t new_max_depth = state->indent->max_depth + INITIAL_MAX_DEPTH;
+        bool *new_active_levels = realloc(
+            state->indent->active_levels, new_max_depth * sizeof(bool));
 
         if (!new_active_levels) {
             asdf_container_iter_destroy(iter);
             return -1;
         }
 
-        state->active_levels = new_active_levels;
-        state->max_depth = new_max_depth;
+        state->indent->active_levels = new_active_levels;
+        state->indent->max_depth = new_max_depth;
     }
 
-    state->active_levels[state->depth] = true;
+    state->indent->active_levels[state->depth] = true;
 
     node_state_t child_state = {
         .depth = state->depth + 1,
-        .max_depth = state->max_depth,
-        .active_levels = state->active_levels,
         .is_mapping = is_mapping,
-        .is_leaf = false};
+        .is_leaf = false,
+        .indent = state->indent};
 
     while (asdf_container_iter_next(&iter)) {
         if (iter->index == size - 1) {
             child_state.is_leaf = true;
-            state->active_levels[state->depth] = false;
+            state->indent->active_levels[state->depth] = false;
         }
 
         node_index_t child_index = {0};
@@ -339,16 +409,15 @@ int asdf_info(asdf_file_t *file, FILE *out, const asdf_info_cfg_t *cfg) {
         if (UNLIKELY(!active_levels))
             return -1;
 
-        node_state_t state = {
-            .depth = 0,
-            .max_depth = INITIAL_MAX_DEPTH,
-            .active_levels = active_levels,
-            .is_mapping = true,
-            .is_leaf = true};
+        // active_levels may be reallocated (grown) during the recursive walk;
+        // it is shared by reference through indent so that the final pointer is
+        // the one we free here.
+        node_indent_t indent = {.active_levels = active_levels, .max_depth = INITIAL_MAX_DEPTH};
+        node_state_t state = {.depth = 0, .is_mapping = true, .is_leaf = true, .indent = &indent};
         node_index_t index = {.key = "root"};
         ret = print_node(out, root, &index, &state);
         asdf_value_destroy(root);
-        free(active_levels);
+        free(indent.active_levels);
     }
 
     if (ret == 0 && cfg->print_blocks) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -354,6 +354,7 @@ EXTRA_DIST += \
     fixtures/info/exploded.info.txt \
     fixtures/info/float.info.txt \
     fixtures/info/int.info.txt \
+    fixtures/info/roman_l2_wcs.info.txt \
     fixtures/info/scalars.info.txt \
     fixtures/info/shared.info.txt \
     fixtures/info/stream.info.txt \
@@ -369,6 +370,7 @@ EXTRA_DIST += \
     fixtures/parse-minimal.asdf \
     fixtures/parse-minimal-empty-tree.asdf \
     fixtures/parse-minimal-extra-comment.asdf \
+    fixtures/roman_l2_wcs.asdf \
     fixtures/roman_wcs.asdf \
     fixtures/scalars.asdf \
     fixtures/scalars-out.asdf \

--- a/tests/fixtures/info/roman_l2_wcs.info.txt
+++ b/tests/fixtures/info/roman_l2_wcs.info.txt
@@ -1,0 +1,1879 @@
+[1mroot[0m (tag:stsci.edu:asdf/core/asdf-1.1.0)
+[2m├─[0m[1masdf_library[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│ ├─[0m[1mauthor[0m (scalar): The ASDF Developers
+[2m│ ├─[0m[1mhomepage[0m (scalar): http://github.com/asdf-format/asdf
+[2m│ ├─[0m[1mname[0m (scalar): asdf
+[2m│ └─[0m[1mversion[0m (scalar): 5.1.0
+[2m├─[0m[1mhistory[0m (mapping)
+[2m│ └─[0m[1mextensions[0m (sequence)
+[2m│   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│   │ ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│   │ ├─[0m[1mextension_uri[0m (scalar): asdf://stsci.edu/datamodels/roman/extensions/static-1.1.0
+[2m│   │ ├─[0m[1mmanifest_software[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │ │ ├─[0m[1mname[0m (scalar): rad
+[2m│   │ │ └─[0m[1mversion[0m (scalar): 0.30.0
+[2m│   │ └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │   ├─[0m[1mname[0m (scalar): roman_datamodels
+[2m│   │   └─[0m[1mversion[0m (scalar): 0.30.0
+[2m│   ├─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│   │ ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│   │ ├─[0m[1mextension_uri[0m (scalar): asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.4.0
+[2m│   │ ├─[0m[1mmanifest_software[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │ │ ├─[0m[1mname[0m (scalar): asdf_wcs_schemas
+[2m│   │ │ └─[0m[1mversion[0m (scalar): 0.5.0
+[2m│   │ └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │   ├─[0m[1mname[0m (scalar): gwcs
+[2m│   │   └─[0m[1mversion[0m (scalar): 1.0.3
+[2m│   ├─[0m[2m[[0m[1m2[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│   │ ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│   │ ├─[0m[1mextension_uri[0m (scalar): asdf://asdf-format.org/transform/extensions/transform-1.6.0
+[2m│   │ ├─[0m[1mmanifest_software[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │ │ ├─[0m[1mname[0m (scalar): asdf_transform_schemas
+[2m│   │ │ └─[0m[1mversion[0m (scalar): 0.6.0
+[2m│   │ └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │   ├─[0m[1mname[0m (scalar): asdf-astropy
+[2m│   │   └─[0m[1mversion[0m (scalar): 0.10.0
+[2m│   ├─[0m[2m[[0m[1m3[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│   │ ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│   │ ├─[0m[1mextension_uri[0m (scalar): asdf://asdf-format.org/core/extensions/core-1.6.0
+[2m│   │ ├─[0m[1mmanifest_software[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │ │ ├─[0m[1mname[0m (scalar): asdf_standard
+[2m│   │ │ └─[0m[1mversion[0m (scalar): 1.5.0
+[2m│   │ └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │   ├─[0m[1mname[0m (scalar): asdf
+[2m│   │   └─[0m[1mversion[0m (scalar): 5.1.0
+[2m│   ├─[0m[2m[[0m[1m4[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│   │ ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│   │ ├─[0m[1mextension_uri[0m (scalar): asdf://astropy.org/astropy/extensions/units-1.3.0
+[2m│   │ └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │   ├─[0m[1mname[0m (scalar): asdf-astropy
+[2m│   │   └─[0m[1mversion[0m (scalar): 0.10.0
+[2m│   ├─[0m[2m[[0m[1m5[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│   │ ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│   │ ├─[0m[1mextension_uri[0m (scalar): asdf://asdf-format.org/astronomy/extensions/astronomy-1.2.0
+[2m│   │ ├─[0m[1mmanifest_software[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │ │ ├─[0m[1mname[0m (scalar): asdf_standard
+[2m│   │ │ └─[0m[1mversion[0m (scalar): 1.5.0
+[2m│   │ └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│   │   ├─[0m[1mname[0m (scalar): asdf-astropy
+[2m│   │   └─[0m[1mversion[0m (scalar): 0.10.0
+[2m│   └─[0m[2m[[0m[1m6[0m[2m][0m (tag:stsci.edu:asdf/core/extension_metadata-1.0.0)
+[2m│     ├─[0m[1mextension_class[0m (scalar): asdf.extension._manifest.ManifestExtension
+[2m│     ├─[0m[1mextension_uri[0m (scalar): asdf://asdf-format.org/astronomy/coordinates/extensions/coordina...
+[2m│     ├─[0m[1mmanifest_software[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│     │ ├─[0m[1mname[0m (scalar): asdf_coordinates_schemas
+[2m│     │ └─[0m[1mversion[0m (scalar): 0.5.1
+[2m│     └─[0m[1msoftware[0m (tag:stsci.edu:asdf/core/software-1.0.0)
+[2m│       ├─[0m[1mname[0m (scalar): asdf-astropy
+[2m│       └─[0m[1mversion[0m (scalar): 0.10.0
+[2m└─[0m[1mroman[0m (mapping)
+[2m  └─[0m[1mmeta[0m (mapping)
+[2m    ├─[0m[1mcal_logs[0m (sequence)
+[2m    │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2026-02-17T21:46:21.496Z :: stpipe.step :: INFO :: Step Exposure...
+[2m    │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2026-02-17T21:46:21.505Z :: stpipe.step :: INFO :: Step Exposure...
+[2m    │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 2026-02-17T21:46:22.548Z :: stpipe.pipeline :: INFO :: Prefetchi...
+[2m    │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 2026-02-17T21:46:22.550Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m4[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m5[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m6[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m7[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m8[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m9[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m10[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m11[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m12[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m13[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m14[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m15[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m16[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch ...
+[2m    │ ├─[0m[2m[[0m[1m17[0m[2m][0m (scalar): 2026-02-17T21:46:22.551Z :: romancal.pipeline.exposure_pipeline ...
+[2m    │ ├─[0m[2m[[0m[1m18[0m[2m][0m (scalar): 2026-02-17T21:46:22.622Z :: stpipe.step :: INFO :: Step dq_init ...
+[2m    │ ├─[0m[2m[[0m[1m19[0m[2m][0m (scalar): 2026-02-17T21:46:22.914Z :: romancal.dq_init.dq_init_step :: INF...
+[2m    │ ├─[0m[2m[[0m[1m20[0m[2m][0m (scalar): 2026-02-17T21:46:22.997Z :: stpipe.step :: INFO :: Step dq_init ...
+[2m    │ ├─[0m[2m[[0m[1m21[0m[2m][0m (scalar): 2026-02-17T21:46:23.033Z :: stpipe.step :: INFO :: Step saturati...
+[2m    │ ├─[0m[2m[[0m[1m22[0m[2m][0m (scalar): 2026-02-17T21:46:23.034Z :: romancal.saturation.saturation_step ...
+[2m    │ ├─[0m[2m[[0m[1m23[0m[2m][0m (scalar): 2026-02-17T21:46:24.781Z :: stcal.saturation.saturation :: INFO ...
+[2m    │ ├─[0m[2m[[0m[1m24[0m[2m][0m (scalar): 2026-02-17T21:46:24.833Z :: stcal.saturation.saturation :: INFO ...
+[2m    │ ├─[0m[2m[[0m[1m25[0m[2m][0m (scalar): 2026-02-17T21:46:24.850Z :: stpipe.step :: INFO :: Step saturati...
+[2m    │ ├─[0m[2m[[0m[1m26[0m[2m][0m (scalar): 2026-02-17T21:46:24.925Z :: stpipe.step :: INFO :: Step refpix r...
+[2m    │ ├─[0m[2m[[0m[1m27[0m[2m][0m (scalar): 2026-02-17T21:46:24.925Z :: romancal.refpix.refpix_step :: DEBUG...
+[2m    │ ├─[0m[2m[[0m[1m28[0m[2m][0m (scalar): 2026-02-17T21:46:24.926Z :: romancal.refpix.refpix_step :: DEBUG...
+[2m    │ ├─[0m[2m[[0m[1m29[0m[2m][0m (scalar): 2026-02-17T21:46:24.942Z :: romancal.refpix.refpix_step :: DEBUG...
+[2m    │ ├─[0m[2m[[0m[1m30[0m[2m][0m (scalar): 2026-02-17T21:46:24.942Z :: romancal.refpix.refpix :: DEBUG :: R...
+[2m    │ ├─[0m[2m[[0m[1m31[0m[2m][0m (scalar): 2026-02-17T21:46:25.133Z :: romancal.refpix.refpix :: DEBUG :: R...
+[2m    │ ├─[0m[2m[[0m[1m32[0m[2m][0m (scalar): 2026-02-17T21:46:25.712Z :: romancal.refpix.refpix :: DEBUG :: R...
+[2m    │ ├─[0m[2m[[0m[1m33[0m[2m][0m (scalar): 2026-02-17T21:46:25.726Z :: py.warnings :: WARNING :: /Users/bgr...
+[2m    │ ├─[0m[2m[[0m[1m34[0m[2m][0m (scalar): 2026-02-17T21:46:25.874Z :: romancal.refpix.refpix :: DEBUG :: C...
+[2m    │ ├─[0m[2m[[0m[1m35[0m[2m][0m (scalar): 2026-02-17T21:46:26.196Z :: romancal.refpix.refpix :: DEBUG :: F...
+[2m    │ ├─[0m[2m[[0m[1m36[0m[2m][0m (scalar): 2026-02-17T21:46:29.314Z :: romancal.refpix.refpix :: DEBUG :: A...
+[2m    │ ├─[0m[2m[[0m[1m37[0m[2m][0m (scalar): 2026-02-17T21:46:29.395Z :: romancal.refpix.refpix :: DEBUG :: R...
+[2m    │ ├─[0m[2m[[0m[1m38[0m[2m][0m (scalar): 2026-02-17T21:46:29.417Z :: romancal.refpix.refpix :: DEBUG :: U...
+[2m    │ ├─[0m[2m[[0m[1m39[0m[2m][0m (scalar): 2026-02-17T21:46:29.441Z :: stpipe.step :: INFO :: Step refpix d...
+[2m    │ ├─[0m[2m[[0m[1m40[0m[2m][0m (scalar): 2026-02-17T21:46:29.476Z :: stpipe.step :: INFO :: Step dark_dec...
+[2m    │ ├─[0m[2m[[0m[1m41[0m[2m][0m (scalar): 2026-02-17T21:46:29.477Z :: romancal.dark_decay.dark_decay_step ...
+[2m    │ ├─[0m[2m[[0m[1m42[0m[2m][0m (scalar): 2026-02-17T21:46:34.587Z :: stpipe.step :: INFO :: Step dark_dec...
+[2m    │ ├─[0m[2m[[0m[1m43[0m[2m][0m (scalar): 2026-02-17T21:46:34.621Z :: stpipe.step :: INFO :: Step wfi18_tr...
+[2m    │ ├─[0m[2m[[0m[1m44[0m[2m][0m (scalar): 2026-02-17T21:46:34.621Z :: stpipe.step :: INFO :: Step wfi18_tr...
+[2m    │ ├─[0m[2m[[0m[1m45[0m[2m][0m (scalar): 2026-02-17T21:46:34.651Z :: stpipe.step :: INFO :: Step linearit...
+[2m    │ ├─[0m[2m[[0m[1m46[0m[2m][0m (scalar): 2026-02-17T21:46:34.655Z :: romancal.linearity.linearity_step ::...
+[2m    │ ├─[0m[2m[[0m[1m47[0m[2m][0m (scalar): 2026-02-17T21:46:34.655Z :: romancal.linearity.linearity_step ::...
+[2m    │ ├─[0m[2m[[0m[1m48[0m[2m][0m (scalar): 2026-02-17T21:46:34.655Z :: romancal.linearity.linearity_step ::...
+[2m    │ ├─[0m[2m[[0m[1m49[0m[2m][0m (scalar): 2026-02-17T21:46:41.801Z :: py.warnings :: WARNING :: /Users/bgr...
+[2m    │ ├─[0m[2m[[0m[1m50[0m[2m][0m (scalar): 2026-02-17T21:47:46.010Z :: romancal.linearity.linearity_step ::...
+[2m    │ ├─[0m[2m[[0m[1m51[0m[2m][0m (scalar): 2026-02-17T21:47:46.031Z :: stpipe.step :: INFO :: Step linearit...
+[2m    │ ├─[0m[2m[[0m[1m52[0m[2m][0m (scalar): 2026-02-17T21:47:46.068Z :: stpipe.step :: INFO :: Step rampfit ...
+[2m    │ ├─[0m[2m[[0m[1m53[0m[2m][0m (scalar): 2026-02-17T21:47:46.071Z :: romancal.ramp_fitting.ramp_fit_step ...
+[2m    │ ├─[0m[2m[[0m[1m54[0m[2m][0m (scalar): 2026-02-17T21:47:46.084Z :: romancal.ramp_fitting.ramp_fit_step ...
+[2m    │ ├─[0m[2m[[0m[1m55[0m[2m][0m (scalar): 2026-02-17T21:47:46.094Z :: romancal.ramp_fitting.ramp_fit_step ...
+[2m    │ ├─[0m[2m[[0m[1m56[0m[2m][0m (scalar): 2026-02-17T21:49:19.590Z :: romancal.ramp_fitting.ramp_fit_step ...
+[2m    │ ├─[0m[2m[[0m[1m57[0m[2m][0m (scalar): 2026-02-17T21:49:19.875Z :: py.warnings :: WARNING :: /Users/bgr...
+[2m    │ ├─[0m[2m[[0m[1m58[0m[2m][0m (scalar): 2026-02-17T21:49:19.887Z :: stpipe.step :: INFO :: Step rampfit ...
+[2m    │ ├─[0m[2m[[0m[1m59[0m[2m][0m (scalar): 2026-02-17T21:49:19.934Z :: stpipe.step :: INFO :: Step dark_cur...
+[2m    │ ├─[0m[2m[[0m[1m60[0m[2m][0m (scalar): 2026-02-17T21:49:19.936Z :: romancal.dark_current.dark_current_s...
+[2m    │ ├─[0m[2m[[0m[1m61[0m[2m][0m (scalar): 2026-02-17T21:49:20.066Z :: stpipe.step :: INFO :: Step dark_cur...
+[2m    │ ├─[0m[2m[[0m[1m62[0m[2m][0m (scalar): 2026-02-17T21:49:20.095Z :: stpipe.step :: INFO :: Step assign_w...
+[2m    │ ├─[0m[2m[[0m[1m63[0m[2m][0m (scalar): 2026-02-17T21:49:20.095Z :: romancal.assign_wcs.assign_wcs_step ...
+[2m    │ ├─[0m[2m[[0m[1m64[0m[2m][0m (scalar): 2026-02-17T21:49:20.096Z :: romancal.assign_wcs.assign_wcs_step ...
+[2m    │ ├─[0m[2m[[0m[1m65[0m[2m][0m (scalar): 2026-02-17T21:49:20.136Z :: stcal.alignment.util :: INFO :: Upda...
+[2m    │ ├─[0m[2m[[0m[1m66[0m[2m][0m (scalar): 2026-02-17T21:49:20.136Z :: romancal.assign_wcs.utils :: INFO ::...
+[2m    │ ├─[0m[2m[[0m[1m67[0m[2m][0m (scalar): 2026-02-17T21:49:20.136Z :: romancal.assign_wcs.utils :: INFO ::...
+[2m    │ ├─[0m[2m[[0m[1m68[0m[2m][0m (scalar): 2026-02-17T21:49:20.137Z :: stpipe.step :: INFO :: Step assign_w...
+[2m    │ ├─[0m[2m[[0m[1m69[0m[2m][0m (scalar): 2026-02-17T21:49:20.169Z :: stpipe.step :: INFO :: Step flatfiel...
+[2m    │ ├─[0m[2m[[0m[1m70[0m[2m][0m (scalar): 2026-02-17T21:49:20.370Z :: stpipe.step :: INFO :: Step flatfiel...
+[2m    │ ├─[0m[2m[[0m[1m71[0m[2m][0m (scalar): 2026-02-17T21:49:20.402Z :: stpipe.step :: INFO :: Step photom r...
+[2m    │ ├─[0m[2m[[0m[1m72[0m[2m][0m (scalar): 2026-02-17T21:49:20.415Z :: romancal.photom.photom :: DEBUG :: p...
+[2m    │ ├─[0m[2m[[0m[1m73[0m[2m][0m (scalar): 2026-02-17T21:49:20.416Z :: romancal.photom.photom :: INFO :: ph...
+[2m    │ ├─[0m[2m[[0m[1m74[0m[2m][0m (scalar): 2026-02-17T21:49:20.416Z :: romancal.photom.photom :: INFO :: un...
+[2m    │ ├─[0m[2m[[0m[1m75[0m[2m][0m (scalar): 2026-02-17T21:49:20.416Z :: stpipe.step :: INFO :: Step photom d...
+[2m    │ ├─[0m[2m[[0m[1m76[0m[2m][0m (scalar): 2026-02-17T21:49:20.449Z :: stpipe.step :: INFO :: Step source_c...
+[2m    │ ├─[0m[2m[[0m[1m77[0m[2m][0m (scalar): 2026-02-17T21:49:20.450Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m78[0m[2m][0m (scalar): 2026-02-17T21:49:22.282Z :: romancal.source_catalog.psf :: INFO ...
+[2m    │ ├─[0m[2m[[0m[1m79[0m[2m][0m (scalar): 2026-02-17T21:49:22.406Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m80[0m[2m][0m (scalar): 2026-02-17T21:49:24.878Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m81[0m[2m][0m (scalar): 2026-02-17T21:49:25.828Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m82[0m[2m][0m (scalar): 2026-02-17T21:49:27.379Z :: romancal.source_catalog.detection ::...
+[2m    │ ├─[0m[2m[[0m[1m83[0m[2m][0m (scalar): 2026-02-17T21:49:27.380Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m84[0m[2m][0m (scalar): 2026-02-17T21:49:27.398Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m85[0m[2m][0m (scalar): 2026-02-17T21:49:27.426Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m86[0m[2m][0m (scalar): 2026-02-17T21:49:27.673Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m87[0m[2m][0m (scalar): 2026-02-17T21:49:27.730Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m88[0m[2m][0m (scalar): 2026-02-17T21:49:27.882Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m89[0m[2m][0m (scalar): 2026-02-17T21:49:27.883Z :: romancal.source_catalog.source_catal...
+[2m    │ ├─[0m[2m[[0m[1m90[0m[2m][0m (scalar): 2026-02-17T21:49:28.986Z :: stpipe.step :: INFO :: Saved model i...
+[2m    │ ├─[0m[2m[[0m[1m91[0m[2m][0m (scalar): 2026-02-17T21:49:29.734Z :: stpipe.step :: INFO :: Saved model i...
+[2m    │ ├─[0m[2m[[0m[1m92[0m[2m][0m (scalar): 2026-02-17T21:49:29.791Z :: stpipe.step :: INFO :: Step source_c...
+[2m    │ ├─[0m[2m[[0m[1m93[0m[2m][0m (scalar): 2026-02-17T21:49:29.835Z :: stpipe.step :: INFO :: Step tweakreg...
+[2m    │ ├─[0m[2m[[0m[1m94[0m[2m][0m (scalar): 2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step :: I...
+[2m    │ ├─[0m[2m[[0m[1m95[0m[2m][0m (scalar): 2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step :: I...
+[2m    │ ├─[0m[2m[[0m[1m96[0m[2m][0m (scalar): 2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step :: I...
+[2m    │ ├─[0m[2m[[0m[1m97[0m[2m][0m (scalar): 2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step :: I...
+[2m    │ ├─[0m[2m[[0m[1m98[0m[2m][0m (scalar): 2026-02-17T21:49:29.908Z :: romancal.tweakreg.tweakreg_step :: I...
+[2m    │ ├─[0m[2m[[0m[1m99[0m[2m][0m (scalar): 2026-02-17T21:50:27.113Z :: tweakwcs.imalign :: INFO ::  
+[2m    │ ├─[0m[2m[[0m[1m100[0m[2m][0m (scalar): 2026-02-17T21:50:27.113Z :: tweakwcs.imalign :: INFO :: ***** tw...
+[2m    │ ├─[0m[2m[[0m[1m101[0m[2m][0m (scalar): 2026-02-17T21:50:27.113Z :: tweakwcs.imalign :: INFO ::       Ve...
+[2m    │ ├─[0m[2m[[0m[1m102[0m[2m][0m (scalar): 2026-02-17T21:50:27.113Z :: tweakwcs.imalign :: INFO ::  
+[2m    │ ├─[0m[2m[[0m[1m103[0m[2m][0m (scalar): 2026-02-17T21:50:27.178Z :: tweakwcs.imalign :: INFO :: Aligning...
+[2m    │ ├─[0m[2m[[0m[1m104[0m[2m][0m (scalar): 2026-02-17T21:50:27.204Z :: tweakwcs.matchutils :: INFO :: Match...
+[2m    │ ├─[0m[2m[[0m[1m105[0m[2m][0m (scalar): 2026-02-17T21:50:27.204Z :: tweakwcs.matchutils :: INFO :: Compu...
+[2m    │ ├─[0m[2m[[0m[1m106[0m[2m][0m (scalar): 2026-02-17T21:50:27.205Z :: tweakwcs.matchutils :: INFO :: Found...
+[2m    │ ├─[0m[2m[[0m[1m107[0m[2m][0m (scalar): 2026-02-17T21:50:27.205Z :: tweakwcs.wcsimage :: INFO :: Found 1...
+[2m    │ ├─[0m[2m[[0m[1m108[0m[2m][0m (scalar): 2026-02-17T21:50:27.205Z :: tweakwcs.linearfit :: INFO :: Perfor...
+[2m    │ ├─[0m[2m[[0m[1m109[0m[2m][0m (scalar): 2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage :: INFO :: Compute...
+[2m    │ ├─[0m[2m[[0m[1m110[0m[2m][0m (scalar): 2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage :: INFO :: XSH: 0....
+[2m    │ ├─[0m[2m[[0m[1m111[0m[2m][0m (scalar): 2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage :: INFO :: 
+[2m    │ ├─[0m[2m[[0m[1m112[0m[2m][0m (scalar): 2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage :: INFO :: FIT RMS...
+[2m    │ ├─[0m[2m[[0m[1m113[0m[2m][0m (scalar): 2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage :: INFO :: Final s...
+[2m    │ ├─[0m[2m[[0m[1m114[0m[2m][0m (scalar): 2026-02-17T21:50:27.224Z :: tweakwcs.imalign :: INFO ::  
+[2m    │ ├─[0m[2m[[0m[1m115[0m[2m][0m (scalar): 2026-02-17T21:50:27.224Z :: tweakwcs.imalign :: INFO :: ***** tw...
+[2m    │ ├─[0m[2m[[0m[1m116[0m[2m][0m (scalar): 2026-02-17T21:50:27.224Z :: tweakwcs.imalign :: INFO :: ***** tw...
+[2m    │ ├─[0m[2m[[0m[1m117[0m[2m][0m (scalar): 2026-02-17T21:50:27.224Z :: tweakwcs.imalign :: INFO ::  
+[2m    │ ├─[0m[2m[[0m[1m118[0m[2m][0m (scalar): 2026-02-17T21:50:27.226Z :: stcal.alignment.util :: INFO :: Upda...
+[2m    │ ├─[0m[2m[[0m[1m119[0m[2m][0m (scalar): 2026-02-17T21:50:27.226Z :: romancal.assign_wcs.utils :: INFO ::...
+[2m    │ ├─[0m[2m[[0m[1m120[0m[2m][0m (scalar): 2026-02-17T21:50:27.226Z :: romancal.assign_wcs.utils :: INFO ::...
+[2m    │ ├─[0m[2m[[0m[1m121[0m[2m][0m (scalar): 2026-02-17T21:50:27.240Z :: stpipe.step :: INFO :: Step tweakreg...
+[2m    │ ├─[0m[2m[[0m[1m122[0m[2m][0m (scalar): 2026-02-17T21:50:27.240Z :: romancal.pipeline.exposure_pipeline ...
+[2m    │ └─[0m[2m[[0m[1m123[0m[2m][0m (scalar): 2026-02-17T21:50:27.332Z :: stpipe.step :: INFO :: Saved model i...
+[2m    ├─[0m[1mcal_step[0m (mapping)
+[2m    │ ├─[0m[1massign_wcs[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mdark[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mdark_decay[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mdq_init[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mflat_field[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mflux[0m (scalar): INCOMPLETE
+[2m    │ ├─[0m[1mlinearity[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1moutlier_detection[0m (scalar): INCOMPLETE
+[2m    │ ├─[0m[1mphotom[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mramp_fit[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mrefpix[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1msaturation[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mskymatch[0m (scalar): INCOMPLETE
+[2m    │ ├─[0m[1msource_catalog[0m (scalar): COMPLETE
+[2m    │ ├─[0m[1mtweakreg[0m (scalar): COMPLETE
+[2m    │ └─[0m[1mwfi18_transient[0m (scalar): N/A
+[2m    ├─[0m[1mcalibration_software_name[0m (scalar): RomanCAL
+[2m    ├─[0m[1mcalibration_software_version[0m (scalar): 0.22.0
+[2m    ├─[0m[1mcoordinates[0m (mapping)
+[2m    │ └─[0m[1mreference_frame[0m (scalar): ICRS
+[2m    ├─[0m[1mephemeris[0m (mapping)
+[2m    │ ├─[0m[1mephemeris_reference_frame[0m (scalar): ?
+[2m    │ ├─[0m[1mspatial_x[0m (scalar): -52044463.08234682
+[2m    │ ├─[0m[1mspatial_y[0m (scalar): -131312741.31107728
+[2m    │ ├─[0m[1mspatial_z[0m (scalar): -56910542.46910208
+[2m    │ ├─[0m[1mtime[0m (scalar): 61557.0
+[2m    │ ├─[0m[1mtype[0m (scalar): DEFINITIVE
+[2m    │ ├─[0m[1mvelocity_x[0m (scalar): 27.507907094602988
+[2m    │ ├─[0m[1mvelocity_y[0m (scalar): -9.484643417914059
+[2m    │ └─[0m[1mvelocity_z[0m (scalar): -4.112149494244798
+[2m    ├─[0m[1mexposure[0m (mapping)
+[2m    │ ├─[0m[1mdata_problem[0m (scalar): ?
+[2m    │ ├─[0m[1meffective_exposure_time[0m (scalar): 133.76
+[2m    │ ├─[0m[1mend_time[0m (tag:stsci.edu:asdf/time/time-1.4.0): 2027-06-01T00:02:13.760
+[2m    │ ├─[0m[1mengineering_quality[0m (scalar): OK
+[2m    │ ├─[0m[1mexposure_time[0m (scalar): 133.76
+[2m    │ ├─[0m[1mframe_time[0m (scalar): 3.04
+[2m    │ ├─[0m[1mma_table_id[0m (scalar): SCI0109
+[2m    │ ├─[0m[1mma_table_name[0m (scalar): ?
+[2m    │ ├─[0m[1mma_table_number[0m (scalar): 109
+[2m    │ ├─[0m[1mmid_time[0m (tag:stsci.edu:asdf/time/time-1.4.0): 2027-06-01T00:01:06.880
+[2m    │ ├─[0m[1mnresultants[0m (scalar): 10
+[2m    │ ├─[0m[1mread_pattern[0m (sequence)
+[2m    │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 1
+[2m    │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 3
+[2m    │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 5
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 6
+[2m    │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 7
+[2m    │ │ ├─[0m[2m[[0m[1m3[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 10
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 11
+[2m    │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 12
+[2m    │ │ │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 13
+[2m    │ │ ├─[0m[2m[[0m[1m4[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 15
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 16
+[2m    │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 17
+[2m    │ │ │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 18
+[2m    │ │ │ ├─[0m[2m[[0m[1m4[0m[2m][0m (scalar): 19
+[2m    │ │ │ └─[0m[2m[[0m[1m5[0m[2m][0m (scalar): 20
+[2m    │ │ ├─[0m[2m[[0m[1m5[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 21
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 22
+[2m    │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 23
+[2m    │ │ │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 24
+[2m    │ │ │ ├─[0m[2m[[0m[1m4[0m[2m][0m (scalar): 25
+[2m    │ │ │ └─[0m[2m[[0m[1m5[0m[2m][0m (scalar): 26
+[2m    │ │ ├─[0m[2m[[0m[1m6[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 27
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 28
+[2m    │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 29
+[2m    │ │ │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 30
+[2m    │ │ │ ├─[0m[2m[[0m[1m4[0m[2m][0m (scalar): 31
+[2m    │ │ │ └─[0m[2m[[0m[1m5[0m[2m][0m (scalar): 32
+[2m    │ │ ├─[0m[2m[[0m[1m7[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 33
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 34
+[2m    │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 35
+[2m    │ │ │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 36
+[2m    │ │ │ ├─[0m[2m[[0m[1m4[0m[2m][0m (scalar): 37
+[2m    │ │ │ └─[0m[2m[[0m[1m5[0m[2m][0m (scalar): 38
+[2m    │ │ ├─[0m[2m[[0m[1m8[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 39
+[2m    │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 40
+[2m    │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 41
+[2m    │ │ │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 42
+[2m    │ │ │ └─[0m[2m[[0m[1m4[0m[2m][0m (scalar): 43
+[2m    │ │ └─[0m[2m[[0m[1m9[0m[2m][0m (sequence)
+[2m    │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 44
+[2m    │ ├─[0m[1mstart_time[0m (tag:stsci.edu:asdf/time/time-1.4.0): 2027-06-01T00:00:00.000
+[2m    │ ├─[0m[1mtruncated[0m (scalar): false
+[2m    │ └─[0m[1mtype[0m (scalar): WFI_IMAGE
+[2m    ├─[0m[1mfile_date[0m (tag:stsci.edu:asdf/time/time-1.4.0)
+[2m    │ ├─[0m[1mbase_format[0m (scalar): datetime
+[2m    │ └─[0m[1mvalue[0m (scalar): 2026-02-17T21:50:27.333
+[2m    ├─[0m[1mfilename[0m (scalar): r0000101001001001001_0001_wfi01_f158_cal.asdf
+[2m    ├─[0m[1mguide_star[0m (mapping)
+[2m    │ ├─[0m[1mepoch[0m (scalar): ?
+[2m    │ ├─[0m[1mguide_mode[0m (scalar): WIM-ACQ
+[2m    │ ├─[0m[1mguide_star_id[0m (scalar): ?
+[2m    │ ├─[0m[1mguide_window_id[0m (scalar): ?
+[2m    │ ├─[0m[1mwindow_xstart[0m (scalar): -999999
+[2m    │ ├─[0m[1mwindow_xstop[0m (scalar): -999983
+[2m    │ ├─[0m[1mwindow_ystart[0m (scalar): -999999
+[2m    │ └─[0m[1mwindow_ystop[0m (scalar): -999983
+[2m    ├─[0m[1minstrument[0m (mapping)
+[2m    │ ├─[0m[1mdetector[0m (scalar): WFI01
+[2m    │ ├─[0m[1mname[0m (scalar): WFI
+[2m    │ └─[0m[1moptical_element[0m (scalar): F158
+[2m    ├─[0m[1mmodel_type[0m (scalar): ImageModel
+[2m    ├─[0m[1mobservation[0m (mapping)
+[2m    │ ├─[0m[1mexecution_plan[0m (scalar): 1
+[2m    │ ├─[0m[1mexposure[0m (scalar): 1
+[2m    │ ├─[0m[1mobservation[0m (scalar): 1
+[2m    │ ├─[0m[1mobservation_id[0m (scalar): 00001010010010010010001
+[2m    │ ├─[0m[1mpass[0m (scalar): 1
+[2m    │ ├─[0m[1mprogram[0m (scalar): 1
+[2m    │ ├─[0m[1msegment[0m (scalar): 1
+[2m    │ ├─[0m[1mvisit[0m (scalar): 1
+[2m    │ ├─[0m[1mvisit_file_activity[0m (scalar): 01
+[2m    │ ├─[0m[1mvisit_file_group[0m (scalar): 0
+[2m    │ ├─[0m[1mvisit_file_sequence[0m (scalar): 1
+[2m    │ ├─[0m[1mvisit_id[0m (scalar): 0000101001001001001
+[2m    │ └─[0m[1mwfi_parallel[0m (scalar): false
+[2m    ├─[0m[1morigin[0m (scalar): STSCI/SOC
+[2m    ├─[0m[1mphotometry[0m (mapping)
+[2m    │ ├─[0m[1mconversion_megajanskys[0m (scalar): 0.7367810113020512
+[2m    │ ├─[0m[1mconversion_megajanskys_uncertainty[0m (scalar): 0.02866405239530676
+[2m    │ └─[0m[1mpixel_area[0m (scalar): 2.8083389953727505e-13
+[2m    ├─[0m[1mpointing[0m (mapping)
+[2m    │ ├─[0m[1mdec_v1[0m (scalar): 66.49600017133261
+[2m    │ ├─[0m[1mpa_aperture[0m (scalar): 0
+[2m    │ ├─[0m[1mpa_v3[0m (scalar): 59.999051896586074
+[2m    │ ├─[0m[1mpointing_engineering_source[0m (scalar): CALCULATED
+[2m    │ ├─[0m[1mra_v1[0m (scalar): 269.99997982111586
+[2m    │ ├─[0m[1mtarget_aperture[0m (scalar): WFI_CEN
+[2m    │ ├─[0m[1mtarget_dec[0m (scalar): 66.0
+[2m    │ └─[0m[1mtarget_ra[0m (scalar): 270.0
+[2m    ├─[0m[1mprd_version[0m (scalar): ?
+[2m    ├─[0m[1mproduct_type[0m (scalar): l2
+[2m    ├─[0m[1mprogram[0m (mapping)
+[2m    │ ├─[0m[1mcategory[0m (scalar): ?
+[2m    │ ├─[0m[1minvestigator_name[0m (scalar): ?
+[2m    │ ├─[0m[1mscience_category[0m (scalar): ?
+[2m    │ ├─[0m[1msubcategory[0m (scalar): CAL
+[2m    │ └─[0m[1mtitle[0m (scalar): ?
+[2m    ├─[0m[1mrcs[0m (mapping)
+[2m    │ ├─[0m[1mactive[0m (scalar): false
+[2m    │ ├─[0m[1mbank[0m (scalar): 1
+[2m    │ ├─[0m[1mcounts[0m (scalar): -999999
+[2m    │ ├─[0m[1melectronics[0m (scalar): A
+[2m    │ └─[0m[1mled[0m (scalar): 1
+[2m    ├─[0m[1mref_file[0m (mapping)
+[2m    │ ├─[0m[1mapcorr[0m (scalar): crds://roman_wfi_apcorr_0002.asdf
+[2m    │ ├─[0m[1marea[0m (scalar): ?
+[2m    │ ├─[0m[1mcrds[0m (mapping)
+[2m    │ │ ├─[0m[1mcontext[0m (scalar): roman_0046.pmap
+[2m    │ │ └─[0m[1mversion[0m (scalar): 13.1.3
+[2m    │ ├─[0m[1mdark[0m (scalar): crds://roman_wfi_dark_0364.asdf
+[2m    │ ├─[0m[1mdarkdecaysignal[0m (scalar): crds://roman_wfi_darkdecaysignal_0001.asdf
+[2m    │ ├─[0m[1mdistortion[0m (scalar): crds://roman_wfi_distortion_0014.asdf
+[2m    │ ├─[0m[1mepsf[0m (scalar): crds://roman_wfi_epsf_0182.asdf
+[2m    │ ├─[0m[1mflat[0m (scalar): crds://roman_wfi_flat_0166.asdf
+[2m    │ ├─[0m[1mgain[0m (scalar): crds://roman_wfi_gain_0022.asdf
+[2m    │ ├─[0m[1mintegralnonlinearity[0m (scalar): crds://roman_wfi_integralnonlinearity_0003.asdf
+[2m    │ ├─[0m[1minverse_linearity[0m (scalar): ?
+[2m    │ ├─[0m[1minverselinearity[0m (scalar): crds://roman_wfi_inverselinearity_0042.asdf
+[2m    │ ├─[0m[1mlinearity[0m (scalar): crds://roman_wfi_linearity_0039.asdf
+[2m    │ ├─[0m[1mmask[0m (scalar): crds://roman_wfi_mask_0030.asdf
+[2m    │ ├─[0m[1mphotom[0m (scalar): crds://roman_wfi_photom_0040.asdf
+[2m    │ ├─[0m[1mreadnoise[0m (scalar): crds://roman_wfi_readnoise_0024.asdf
+[2m    │ ├─[0m[1mrefpix[0m (scalar): crds://roman_wfi_refpix_0013.asdf
+[2m    │ └─[0m[1msaturation[0m (scalar): crds://roman_wfi_saturation_0031.asdf
+[2m    ├─[0m[1msdf_software_version[0m (scalar): ?
+[2m    ├─[0m[1msource_catalog[0m (mapping)
+[2m    │ └─[0m[1mtweakreg_catalog_name[0m (scalar): r0000101001001001001_0001_wfi01_f158_cat.parquet
+[2m    ├─[0m[1mtelescope[0m (scalar): ROMAN
+[2m    ├─[0m[1mvelocity_aberration[0m (mapping)
+[2m    │ ├─[0m[1mdec_reference[0m (scalar): 66.0355095513252
+[2m    │ ├─[0m[1mra_reference[0m (scalar): 269.8325254855773
+[2m    │ └─[0m[1mscale_factor[0m (scalar): 1.0000003455620605
+[2m    ├─[0m[1mvisit[0m (mapping)
+[2m    │ ├─[0m[1mdither[0m (mapping)
+[2m    │ │ ├─[0m[1mexecuted_pattern[0m (sequence)
+[2m    │ │ ├─[0m[1mprimary_name[0m (scalar): ?
+[2m    │ │ └─[0m[1msubpixel_name[0m (scalar): ?
+[2m    │ ├─[0m[1minternal_target[0m (scalar): false
+[2m    │ ├─[0m[1mnexposures[0m (scalar): -999999
+[2m    │ ├─[0m[1mstart_time[0m (tag:stsci.edu:asdf/time/time-1.4.0): 2020-01-01T00:00:00.000
+[2m    │ ├─[0m[1mstatus[0m (scalar): SUCCESSFUL
+[2m    │ └─[0m[1mtype[0m (scalar): GENERAL_ENGINEERING
+[2m    ├─[0m[1mwcs[0m (tag:stsci.edu:gwcs/wcs-1.4.0)
+[2m    │ ├─[0m[1mname[0m (scalar): FIT-LVL2-GAIADR3_S3
+[2m    │ ├─[0m[1mpixel_shape[0m (scalar): null
+[2m    │ └─[0m[1msteps[0m (sequence)
+[2m    │   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:gwcs/step-1.3.0)
+[2m    │   │ ├─[0m[1mframe[0m (tag:stsci.edu:gwcs/frame2d-1.2.0)
+[2m    │   │ │ ├─[0m[1maxes_names[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │ │ ├─[0m[1maxes_order[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │ │ ├─[0m[1maxis_physical_types[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): custom:x
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): custom:y
+[2m    │   │ │ ├─[0m[1mname[0m (scalar): detector
+[2m    │   │ │ └─[0m[1munit[0m (sequence)
+[2m    │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): pixel
+[2m    │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): pixel
+[2m    │   │ └─[0m[1mtransform[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   ├─[0m[1mbounding_box[0m (tag:stsci.edu:asdf/transform/property/bounding_box-1.1.0)
+[2m    │   │   │ ├─[0m[1mignore[0m (sequence)
+[2m    │   │   │ ├─[0m[1mintervals[0m (mapping)
+[2m    │   │   │ │ ├─[0m[1mx0[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -0.5
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 4087.5
+[2m    │   │   │ │ └─[0m[1mx1[0m (sequence)
+[2m    │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -0.5
+[2m    │   │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 4087.5
+[2m    │   │   │ └─[0m[1morder[0m (scalar): F
+[2m    │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[1moffset[0m (scalar): 1.0
+[2m    │   │   │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1moffset[0m (scalar): 1.0
+[2m    │   │   │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │ │ │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │   │ │ ├─[0m[1moffset[0m (scalar): -2044.5
+[2m    │   │   │ │ │ │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │ │ │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │   │   ├─[0m[1moffset[0m (scalar): -2044.5
+[2m    │   │   │ │ │ │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │ │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │ │ │ │ │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │   │ │ │ │   └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): x3
+[2m    │   │   │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │   │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │ │ │   │ │ ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │ │ │   │ │ │ ├─[0m[1msource[0m (scalar): 0
+[2m    │   │   │ │ │   │ │ │   │ │ │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │ │ │   │ │ │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │ │ │   │ │ │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │   │ │ ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ │ │   │ │ ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │ │ │   │ │ └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │ │ │   │   ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │ │ │   │   │ ├─[0m[1msource[0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │   │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │ │ │   │   │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │ │ │   │   │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │   │   ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ │ │   │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │ │ │   │   └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │     │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │     │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │       ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │   │       └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │   │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │   │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │ │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ ├─[0m[1minverse[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │   │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │   │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │ │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │ │ │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │ │ │ │ │ │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │ │ │   ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │   │ │ │ │ │   └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): x3
+[2m    │   │   │ │ │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │   │ │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │ │ │ │   │ │ ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ ├─[0m[1msource[0m (scalar): 2
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │ │   │ │ ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ │ │ │   │ │ ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │ │ │ │   │ │ └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │ │ │ │   │   ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │ │ │ │   │   │ ├─[0m[1msource[0m (scalar): 3
+[2m    │   │   │ │ │   │ │ │ │   │   │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │ │ │ │   │   │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │ │ │ │   │   │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 6
+[2m    │   │   │ │ │   │ │ │ │   │   ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ │ │ │   │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │ │ │ │   │   └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │     │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │     │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │       ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │ │ │ │   │       └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │   │ │ │ │   │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │ │   │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │   │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │ │ │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │   │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │   │ │ │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │ │   ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │   │   │ │   └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): x3
+[2m    │   │   │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │   │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │   │   │ │ ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │   │   │ │ │ ├─[0m[1msource[0m (scalar): 4
+[2m    │   │   │ │ │   │   │   │ │ │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │   │   │ │ │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │   │   │ │ │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │   │ │ ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │   │   │ │ ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │   │   │ │ └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │   │   │   ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │   │   │   │ ├─[0m[1msource[0m (scalar): 5
+[2m    │   │   │ │ │   │   │   │   │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │   │   │   │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │   │   │   │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │   │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │   │   ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │   │   │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │   │   │   └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │     │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │     │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │   │       ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │   │       └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │   │   │   │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │   │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   ├─[0m[1minverse[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │   │   │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │   │   │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │ │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │   │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │ │ │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │   │   │ │ │ │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │ │ │   ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │   │   │ │ │   └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): x3
+[2m    │   │   │ │ │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │   │   │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │   │ │   │ │ ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │   │ │   │ │ │ ├─[0m[1msource[0m (scalar): 6
+[2m    │   │   │ │ │   │   │ │   │ │ │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │   │ │   │ │ │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │   │ │   │ │ │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │ │   │ │ ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │   │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │   │ │   │ │ ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │   │ │   │ │ └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/polynomial-1.2.0)
+[2m    │   │   │ │ │   │   │ │   │   ├─[0m[1mcoefficients[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │   │   │ │   │   │ ├─[0m[1msource[0m (scalar): 7
+[2m    │   │   │ │ │   │   │ │   │   │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │   │   │ │   │   │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │   │   │ │   │   │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │   │   │ │   │   ├─[0m[1mdomain[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │   │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │   │ │   │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   │   │ │   │   └─[0m[1mwindow[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │     │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │     │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │       ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -1
+[2m    │   │   │ │ │   │   │ │   │       └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │   │   │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │   │   │ │   │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │ │   │ └─[0m[2m[[0m[1m3[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │   │   │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │   │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │   │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   │   │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): z0
+[2m    │   │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): z1
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │ │ ├─[0m[1moffset[0m (scalar): 1312.9491452484797
+[2m    │   │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │   ├─[0m[1moffset[0m (scalar): -1040.7853726755036
+[2m    │   │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   ├─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/step-1.3.0)
+[2m    │   │ ├─[0m[1mframe[0m (tag:stsci.edu:gwcs/frame2d-1.2.0)
+[2m    │   │ │ ├─[0m[1maxes_names[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): v2
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): v3
+[2m    │   │ │ ├─[0m[1maxes_order[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │ │ ├─[0m[1maxis_physical_types[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): custom:v2
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): custom:v3
+[2m    │   │ │ ├─[0m[1mname[0m (scalar): v2v3
+[2m    │   │ │ └─[0m[1munit[0m (sequence)
+[2m    │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): arcsec
+[2m    │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): arcsec
+[2m    │   │ └─[0m[1mtransform[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ ├─[0m[1mfactor[0m (scalar): 1.0000003455620605
+[2m    │   │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ ├─[0m[1mname[0m (scalar): dva_scale_v2
+[2m    │   │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │   ├─[0m[1mfactor[0m (scalar): 1.0000003455620605
+[2m    │   │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   ├─[0m[1mname[0m (scalar): dva_scale_v3
+[2m    │   │   │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │ │ ├─[0m[1mname[0m (scalar): dva_v2_shift
+[2m    │   │   │   │ │ ├─[0m[1moffset[0m (scalar): -0.0004537054119925875
+[2m    │   │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/shift-1.3.0)
+[2m    │   │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │   ├─[0m[1mname[0m (scalar): dva_v3_shift
+[2m    │   │   │   │   ├─[0m[1moffset[0m (scalar): 0.0003596559379428446
+[2m    │   │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   ├─[0m[1mname[0m (scalar): DVA_Correction
+[2m    │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   ├─[0m[2m[[0m[1m2[0m[2m][0m (tag:stsci.edu:gwcs/step-1.3.0)
+[2m    │   │ ├─[0m[1mframe[0m (tag:stsci.edu:gwcs/frame2d-1.2.0)
+[2m    │   │ │ ├─[0m[1maxes_names[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): v2
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): v3
+[2m    │   │ │ ├─[0m[1maxes_order[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │ │ ├─[0m[1maxis_physical_types[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): custom:v2
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): custom:v3
+[2m    │   │ │ ├─[0m[1mname[0m (scalar): v2v3vacorr
+[2m    │   │ │ └─[0m[1munit[0m (sequence)
+[2m    │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): arcsec
+[2m    │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): arcsec
+[2m    │   │ └─[0m[1mtransform[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mfactor[0m (scalar): 0.0002777777777777778
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mname[0m (scalar): arcsec_to_deg_1D
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mfactor[0m (scalar): 0.0002777777777777778
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): arcsec_to_deg_1D
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mname[0m (scalar): arcsec_to_deg_2D
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/spherical_cartesian-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): s2c
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mtransform_type[0m (scalar): spherical_to_cartesian
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1mwrap_lon_at[0m (scalar): 180
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.1.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mangles[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0.3647080959023555
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0.28910704796541764
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 59.846679364670365
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1maxes_order[0m (scalar): zyx
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): det_to_optic_axis
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1mrotation_type[0m (scalar): cartesian
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/divide-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ ├─[0m[1mname[0m (scalar): xyz
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1mn_inputs[0m (scalar): 3
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1mname[0m (scalar): xxx
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │     ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │     └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   ├─[0m[1mname[0m (scalar): xtyt
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): Cartesian 3D to TAN
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/affine-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │   ├─[0m[1mmatrix[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ ├─[0m[1msource[0m (scalar): 8
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): tp_affine
+[2m    │   │   │ │ │ │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │   └─[0m[1mtranslation[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │     ├─[0m[1msource[0m (scalar): 9
+[2m    │   │   │ │ │ │ │ │ │ │ │     ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │ │ │ │ │ │ │     ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │ │ │ │ │ │ │     └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │       └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │   │ │ ├─[0m[1mname[0m (scalar): xtyt2xyz
+[2m    │   │   │ │ │ │ │ │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/constant-1.5.0)
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ ├─[0m[1mdimensions[0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ ├─[0m[1mname[0m (scalar): one
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │   │   │ │ └─[0m[1mvalue[0m (scalar): 1.0
+[2m    │   │   │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/identity-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   │   │   ├─[0m[1mn_dims[0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │   │   │   ├─[0m[1mname[0m (scalar): I(2D)
+[2m    │   │   │ │ │ │ │ │ │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │   │     ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │     └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): TAN to cartesian 3D
+[2m    │   │   │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │     ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │     └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.1.0)
+[2m    │   │   │ │ │ │ │   ├─[0m[1mangles[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -59.846679364670365
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): -0.28910704796541764
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): -0.3647080959023555
+[2m    │   │   │ │ │ │ │   ├─[0m[1maxes_order[0m (scalar): xyz
+[2m    │   │   │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │   ├─[0m[1mname[0m (scalar): optic_axis_to_det
+[2m    │   │   │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │   └─[0m[1mrotation_type[0m (scalar): cartesian
+[2m    │   │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/spherical_cartesian-1.3.0)
+[2m    │   │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   ├─[0m[1mname[0m (scalar): c2s
+[2m    │   │   │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ │ │   ├─[0m[1mtransform_type[0m (scalar): cartesian_to_spherical
+[2m    │   │   │ │ │   └─[0m[1mwrap_lon_at[0m (scalar): 180
+[2m    │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │   │ │ ├─[0m[1mfactor[0m (scalar): 3600.0
+[2m    │   │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │ │ ├─[0m[1mname[0m (scalar): deg_to_arcsec_1D
+[2m    │   │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │   │   ├─[0m[1mfactor[0m (scalar): 3600.0
+[2m    │   │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │   ├─[0m[1mname[0m (scalar): deg_to_arcsec_1D
+[2m    │   │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │   ├─[0m[1mname[0m (scalar): deg_to_arcsec_2D
+[2m    │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   ├─[0m[1minverse[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mfactor[0m (scalar): 0.0002777777777777778
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mname[0m (scalar): arcsec_to_deg_1D
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mfactor[0m (scalar): 0.0002777777777777778
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): arcsec_to_deg_1D
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1mname[0m (scalar): arcsec_to_deg_2D
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/spherical_cartesian-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): s2c
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mtransform_type[0m (scalar): spherical_to_cartesian
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1mwrap_lon_at[0m (scalar): 180
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.1.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mangles[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0.3647080959023555
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0.28910704796541764
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 59.846679364670365
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1maxes_order[0m (scalar): zyx
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): det_to_optic_axis
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1mrotation_type[0m (scalar): cartesian
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/divide-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ ├─[0m[1mname[0m (scalar): xyz
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1mn_inputs[0m (scalar): 3
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   ├─[0m[1mname[0m (scalar): xxx
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │     ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │     └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   ├─[0m[1mname[0m (scalar): xtyt
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): Cartesian 3D to TAN
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/affine-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   ├─[0m[1mmatrix[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ ├─[0m[1msource[0m (scalar): 10
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): tp_affine_inv
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ │ │   └─[0m[1mtranslation[0m (tag:stsci.edu:asdf/core/ndarray-1.1.0)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │     ├─[0m[1msource[0m (scalar): 11
+[2m    │   │   │ │ │ │ │ │ │ │ │ │     ├─[0m[1mdatatype[0m (scalar): float64
+[2m    │   │   │ │ │ │ │ │ │ │ │ │     ├─[0m[1mbyteorder[0m (scalar): little
+[2m    │   │   │ │ │ │ │ │ │ │ │ │     └─[0m[1mshape[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │       └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/remap_axes-1.4.0)
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ ├─[0m[1mmapping[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ ├─[0m[1mname[0m (scalar): xtyt2xyz
+[2m    │   │   │ │ │ │ │ │ │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x2
+[2m    │   │   │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/constant-1.5.0)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ ├─[0m[1mdimensions[0m (scalar): 1
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ ├─[0m[1mname[0m (scalar): one
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ │ └─[0m[1mvalue[0m (scalar): 1.0
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/identity-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   │   │   ├─[0m[1mn_dims[0m (scalar): 2
+[2m    │   │   │ │ │ │ │ │ │ │   │   │   ├─[0m[1mname[0m (scalar): I(2D)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │   │     ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │     └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): TAN to cartesian 3D
+[2m    │   │   │ │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ │     ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │     └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.1.0)
+[2m    │   │   │ │ │ │ │ │   ├─[0m[1mangles[0m (sequence)
+[2m    │   │   │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -59.846679364670365
+[2m    │   │   │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): -0.28910704796541764
+[2m    │   │   │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): -0.3647080959023555
+[2m    │   │   │ │ │ │ │ │   ├─[0m[1maxes_order[0m (scalar): xyz
+[2m    │   │   │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │   ├─[0m[1mname[0m (scalar): optic_axis_to_det
+[2m    │   │   │ │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │ │   └─[0m[1mrotation_type[0m (scalar): cartesian
+[2m    │   │   │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/spherical_cartesian-1.3.0)
+[2m    │   │   │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │   ├─[0m[1mname[0m (scalar): c2s
+[2m    │   │   │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ │ │ │   ├─[0m[1mtransform_type[0m (scalar): cartesian_to_spherical
+[2m    │   │   │ │ │ │   └─[0m[1mwrap_lon_at[0m (scalar): 180
+[2m    │   │   │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │   │ │ ├─[0m[1mfactor[0m (scalar): 3600.0
+[2m    │   │   │ │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │   │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │   │ │ ├─[0m[1mname[0m (scalar): deg_to_arcsec_1D
+[2m    │   │   │ │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │   │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │   │   ├─[0m[1mfactor[0m (scalar): 3600.0
+[2m    │   │   │ │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │   │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │   │   ├─[0m[1mname[0m (scalar): deg_to_arcsec_1D
+[2m    │   │   │ │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │   │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │   ├─[0m[1mname[0m (scalar): deg_to_arcsec_2D
+[2m    │   │   │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ ├─[0m[1mname[0m (scalar): Inverse JWST tangent-plane linear correction. v1
+[2m    │   │   │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   ├─[0m[1mname[0m (scalar): JWST tangent-plane linear correction. v1
+[2m    │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   ├─[0m[2m[[0m[1m3[0m[2m][0m (tag:stsci.edu:gwcs/step-1.3.0)
+[2m    │   │ ├─[0m[1mframe[0m (tag:stsci.edu:gwcs/frame2d-1.2.0)
+[2m    │   │ │ ├─[0m[1maxes_names[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): v2
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): v3
+[2m    │   │ │ ├─[0m[1maxes_order[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │   │ │ ├─[0m[1maxis_physical_types[0m (sequence)
+[2m    │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): custom:v2
+[2m    │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): custom:v3
+[2m    │   │ │ ├─[0m[1mname[0m (scalar): v2v3corr
+[2m    │   │ │ └─[0m[1munit[0m (sequence)
+[2m    │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): arcsec
+[2m    │   │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): arcsec
+[2m    │   │ └─[0m[1mtransform[0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/compose-1.3.0)
+[2m    │   │   │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/concatenate-1.3.0)
+[2m    │   │   │ │ │ │ │ │ ├─[0m[1mforward[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[1mfactor[0m (scalar): 0.0002777777777777778
+[2m    │   │   │ │ │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │ │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ │   └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/scale-1.3.0)
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1mfactor[0m (scalar): 0.0002777777777777778
+[2m    │   │   │ │ │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │   │ └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │ │ │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │     └─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): y0
+[2m    │   │   │ │ │ │ │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y1
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/spherical_cartesian-1.3.0)
+[2m    │   │   │ │ │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │ │ │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ │ │   ├─[0m[1mtransform_type[0m (scalar): spherical_to_cartesian
+[2m    │   │   │ │ │ │ │   └─[0m[1mwrap_lon_at[0m (scalar): 180
+[2m    │   │   │ │ │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/transform/rotate_sequence_3d-1.1.0)
+[2m    │   │   │ │ │   ├─[0m[1mangles[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0.3647080959023555
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0.28910704796541764
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m2[0m[2m][0m (scalar): 59.846679364670365
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m3[0m[2m][0m (scalar): 66.0355095513252
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m4[0m[2m][0m (scalar): -269.8325254855773
+[2m    │   │   │ │ │   ├─[0m[1maxes_order[0m (scalar): zyxyz
+[2m    │   │   │ │ │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │ │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │ │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ │ │   └─[0m[1mrotation_type[0m (scalar): cartesian
+[2m    │   │   │ │ ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   │ │ └─[0m[1moutputs[0m (sequence)
+[2m    │   │   │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │ │   ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │ │   └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:gwcs/spherical_cartesian-1.3.0)
+[2m    │   │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m1[0m[2m][0m (scalar): y
+[2m    │   │   │   │ └─[0m[2m[[0m[1m2[0m[2m][0m (scalar): z
+[2m    │   │   │   ├─[0m[1moutputs[0m (sequence)
+[2m    │   │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   │   │   ├─[0m[1mtransform_type[0m (scalar): cartesian_to_spherical
+[2m    │   │   │   └─[0m[1mwrap_lon_at[0m (scalar): 360
+[2m    │   │   ├─[0m[1minputs[0m (sequence)
+[2m    │   │   │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): x0
+[2m    │   │   │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): x1
+[2m    │   │   ├─[0m[1mname[0m (scalar): v23tosky
+[2m    │   │   └─[0m[1moutputs[0m (sequence)
+[2m    │   │     ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │   │     └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │   └─[0m[2m[[0m[1m4[0m[2m][0m (tag:stsci.edu:gwcs/step-1.3.0)
+[2m    │     ├─[0m[1mframe[0m (tag:stsci.edu:gwcs/celestial_frame-1.2.0)
+[2m    │     │ ├─[0m[1maxes_names[0m (sequence)
+[2m    │     │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): lon
+[2m    │     │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): lat
+[2m    │     │ ├─[0m[1maxes_order[0m (sequence)
+[2m    │     │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0
+[2m    │     │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1
+[2m    │     │ ├─[0m[1maxis_physical_types[0m (sequence)
+[2m    │     │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): pos.eq.ra
+[2m    │     │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): pos.eq.dec
+[2m    │     │ ├─[0m[1mname[0m (scalar): world
+[2m    │     │ ├─[0m[1mreference_frame[0m (tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0)
+[2m    │     │ │ └─[0m[1mframe_attributes[0m (mapping)
+[2m    │     │ └─[0m[1munit[0m (sequence)
+[2m    │     │   ├─[0m[2m[[0m[1m0[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): deg
+[2m    │     │   └─[0m[2m[[0m[1m1[0m[2m][0m (tag:stsci.edu:asdf/unit/unit-1.0.0): deg
+[2m    │     └─[0m[1mtransform[0m (scalar): null
+[2m    ├─[0m[1mwcs_fit_results[0m (mapping)
+[2m    │ ├─[0m[1m<rot>[0m (scalar): 2.844338799936102e-05
+[2m    │ ├─[0m[1m<scale>[0m (scalar): 1.0
+[2m    │ ├─[0m[1mcenter[0m (sequence)
+[2m    │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -4.380064906371088
+[2m    │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): -21.04270513531622
+[2m    │ ├─[0m[1mfitgeom[0m (scalar): rshift
+[2m    │ ├─[0m[1mmae[0m (scalar): 0.0017111099766289842
+[2m    │ ├─[0m[1mmatrix[0m (sequence)
+[2m    │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (sequence)
+[2m    │ │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0.9999999999998768
+[2m    │ │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 4.964307710110721e-07
+[2m    │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (sequence)
+[2m    │ │   ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): -4.964307710110721e-07
+[2m    │ │   └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 0.9999999999998768
+[2m    │ ├─[0m[1mnmatches[0m (scalar): 107
+[2m    │ ├─[0m[1mproper[0m (scalar): true
+[2m    │ ├─[0m[1mproper_rot[0m (scalar): 2.844338799936102e-05
+[2m    │ ├─[0m[1mrmse[0m (scalar): 0.0020857122860393922
+[2m    │ ├─[0m[1mrot[0m (sequence)
+[2m    │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 2.844338799936102e-05
+[2m    │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 2.844338799936102e-05
+[2m    │ ├─[0m[1mscale[0m (sequence)
+[2m    │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 1.0
+[2m    │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 1.0
+[2m    │ ├─[0m[1mshift[0m (sequence)
+[2m    │ │ ├─[0m[2m[[0m[1m0[0m[2m][0m (scalar): 0.0002720710784867062
+[2m    │ │ └─[0m[2m[[0m[1m1[0m[2m][0m (scalar): 6.3471277370164e-05
+[2m    │ ├─[0m[1mskew[0m (scalar): 0.0
+[2m    │ └─[0m[1mstatus[0m (scalar): SUCCESS
+[2m    └─[0m[1mwcsinfo[0m (mapping)
+[2m      ├─[0m[1maperture_name[0m (scalar): WFI01_FULL
+[2m      ├─[0m[1mdec_ref[0m (scalar): 66.0355095513252
+[2m      ├─[0m[1mra_ref[0m (scalar): 269.8325254855773
+[2m      ├─[0m[1mroll_ref[0m (scalar): 59.846679364670365
+[2m      ├─[0m[1ms_region[0m (scalar): POLYGON ICRS  269.986946024 65.974265006 269.986740333 66.097228...
+[2m      ├─[0m[1mv2_ref[0m (scalar): 1312.9491452484797
+[2m      ├─[0m[1mv3_ref[0m (scalar): -1040.7853726755036
+[2m      ├─[0m[1mv3yangle[0m (scalar): -60.0
+[2m      └─[0m[1mvparity[0m (scalar): -1
+[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #0                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 288                            [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: fba99be39b932d3bce1f0136c34b1f4c     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #1                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 288                            [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: 6e1b06e0e25ef71ea7387a0db4491ee1     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #2                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 288                            [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: 982d757270ffb7feee14cec2fb4b659f     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #3                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 288                            [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 288                                 [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: 0e9610a9d873ce4878ac6bc5e1caeae9     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #4                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 32                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: af3ceb00c54949aff4f05b5018125952     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #5                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 32                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: ef5bbd965f6479d44b1934de0eb9a38e     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #6                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 32                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: af3ceb00c54949aff4f05b5018125952     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #7                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 32                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: ef5bbd965f6479d44b1934de0eb9a38e     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #8                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 32                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: 9141dd1409ba2d6bbdf93f8a7492d4e5     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                    Block #9                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 16                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 16                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 16                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: c16606918f59cc6d84af7369095678cb     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                   Block #10                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 32                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 32                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: 40907350bb128a46b81e1c735777f4fd     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m[2m┌────────────────────────────────────────────────┐
+[0m[2m│[0m                   Block #11                    [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m flags: 0x00000000                              [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m compression: ""                                [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m allocated_size: 16                             [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m used_size: 16                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m data_size: 16                                  [2m│[0m
+[2m├────────────────────────────────────────────────┤
+[0m[2m│[0m checksum: 1ceee070a214b933d81aa5f9e2532069     [2m│[0m
+[2m└────────────────────────────────────────────────┘
+[0m

--- a/tests/fixtures/roman_l2_wcs.asdf
+++ b/tests/fixtures/roman_l2_wcs.asdf
@@ -1,0 +1,980 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.6.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: The ASDF Developers, homepage: 'http://github.com/asdf-format/asdf',
+  name: asdf, version: 5.1.0}
+history:
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://stsci.edu/datamodels/roman/extensions/static-1.1.0
+    manifest_software: !core/software-1.0.0 {name: rad, version: 0.30.0}
+    software: !core/software-1.0.0 {name: roman_datamodels, version: 0.30.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/astronomy/gwcs/extensions/gwcs-1.4.0
+    manifest_software: !core/software-1.0.0 {name: asdf_wcs_schemas, version: 0.5.0}
+    software: !core/software-1.0.0 {name: gwcs, version: 1.0.3}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/transform/extensions/transform-1.6.0
+    manifest_software: !core/software-1.0.0 {name: asdf_transform_schemas, version: 0.6.0}
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.10.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/core/extensions/core-1.6.0
+    manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+    software: !core/software-1.0.0 {name: asdf, version: 5.1.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://astropy.org/astropy/extensions/units-1.3.0
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.10.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/astronomy/extensions/astronomy-1.2.0
+    manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.5.0}
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.10.0}
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension._manifest.ManifestExtension
+    extension_uri: asdf://asdf-format.org/astronomy/coordinates/extensions/coordinates-1.0.0
+    manifest_software: !core/software-1.0.0 {name: asdf_coordinates_schemas, version: 0.5.1}
+    software: !core/software-1.0.0 {name: asdf-astropy, version: 0.10.0}
+roman:
+  meta:
+    cal_logs: ['2026-02-17T21:46:21.496Z :: stpipe.step :: INFO :: Step ExposurePipeline
+        running with args (''data/r0000101001001001001_0001_wfi01_f158_uncal.asdf'',).',
+      "2026-02-17T21:46:21.505Z :: stpipe.step :: INFO :: Step ExposurePipeline parameters
+        are:\n  pre_hooks: []\n  post_hooks: []\n  output_file: None\n  output_dir:
+        None\n  output_ext: .asdf\n  output_use_model: False\n  output_use_index:
+        True\n  save_results: True\n  skip: False\n  suffix: cal\n  search_output_file:
+        True\n  input_dir: data\n  update_version: False\n  steps:\n    dq_init:\n
+        \     pre_hooks: []\n      post_hooks: []\n      output_file: None\n      output_dir:
+        None\n      output_ext: .asdf\n      output_use_model: False\n      output_use_index:
+        True\n      save_results: False\n      skip: False\n      suffix: None\n      search_output_file:
+        True\n      input_dir: data\n      update_version: False\n    saturation:\n
+        \     pre_hooks: []\n      post_hooks: []\n      output_file: None\n      output_dir:
+        None\n      output_ext: .asdf\n      output_use_model: False\n      output_use_index:
+        True\n      save_results: False\n      skip: False\n      suffix: None\n      search_output_file:
+        True\n      input_dir: data\n      update_version: False\n    refpix:\n      pre_hooks:
+        []\n      post_hooks: []\n      output_file: None\n      output_dir: None\n
+        \     output_ext: .asdf\n      output_use_model: False\n      output_use_index:
+        True\n      save_results: False\n      skip: False\n      suffix: None\n      search_output_file:
+        True\n      input_dir: data\n      update_version: False\n      remove_offset:
+        True\n      remove_trends: True\n      cosine_interpolate: True\n      fft_interpolate:
+        True\n    dark_decay:\n      pre_hooks: []\n      post_hooks: []\n      output_file:
+        None\n      output_dir: None\n      output_ext: .asdf\n      output_use_model:
+        False\n      output_use_index: True\n      save_results: False\n      skip:
+        False\n      suffix: None\n      search_output_file: True\n      input_dir:
+        data\n      update_version: False\n    wfi18_transient:\n      pre_hooks:
+        []\n      post_hooks: []\n      output_file: None\n      output_dir: None\n
+        \     output_ext: .asdf\n      output_use_model: False\n      output_use_index:
+        True\n      save_results: False\n      skip: False\n      suffix: None\n      search_output_file:
+        True\n      input_dir: data\n      update_version: False\n      mask_rows:
+        False\n    linearity:\n      pre_hooks: []\n      post_hooks: []\n      output_file:
+        None\n      output_dir: None\n      output_ext: .asdf\n      output_use_model:
+        False\n      output_use_index: True\n      save_results: False\n      skip:
+        False\n      suffix: None\n      search_output_file: True\n      input_dir:
+        data\n      update_version: False\n    dark_current:\n      pre_hooks: []\n
+        \     post_hooks: []\n      output_file: None\n      output_dir: None\n      output_ext:
+        .asdf\n      output_use_model: False\n      output_use_index: True\n      save_results:
+        False\n      skip: False\n      suffix: None\n      search_output_file: True\n
+        \     input_dir: data\n      update_version: False\n      dark_output: None\n
+        \   rampfit:\n      pre_hooks: []\n      post_hooks: []\n      output_file:
+        None\n      output_dir: None\n      output_ext: .asdf\n      output_use_model:
+        False\n      output_use_index: True\n      save_results: False\n      skip:
+        False\n      suffix: rampfit\n      search_output_file: True\n      input_dir:
+        data\n      update_version: False\n      algorithm: likely\n      use_ramp_jump_detection:
+        True\n      threshold_intercept: None\n      threshold_constant: None\n      include_var_rnoise:
+        False\n      maximum_cores: '1'\n      expand_large_events: False\n      min_sat_area:
+        1.0\n      min_jump_area: 6.0\n      expand_factor: 1.9\n      sat_required_snowball:
+        True\n      min_sat_radius_extend: 0.5\n      sat_expand: 2\n      edge_size:
+        0\n    assign_wcs:\n      pre_hooks: []\n      post_hooks: []\n      output_file:
+        None\n      output_dir: None\n      output_ext: .asdf\n      output_use_model:
+        False\n      output_use_index: True\n      save_results: False\n      skip:
+        False\n      suffix: None\n      search_output_file: True\n      input_dir:
+        data\n      update_version: False\n    flatfield:\n      pre_hooks: []\n      post_hooks:
+        []\n      output_file: None\n      output_dir: None\n      output_ext: .asdf\n
+        \     output_use_model: False\n      output_use_index: True\n      save_results:
+        False\n      skip: False\n      suffix: None\n      search_output_file: True\n
+        \     input_dir: data\n      update_version: False\n      include_var_flat:
+        False\n    photom:\n      pre_hooks: []\n      post_hooks: []\n      output_file:
+        None\n      output_dir: None\n      output_ext: .asdf\n      output_use_model:
+        False\n      output_use_index: True\n      save_results: False\n      skip:
+        False\n      suffix: None\n      search_output_file: True\n      input_dir:
+        data\n      update_version: False\n    source_catalog:\n      pre_hooks: []\n
+        \     post_hooks: []\n      output_file: None\n      output_dir: None\n      output_ext:
+        .asdf\n      output_use_model: False\n      output_use_index: True\n      save_results:
+        False\n      skip: False\n      suffix: cat\n      search_output_file: True\n
+        \     input_dir: data\n      update_version: False\n      bkg_boxsize: 1000\n
+        \     kernel_fwhm: 2.0\n      snr_threshold: 3.0\n      npixels: 25\n      deblend:
+        False\n      fit_psf: True\n      forced_segmentation: ''\n    tweakreg:\n
+        \     pre_hooks: []\n      post_hooks: []\n      output_file: None\n      output_dir:
+        None\n      output_ext: .asdf\n      output_use_model: True\n      output_use_index:
+        True\n      save_results: False\n      skip: False\n      suffix: None\n      search_output_file:
+        True\n      input_dir: data\n      update_version: False\n      use_custom_catalogs:
+        False\n      catalog_format: ascii.ecsv\n      catfile: ''\n      catalog_path:
+        ''\n      enforce_user_order: False\n      expand_refcat: False\n      minobj:
+        15\n      searchrad: 2.0\n      use2dhist: True\n      separation: 1.0\n      tolerance:
+        0.7\n      fitgeometry: rshift\n      nclip: 3\n      sigma: 3.0\n      abs_refcat:
+        GAIADR3_S3\n      save_abs_catalog: False\n      abs_minobj: 15\n      abs_searchrad:
+        6.0\n      abs_use2dhist: True\n      abs_separation: 1.0\n      abs_tolerance:
+        0.7\n      abs_fitgeometry: rshift\n      abs_nclip: 3\n      abs_sigma: 3.0\n
+        \     update_source_catalog_coordinates: False\n      vo_timeout: 1200.0",
+      '2026-02-17T21:46:22.548Z :: stpipe.pipeline :: INFO :: Prefetching reference
+        files for dataset: ''r0000101001001001001_0001_wfi01_f158_uncal.asdf'' reftypes
+        = [''apcorr'', ''dark'', ''darkdecaysignal'', ''distortion'', ''flat'', ''gain'',
+        ''integralnonlinearity'', ''inverselinearity'', ''linearity'', ''mask'', ''photom'',
+        ''readnoise'', ''refpix'', ''saturation'']', '2026-02-17T21:46:22.550Z ::
+        stpipe.pipeline :: INFO :: Prefetch for APCORR reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_apcorr_0002.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for DARK reference
+        file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_dark_0364.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for DARKDECAYSIGNAL
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_darkdecaysignal_0001.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for DISTORTION
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_distortion_0014.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for FLAT reference
+        file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_flat_0166.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for GAIN reference
+        file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_gain_0022.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for INTEGRALNONLINEARITY
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_integralnonlinearity_0003.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for INVERSELINEARITY
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_inverselinearity_0042.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for LINEARITY
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_linearity_0039.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for MASK reference
+        file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_mask_0030.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for PHOTOM
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_photom_0040.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for READNOISE
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_readnoise_0024.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for REFPIX
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_refpix_0013.asdf''.',
+      '2026-02-17T21:46:22.551Z :: stpipe.pipeline :: INFO :: Prefetch for SATURATION
+        reference file is ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_saturation_0031.asdf''.',
+      '2026-02-17T21:46:22.551Z :: romancal.pipeline.exposure_pipeline :: INFO ::
+        Starting Roman exposure calibration pipeline ...', '2026-02-17T21:46:22.622Z
+        :: stpipe.step :: INFO :: Step dq_init running with args (<roman_datamodels.datamodels._datamodels.ScienceRawModel
+        object at 0x10d7d9760>,).', '2026-02-17T21:46:22.914Z :: romancal.dq_init.dq_init_step
+        :: INFO :: Flagging rows from: -999999 to -999983 as affected by guide window
+        read', '2026-02-17T21:46:22.997Z :: stpipe.step :: INFO :: Step dq_init done',
+      '2026-02-17T21:46:23.033Z :: stpipe.step :: INFO :: Step saturation running
+        with args (<roman_datamodels.datamodels._datamodels.RampModel object at 0x10c85b100>,).',
+      '2026-02-17T21:46:23.034Z :: romancal.saturation.saturation_step :: INFO ::
+        Using SATURATION reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_saturation_0031.asdf',
+      '2026-02-17T21:46:24.781Z :: stcal.saturation.saturation :: INFO :: Detected
+        77610 saturated pixels', '2026-02-17T21:46:24.833Z :: stcal.saturation.saturation
+        :: INFO :: Detected 65730 A/D floor pixels', '2026-02-17T21:46:24.850Z ::
+        stpipe.step :: INFO :: Step saturation done', '2026-02-17T21:46:24.925Z ::
+        stpipe.step :: INFO :: Step refpix running with args (<roman_datamodels.datamodels._datamodels.RampModel
+        object at 0x10c85b100>,).', '2026-02-17T21:46:24.925Z :: romancal.refpix.refpix_step
+        :: DEBUG :: Opening the science data: <roman_datamodels.datamodels._datamodels.RampModel
+        object at 0x10c85b100>', '2026-02-17T21:46:24.926Z :: romancal.refpix.refpix_step
+        :: DEBUG :: Opening the reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_refpix_0013.asdf',
+      '2026-02-17T21:46:24.942Z :: romancal.refpix.refpix_step :: DEBUG :: Running
+        the reference pixel correction', '2026-02-17T21:46:24.942Z :: romancal.refpix.refpix
+        :: DEBUG :: Reading data from datamodel into single array', '2026-02-17T21:46:25.133Z
+        :: romancal.refpix.refpix :: DEBUG :: Removed the general offset from data,
+        to be re-applied later.', '2026-02-17T21:46:25.712Z :: romancal.refpix.refpix
+        :: DEBUG :: Removed boundary trends (in time) from data.', "2026-02-17T21:46:25.726Z
+        :: py.warnings :: WARNING :: /Users/bgraham/.pyenv/versions/3.12.4/envs/b21_moc_files/lib/python3.12/site-packages/romancal/refpix/data.py:398:
+        RuntimeWarning: invalid value encountered in divide\n  kern = (cov / mask_conv).reshape(rows,
+        columns)\n", '2026-02-17T21:46:25.874Z :: romancal.refpix.refpix :: DEBUG
+        :: Cosine interpolated the reference pixels.', '2026-02-17T21:46:26.196Z ::
+        romancal.refpix.refpix :: DEBUG :: FFT interpolated the reference pixel pads.',
+      '2026-02-17T21:46:29.314Z :: romancal.refpix.refpix :: DEBUG :: Applied reference
+        pixel correction', '2026-02-17T21:46:29.395Z :: romancal.refpix.refpix ::
+        DEBUG :: Re-applied the general offset (if removed) to the data.', '2026-02-17T21:46:29.417Z
+        :: romancal.refpix.refpix :: DEBUG :: Updated the datamodel with the corrected
+        data.', '2026-02-17T21:46:29.441Z :: stpipe.step :: INFO :: Step refpix done',
+      '2026-02-17T21:46:29.476Z :: stpipe.step :: INFO :: Step dark_decay running
+        with args (<roman_datamodels.datamodels._datamodels.RampModel object at 0x10c85b100>,).',
+      '2026-02-17T21:46:29.477Z :: romancal.dark_decay.dark_decay_step :: INFO ::
+        Using DARKDECAYSIGNAL reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_darkdecaysignal_0001.asdf',
+      '2026-02-17T21:46:34.587Z :: stpipe.step :: INFO :: Step dark_decay done', '2026-02-17T21:46:34.621Z
+        :: stpipe.step :: INFO :: Step wfi18_transient running with args (<roman_datamodels.datamodels._datamodels.RampModel
+        object at 0x10c85b100>,).', '2026-02-17T21:46:34.621Z :: stpipe.step :: INFO
+        :: Step wfi18_transient done', '2026-02-17T21:46:34.651Z :: stpipe.step ::
+        INFO :: Step linearity running with args (<roman_datamodels.datamodels._datamodels.RampModel
+        object at 0x10c85b100>,).', '2026-02-17T21:46:34.655Z :: romancal.linearity.linearity_step
+        :: INFO :: Using LINEARITY reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_linearity_0039.asdf',
+      '2026-02-17T21:46:34.655Z :: romancal.linearity.linearity_step :: INFO :: Using
+        INVERSELINEARITY reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_inverselinearity_0042.asdf',
+      '2026-02-17T21:46:34.655Z :: romancal.linearity.linearity_step :: INFO :: Using
+        INTEGRALNONLINEARITY reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_integralnonlinearity_0003.asdf',
+      "2026-02-17T21:46:41.801Z :: py.warnings :: WARNING :: /Users/bgraham/.pyenv/versions/3.12.4/envs/b21_moc_files/lib/python3.12/site-packages/stcal/linearity/linearity.py:528:
+        RuntimeWarning: overflow encountered in cast\n  data[i] = np.where(resultant_saturated,
+        data[i], corrected_resultant)\n", '2026-02-17T21:47:46.010Z :: romancal.linearity.linearity_step
+        :: WARNING :: Flagged 630 spurious values outside remotely plausible range.',
+      '2026-02-17T21:47:46.031Z :: stpipe.step :: INFO :: Step linearity done', '2026-02-17T21:47:46.068Z
+        :: stpipe.step :: INFO :: Step rampfit running with args (<roman_datamodels.datamodels._datamodels.RampModel
+        object at 0x10c85b100>,).', '2026-02-17T21:47:46.071Z :: romancal.ramp_fitting.ramp_fit_step
+        :: INFO :: Using READNOISE reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_readnoise_0024.asdf',
+      '2026-02-17T21:47:46.084Z :: romancal.ramp_fitting.ramp_fit_step :: INFO ::
+        Using GAIN reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_gain_0022.asdf',
+      '2026-02-17T21:47:46.094Z :: romancal.ramp_fitting.ramp_fit_step :: INFO ::
+        Number of resultants: 10 ', '2026-02-17T21:49:19.590Z :: romancal.ramp_fitting.ramp_fit_step
+        :: INFO :: Number of resultants: 10 ', "2026-02-17T21:49:19.875Z :: py.warnings
+        :: WARNING :: /Users/bgraham/.pyenv/versions/3.12.4/envs/b21_moc_files/lib/python3.12/site-packages/romancal/ramp_fitting/ramp_fit_step.py:366:
+        RuntimeWarning: overflow encountered in cast\n  im.dumo = (slopes_alt[4:-4,
+        4:-4] - im.data).astype(\"float16\")\n", '2026-02-17T21:49:19.887Z :: stpipe.step
+        :: INFO :: Step rampfit done', '2026-02-17T21:49:19.934Z :: stpipe.step ::
+        INFO :: Step dark_current running with args (<roman_datamodels.datamodels._datamodels.ImageModel
+        object at 0x10d8071a0>,).', '2026-02-17T21:49:19.936Z :: romancal.dark_current.dark_current_step
+        :: INFO :: Using DARK reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_dark_0364.asdf',
+      '2026-02-17T21:49:20.066Z :: stpipe.step :: INFO :: Step dark_current done',
+      '2026-02-17T21:49:20.095Z :: stpipe.step :: INFO :: Step assign_wcs running
+        with args (<roman_datamodels.datamodels._datamodels.ImageModel object at 0x10d8071a0>,).',
+      '2026-02-17T21:49:20.095Z :: romancal.assign_wcs.assign_wcs_step :: INFO ::
+        reftype, distortion', '2026-02-17T21:49:20.096Z :: romancal.assign_wcs.assign_wcs_step
+        :: INFO :: Using reference files: {''distortion'': ''/Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_distortion_0014.asdf''}
+        for assign_wcs', '2026-02-17T21:49:20.136Z :: stcal.alignment.util :: INFO
+        :: Update S_REGION to POLYGON ICRS  269.986945913 65.974265020 269.986740071
+        66.097228517 269.676782731 66.097195577 269.680114248 65.974342004', '2026-02-17T21:49:20.136Z
+        :: romancal.assign_wcs.utils :: INFO :: S_REGION VALUES: POLYGON ICRS  269.986945913
+        65.974265020 269.986740071 66.097228517 269.676782731 66.097195577 269.680114248
+        65.974342004', '2026-02-17T21:49:20.136Z :: romancal.assign_wcs.utils :: INFO
+        :: Update S_REGION to POLYGON ICRS  269.986945913 65.974265020 269.986740071
+        66.097228517 269.676782731 66.097195577 269.680114248 65.974342004', '2026-02-17T21:49:20.137Z
+        :: stpipe.step :: INFO :: Step assign_wcs done', '2026-02-17T21:49:20.169Z
+        :: stpipe.step :: INFO :: Step flatfield running with args (<roman_datamodels.datamodels._datamodels.ImageModel
+        object at 0x10d8071a0>,).', '2026-02-17T21:49:20.370Z :: stpipe.step :: INFO
+        :: Step flatfield done', '2026-02-17T21:49:20.402Z :: stpipe.step :: INFO
+        :: Step photom running with args (<roman_datamodels.datamodels._datamodels.ImageModel
+        object at 0x10d8071a0>,).', '2026-02-17T21:49:20.415Z :: romancal.photom.photom
+        :: DEBUG :: pixel_area = 2.8083389953727505e-13', '2026-02-17T21:49:20.416Z
+        :: romancal.photom.photom :: INFO :: photmjsr value: 0.736781', '2026-02-17T21:49:20.416Z
+        :: romancal.photom.photom :: INFO :: uncertainty value: 0.0286641', '2026-02-17T21:49:20.416Z
+        :: stpipe.step :: INFO :: Step photom done', '2026-02-17T21:49:20.449Z ::
+        stpipe.step :: INFO :: Step source_catalog running with args (<roman_datamodels.datamodels._datamodels.ImageModel
+        object at 0x10d8071a0>,).', '2026-02-17T21:49:20.450Z :: romancal.source_catalog.source_catalog_step
+        :: INFO :: Using ePSF reference file: /Users/bgraham/roman_crds_cache/references/roman/wfi/roman_wfi_epsf_0182.asdf',
+      '2026-02-17T21:49:22.282Z :: romancal.source_catalog.psf :: INFO :: Performed
+        jitter convolution.  Image kernel: (8, 8, 0) Reference kernel: (0, 0, 0)',
+      '2026-02-17T21:49:22.406Z :: romancal.source_catalog.source_catalog_step ::
+        INFO :: Calculating and subtracting background', '2026-02-17T21:49:24.878Z
+        :: romancal.source_catalog.source_catalog_step :: INFO :: Creating detection
+        image', '2026-02-17T21:49:25.828Z :: romancal.source_catalog.source_catalog_step
+        :: INFO :: Detecting sources', '2026-02-17T21:49:27.379Z :: romancal.source_catalog.detection
+        :: INFO :: Detected 111 sources', '2026-02-17T21:49:27.380Z :: romancal.source_catalog.source_catalog_step
+        :: INFO :: Creating ee_fractions model', '2026-02-17T21:49:27.398Z :: romancal.source_catalog.source_catalog_step
+        :: INFO :: Creating source catalog', '2026-02-17T21:49:27.426Z :: romancal.source_catalog.source_catalog
+        :: INFO :: Calculating segment properties', '2026-02-17T21:49:27.673Z :: romancal.source_catalog.source_catalog
+        :: INFO :: Calculating aperture photometry', '2026-02-17T21:49:27.730Z ::
+        romancal.source_catalog.source_catalog :: INFO :: Calculating DAOFind properties',
+      '2026-02-17T21:49:27.882Z :: romancal.source_catalog.source_catalog :: INFO
+        :: Calculating nearest neighbor properties', '2026-02-17T21:49:27.883Z ::
+        romancal.source_catalog.source_catalog :: INFO :: Calculating PSF photometry',
+      '2026-02-17T21:49:28.986Z :: stpipe.step :: INFO :: Saved model in r0000101001001001001_0001_wfi01_f158_segm.asdf',
+      '2026-02-17T21:49:29.734Z :: stpipe.step :: INFO :: Saved model in r0000101001001001001_0001_wfi01_f158_cat.parquet',
+      '2026-02-17T21:49:29.791Z :: stpipe.step :: INFO :: Step source_catalog done',
+      '2026-02-17T21:49:29.835Z :: stpipe.step :: INFO :: Step tweakreg running with
+        args (<romancal.datamodels.library.ModelLibrary object at 0x10d921250>,).',
+      '2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step :: INFO :: Number
+        of image groups to be aligned: 1.', '2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step
+        :: INFO :: Image groups:', '2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step
+        :: INFO ::   00001010010010010010001', '2026-02-17T21:49:29.835Z :: romancal.tweakreg.tweakreg_step
+        :: INFO :: All source catalogs will be saved to: /Users/bgraham/projects/260217_b21_moc_files',
+      '2026-02-17T21:49:29.908Z :: romancal.tweakreg.tweakreg_step :: INFO :: Using
+        107 sources from r0000101001001001001_0001_wfi01_f158_uncal.asdf.', '2026-02-17T21:50:27.113Z
+        :: tweakwcs.imalign :: INFO ::  ', '2026-02-17T21:50:27.113Z :: tweakwcs.imalign
+        :: INFO :: ***** tweakwcs.imalign.align_wcs() started on 2026-02-17 16:50:27.113716',
+      '2026-02-17T21:50:27.113Z :: tweakwcs.imalign :: INFO ::       Version 0.8.12',
+      '2026-02-17T21:50:27.113Z :: tweakwcs.imalign :: INFO ::  ', '2026-02-17T21:50:27.178Z
+        :: tweakwcs.imalign :: INFO :: Aligning image catalog ''GROUP ID: 987654''
+        to the reference catalog.', '2026-02-17T21:50:27.204Z :: tweakwcs.matchutils
+        :: INFO :: Matching sources from ''r0000101001001001001_0001_wfi01_f158_uncal''
+        catalog with sources from the reference ''GAIADR3_S3'' catalog.', '2026-02-17T21:50:27.204Z
+        :: tweakwcs.matchutils :: INFO :: Computing initial guess for X and Y shifts...',
+      '2026-02-17T21:50:27.205Z :: tweakwcs.matchutils :: INFO :: Found initial X
+        and Y shifts of 0.01183, 0.01183 (arcsec) with significance of 107 and 107
+        matches.', '2026-02-17T21:50:27.205Z :: tweakwcs.wcsimage :: INFO :: Found
+        107 matches for ''GROUP ID: 987654''...', '2026-02-17T21:50:27.205Z :: tweakwcs.linearfit
+        :: INFO :: Performing ''rshift'' fit', '2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage
+        :: INFO :: Computed ''rshift'' fit for GROUP ID: 987654:', '2026-02-17T21:50:27.206Z
+        :: tweakwcs.wcsimage :: INFO :: XSH: 0.000272071  YSH: 6.34713e-05    ROT:
+        2.84434e-05    SCALE: 1', '2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage ::
+        INFO :: ', '2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage :: INFO :: FIT RMSE:
+        0.00208571   FIT MAE: 0.00171111', '2026-02-17T21:50:27.206Z :: tweakwcs.wcsimage
+        :: INFO :: Final solution based on 103 objects.', '2026-02-17T21:50:27.224Z
+        :: tweakwcs.imalign :: INFO ::  ', '2026-02-17T21:50:27.224Z :: tweakwcs.imalign
+        :: INFO :: ***** tweakwcs.imalign.align_wcs() ended on 2026-02-17 16:50:27.224039',
+      '2026-02-17T21:50:27.224Z :: tweakwcs.imalign :: INFO :: ***** tweakwcs.imalign.align_wcs()
+        TOTAL RUN TIME: 0:00:00.110323', '2026-02-17T21:50:27.224Z :: tweakwcs.imalign
+        :: INFO ::  ', '2026-02-17T21:50:27.226Z :: stcal.alignment.util :: INFO ::
+        Update S_REGION to POLYGON ICRS  269.986946024 65.974265006 269.986740333
+        66.097228503 269.676782993 66.097195626 269.680114359 65.974342053', '2026-02-17T21:50:27.226Z
+        :: romancal.assign_wcs.utils :: INFO :: S_REGION VALUES: POLYGON ICRS  269.986946024
+        65.974265006 269.986740333 66.097228503 269.676782993 66.097195626 269.680114359
+        65.974342053', '2026-02-17T21:50:27.226Z :: romancal.assign_wcs.utils :: INFO
+        :: Update S_REGION to POLYGON ICRS  269.986946024 65.974265006 269.986740333
+        66.097228503 269.676782993 66.097195626 269.680114359 65.974342053', '2026-02-17T21:50:27.240Z
+        :: stpipe.step :: INFO :: Step tweakreg done', '2026-02-17T21:50:27.240Z ::
+        romancal.pipeline.exposure_pipeline :: INFO :: Roman exposure calibration
+        pipeline ending...', '2026-02-17T21:50:27.332Z :: stpipe.step :: INFO :: Saved
+        model in r0000101001001001001_0001_wfi01_f158_wcs.asdf']
+    cal_step: {assign_wcs: COMPLETE, dark: COMPLETE, dark_decay: COMPLETE, dq_init: COMPLETE,
+      flat_field: COMPLETE, flux: INCOMPLETE, linearity: COMPLETE, outlier_detection: INCOMPLETE,
+      photom: COMPLETE, ramp_fit: COMPLETE, refpix: COMPLETE, saturation: COMPLETE,
+      skymatch: INCOMPLETE, source_catalog: COMPLETE, tweakreg: COMPLETE, wfi18_transient: N/A}
+    calibration_software_name: RomanCAL
+    calibration_software_version: 0.22.0
+    coordinates: {reference_frame: ICRS}
+    ephemeris: {ephemeris_reference_frame: '?', spatial_x: -52044463.08234682, spatial_y: -131312741.31107728,
+      spatial_z: -56910542.46910208, time: 61557.0, type: DEFINITIVE, velocity_x: 27.507907094602988,
+      velocity_y: -9.484643417914059, velocity_z: -4.112149494244798}
+    exposure:
+      data_problem: '?'
+      effective_exposure_time: 133.76
+      end_time: !time/time-1.4.0 2027-06-01T00:02:13.760
+      engineering_quality: OK
+      exposure_time: 133.76
+      frame_time: 3.04
+      ma_table_id: SCI0109
+      ma_table_name: '?'
+      ma_table_number: 109
+      mid_time: !time/time-1.4.0 2027-06-01T00:01:06.880
+      nresultants: 10
+      read_pattern:
+      - [1]
+      - [2, 3]
+      - [5, 6, 7]
+      - [10, 11, 12, 13]
+      - [15, 16, 17, 18, 19, 20]
+      - [21, 22, 23, 24, 25, 26]
+      - [27, 28, 29, 30, 31, 32]
+      - [33, 34, 35, 36, 37, 38]
+      - [39, 40, 41, 42, 43]
+      - [44]
+      start_time: !time/time-1.4.0 2027-06-01T00:00:00.000
+      truncated: false
+      type: WFI_IMAGE
+    file_date: !time/time-1.4.0 {base_format: datetime, value: '2026-02-17T21:50:27.333'}
+    filename: r0000101001001001001_0001_wfi01_f158_cal.asdf
+    guide_star: {epoch: '?', guide_mode: WIM-ACQ, guide_star_id: '?', guide_window_id: '?',
+      window_xstart: -999999, window_xstop: -999983, window_ystart: -999999, window_ystop: -999983}
+    instrument: {detector: WFI01, name: WFI, optical_element: F158}
+    model_type: ImageModel
+    observation: {execution_plan: 1, exposure: 1, observation: 1, observation_id: '00001010010010010010001',
+      pass: 1, program: 1, segment: 1, visit: 1, visit_file_activity: '01', visit_file_group: 0,
+      visit_file_sequence: 1, visit_id: '0000101001001001001', wfi_parallel: false}
+    origin: STSCI/SOC
+    photometry: {conversion_megajanskys: 0.7367810113020512, conversion_megajanskys_uncertainty: 0.02866405239530676,
+      pixel_area: 2.8083389953727505e-13}
+    pointing: {dec_v1: 66.49600017133261, pa_aperture: 0, pa_v3: 59.999051896586074,
+      pointing_engineering_source: CALCULATED, ra_v1: 269.99997982111586, target_aperture: WFI_CEN,
+      target_dec: 66.0, target_ra: 270.0}
+    prd_version: '?'
+    product_type: l2
+    program: {category: '?', investigator_name: '?', science_category: '?', subcategory: CAL,
+      title: '?'}
+    rcs: {active: false, bank: '1', counts: -999999, electronics: A, led: '1'}
+    ref_file:
+      apcorr: crds://roman_wfi_apcorr_0002.asdf
+      area: '?'
+      crds: {context: roman_0046.pmap, version: 13.1.3}
+      dark: crds://roman_wfi_dark_0364.asdf
+      darkdecaysignal: crds://roman_wfi_darkdecaysignal_0001.asdf
+      distortion: crds://roman_wfi_distortion_0014.asdf
+      epsf: crds://roman_wfi_epsf_0182.asdf
+      flat: crds://roman_wfi_flat_0166.asdf
+      gain: crds://roman_wfi_gain_0022.asdf
+      integralnonlinearity: crds://roman_wfi_integralnonlinearity_0003.asdf
+      inverse_linearity: '?'
+      inverselinearity: crds://roman_wfi_inverselinearity_0042.asdf
+      linearity: crds://roman_wfi_linearity_0039.asdf
+      mask: crds://roman_wfi_mask_0030.asdf
+      photom: crds://roman_wfi_photom_0040.asdf
+      readnoise: crds://roman_wfi_readnoise_0024.asdf
+      refpix: crds://roman_wfi_refpix_0013.asdf
+      saturation: crds://roman_wfi_saturation_0031.asdf
+    sdf_software_version: '?'
+    source_catalog: {tweakreg_catalog_name: r0000101001001001001_0001_wfi01_f158_cat.parquet}
+    telescope: ROMAN
+    velocity_aberration: {dec_reference: 66.0355095513252, ra_reference: 269.8325254855773,
+      scale_factor: 1.0000003455620605}
+    visit:
+      dither:
+        executed_pattern: []
+        primary_name: '?'
+        subpixel_name: '?'
+      internal_target: false
+      nexposures: -999999
+      start_time: !time/time-1.4.0 2020-01-01T00:00:00.000
+      status: SUCCESSFUL
+      type: GENERAL_ENGINEERING
+    wcs: !<tag:stsci.edu:gwcs/wcs-1.4.0>
+      name: FIT-LVL2-GAIADR3_S3
+      pixel_shape: null
+      steps:
+      - !<tag:stsci.edu:gwcs/step-1.3.0>
+        frame: !<tag:stsci.edu:gwcs/frame2d-1.2.0>
+          axes_names: [x, y]
+          axes_order: [0, 1]
+          axis_physical_types: ['custom:x', 'custom:y']
+          name: detector
+          unit: [!unit/unit-1.0.0 pixel, !unit/unit-1.0.0 pixel]
+        transform: !transform/compose-1.3.0
+          bounding_box: !transform/property/bounding_box-1.1.0
+            ignore: []
+            intervals:
+              x0: [-0.5, 4087.5]
+              x1: [-0.5, 4087.5]
+            order: F
+          forward:
+          - !transform/compose-1.3.0
+            forward:
+            - !transform/compose-1.3.0
+              forward:
+              - !transform/concatenate-1.3.0
+                forward:
+                - &id001 !transform/shift-1.3.0
+                  inputs: [x]
+                  offset: 1.0
+                  outputs: [y]
+                - *id001
+                inputs: [x0, x1]
+                outputs: [y0, y1]
+              - !transform/concatenate-1.3.0
+                forward:
+                - !transform/shift-1.3.0
+                  inputs: [x]
+                  offset: -2044.5
+                  outputs: [y]
+                - !transform/shift-1.3.0
+                  inputs: [x]
+                  offset: -2044.5
+                  outputs: [y]
+                inputs: [x0, x1]
+                outputs: [y0, y1]
+              inputs: [x0, x1]
+              outputs: [y0, y1]
+            - !transform/compose-1.3.0
+              forward:
+              - !transform/compose-1.3.0
+                forward:
+                - !transform/remap_axes-1.4.0
+                  inputs: [x0, x1]
+                  mapping: [0, 1, 0, 1]
+                  outputs: [x0, x1, x2, x3]
+                - !transform/concatenate-1.3.0
+                  forward:
+                  - !transform/polynomial-1.2.0
+                    coefficients: !core/ndarray-1.1.0
+                      source: 0
+                      datatype: float64
+                      byteorder: little
+                      shape: [6, 6]
+                    domain:
+                    - [-1, 1]
+                    - [-1, 1]
+                    inputs: [x, y]
+                    outputs: [z]
+                    window:
+                    - [-1, 1]
+                    - [-1, 1]
+                  - !transform/polynomial-1.2.0
+                    coefficients: !core/ndarray-1.1.0
+                      source: 1
+                      datatype: float64
+                      byteorder: little
+                      shape: [6, 6]
+                    domain:
+                    - [-1, 1]
+                    - [-1, 1]
+                    inputs: [x, y]
+                    outputs: [z]
+                    window:
+                    - [-1, 1]
+                    - [-1, 1]
+                  inputs: [x0, y0, x1, y1]
+                  outputs: [z0, z1]
+                inputs: [x0, x1]
+                inverse: !transform/compose-1.3.0
+                  forward:
+                  - !transform/remap_axes-1.4.0
+                    inputs: [x0, x1]
+                    mapping: [0, 1, 0, 1]
+                    outputs: [x0, x1, x2, x3]
+                  - !transform/concatenate-1.3.0
+                    forward:
+                    - !transform/polynomial-1.2.0
+                      coefficients: !core/ndarray-1.1.0
+                        source: 2
+                        datatype: float64
+                        byteorder: little
+                        shape: [6, 6]
+                      domain:
+                      - [-1, 1]
+                      - [-1, 1]
+                      inputs: [x, y]
+                      outputs: [z]
+                      window:
+                      - [-1, 1]
+                      - [-1, 1]
+                    - !transform/polynomial-1.2.0
+                      coefficients: !core/ndarray-1.1.0
+                        source: 3
+                        datatype: float64
+                        byteorder: little
+                        shape: [6, 6]
+                      domain:
+                      - [-1, 1]
+                      - [-1, 1]
+                      inputs: [x, y]
+                      outputs: [z]
+                      window:
+                      - [-1, 1]
+                      - [-1, 1]
+                    inputs: [x0, y0, x1, y1]
+                    outputs: [z0, z1]
+                  inputs: [x0, x1]
+                  outputs: [z0, z1]
+                outputs: [z0, z1]
+              - !transform/compose-1.3.0
+                forward:
+                - !transform/remap_axes-1.4.0
+                  inputs: [x0, x1]
+                  mapping: [0, 1, 0, 1]
+                  outputs: [x0, x1, x2, x3]
+                - !transform/concatenate-1.3.0
+                  forward:
+                  - !transform/polynomial-1.2.0
+                    coefficients: !core/ndarray-1.1.0
+                      source: 4
+                      datatype: float64
+                      byteorder: little
+                      shape: [2, 2]
+                    domain:
+                    - [-1, 1]
+                    - [-1, 1]
+                    inputs: [x, y]
+                    outputs: [z]
+                    window:
+                    - [-1, 1]
+                    - [-1, 1]
+                  - !transform/polynomial-1.2.0
+                    coefficients: !core/ndarray-1.1.0
+                      source: 5
+                      datatype: float64
+                      byteorder: little
+                      shape: [2, 2]
+                    domain:
+                    - [-1, 1]
+                    - [-1, 1]
+                    inputs: [x, y]
+                    outputs: [z]
+                    window:
+                    - [-1, 1]
+                    - [-1, 1]
+                  inputs: [x0, y0, x1, y1]
+                  outputs: [z0, z1]
+                inputs: [x0, x1]
+                inverse: !transform/compose-1.3.0
+                  forward:
+                  - !transform/remap_axes-1.4.0
+                    inputs: [x0, x1]
+                    mapping: [0, 1, 0, 1]
+                    outputs: [x0, x1, x2, x3]
+                  - !transform/concatenate-1.3.0
+                    forward:
+                    - !transform/polynomial-1.2.0
+                      coefficients: !core/ndarray-1.1.0
+                        source: 6
+                        datatype: float64
+                        byteorder: little
+                        shape: [2, 2]
+                      domain:
+                      - [-1, 1]
+                      - [-1, 1]
+                      inputs: [x, y]
+                      outputs: [z]
+                      window:
+                      - [-1, 1]
+                      - [-1, 1]
+                    - !transform/polynomial-1.2.0
+                      coefficients: !core/ndarray-1.1.0
+                        source: 7
+                        datatype: float64
+                        byteorder: little
+                        shape: [2, 2]
+                      domain:
+                      - [-1, 1]
+                      - [-1, 1]
+                      inputs: [x, y]
+                      outputs: [z]
+                      window:
+                      - [-1, 1]
+                      - [-1, 1]
+                    inputs: [x0, y0, x1, y1]
+                    outputs: [z0, z1]
+                  inputs: [x0, x1]
+                  outputs: [z0, z1]
+                outputs: [z0, z1]
+              inputs: [x0, x1]
+              outputs: [z0, z1]
+            inputs: [x0, x1]
+            outputs: [z0, z1]
+          - !transform/concatenate-1.3.0
+            forward:
+            - !transform/shift-1.3.0
+              inputs: [x]
+              offset: 1312.9491452484797
+              outputs: [y]
+            - !transform/shift-1.3.0
+              inputs: [x]
+              offset: -1040.7853726755036
+              outputs: [y]
+            inputs: [x0, x1]
+            outputs: [y0, y1]
+          inputs: [x0, x1]
+          outputs: [y0, y1]
+      - !<tag:stsci.edu:gwcs/step-1.3.0>
+        frame: !<tag:stsci.edu:gwcs/frame2d-1.2.0>
+          axes_names: [v2, v3]
+          axes_order: [0, 1]
+          axis_physical_types: ['custom:v2', 'custom:v3']
+          name: v2v3
+          unit: [!unit/unit-1.0.0 arcsec, !unit/unit-1.0.0 arcsec]
+        transform: !transform/compose-1.3.0
+          forward:
+          - !transform/concatenate-1.3.0
+            forward:
+            - !transform/scale-1.3.0
+              factor: 1.0000003455620605
+              inputs: [x]
+              name: dva_scale_v2
+              outputs: [y]
+            - !transform/scale-1.3.0
+              factor: 1.0000003455620605
+              inputs: [x]
+              name: dva_scale_v3
+              outputs: [y]
+            inputs: [x0, x1]
+            outputs: [y0, y1]
+          - !transform/concatenate-1.3.0
+            forward:
+            - !transform/shift-1.3.0
+              inputs: [x]
+              name: dva_v2_shift
+              offset: -0.0004537054119925875
+              outputs: [y]
+            - !transform/shift-1.3.0
+              inputs: [x]
+              name: dva_v3_shift
+              offset: 0.0003596559379428446
+              outputs: [y]
+            inputs: [x0, x1]
+            outputs: [y0, y1]
+          inputs: [x0, x1]
+          name: DVA_Correction
+          outputs: [y0, y1]
+      - !<tag:stsci.edu:gwcs/step-1.3.0>
+        frame: !<tag:stsci.edu:gwcs/frame2d-1.2.0>
+          axes_names: [v2, v3]
+          axes_order: [0, 1]
+          axis_physical_types: ['custom:v2', 'custom:v3']
+          name: v2v3vacorr
+          unit: [!unit/unit-1.0.0 arcsec, !unit/unit-1.0.0 arcsec]
+        transform: !transform/compose-1.3.0
+          forward:
+          - !transform/compose-1.3.0
+            forward:
+            - !transform/compose-1.3.0
+              forward:
+              - !transform/compose-1.3.0
+                forward:
+                - !transform/compose-1.3.0
+                  forward:
+                  - !transform/compose-1.3.0
+                    forward:
+                    - !transform/compose-1.3.0
+                      forward:
+                      - !transform/compose-1.3.0
+                        forward:
+                        - &id004 !transform/concatenate-1.3.0
+                          forward:
+                          - &id002 !transform/scale-1.3.0
+                            factor: 0.0002777777777777778
+                            inputs: [x]
+                            name: arcsec_to_deg_1D
+                            outputs: [y]
+                          - *id002
+                          inputs: [x0, x1]
+                          name: arcsec_to_deg_2D
+                          outputs: [y0, y1]
+                        - &id005 !<tag:stsci.edu:gwcs/spherical_cartesian-1.3.0>
+                          inputs: [lon, lat]
+                          name: s2c
+                          outputs: [x, y, z]
+                          transform_type: spherical_to_cartesian
+                          wrap_lon_at: 180
+                        inputs: [x0, x1]
+                        outputs: [x, y, z]
+                      - &id006 !transform/rotate_sequence_3d-1.1.0
+                        angles: [0.3647080959023555, 0.28910704796541764, 59.846679364670365]
+                        axes_order: zyx
+                        inputs: [x, y, z]
+                        name: det_to_optic_axis
+                        outputs: [x, y, z]
+                        rotation_type: cartesian
+                      inputs: [x0, x1]
+                      outputs: [x, y, z]
+                    - &id007 !transform/compose-1.3.0
+                      forward:
+                      - !transform/divide-1.3.0
+                        forward:
+                        - !transform/remap_axes-1.4.0
+                          inputs: [x0, x1, x2]
+                          mapping: [0, 1, 2]
+                          name: xyz
+                          outputs: [x0, x1, x2]
+                        - !transform/remap_axes-1.4.0
+                          inputs: [x0, x1, x2]
+                          mapping: [0, 0, 0]
+                          n_inputs: 3
+                          name: xxx
+                          outputs: [x0, x1, x2]
+                        inputs: [x0, x1, x2]
+                        outputs: [x0, x1, x2]
+                      - !transform/remap_axes-1.4.0
+                        inputs: [x0, x1, x2]
+                        mapping: [1, 2]
+                        name: xtyt
+                        outputs: [x0, x1]
+                      inputs: [x0, x1, x2]
+                      name: Cartesian 3D to TAN
+                      outputs: [x0, x1]
+                    inputs: [x0, x1]
+                    outputs: [x0, x1]
+                  - !transform/affine-1.4.0
+                    inputs: [x, y]
+                    matrix: !core/ndarray-1.1.0
+                      source: 8
+                      datatype: float64
+                      byteorder: little
+                      shape: [2, 2]
+                    name: tp_affine
+                    outputs: [x, y]
+                    translation: !core/ndarray-1.1.0
+                      source: 9
+                      datatype: float64
+                      byteorder: little
+                      shape: [2]
+                  inputs: [x0, x1]
+                  outputs: [x, y]
+                - &id008 !transform/compose-1.3.0
+                  forward:
+                  - !transform/remap_axes-1.4.0
+                    inputs: [x0, x1]
+                    mapping: [0, 0, 1]
+                    name: xtyt2xyz
+                    outputs: [x0, x1, x2]
+                  - !transform/concatenate-1.3.0
+                    forward:
+                    - !transform/constant-1.5.0
+                      dimensions: 1
+                      inputs: [x]
+                      name: one
+                      outputs: [y]
+                      value: 1.0
+                    - !transform/identity-1.3.0
+                      inputs: [x0, x1]
+                      n_dims: 2
+                      name: I(2D)
+                      outputs: [x0, x1]
+                    inputs: [x, x0, x1]
+                    outputs: [y, x0, x1]
+                  inputs: [x0, x1]
+                  name: TAN to cartesian 3D
+                  outputs: [y, x0, x1]
+                inputs: [x0, x1]
+                outputs: [y, x0, x1]
+              - &id009 !transform/rotate_sequence_3d-1.1.0
+                angles: [-59.846679364670365, -0.28910704796541764, -0.3647080959023555]
+                axes_order: xyz
+                inputs: [x, y, z]
+                name: optic_axis_to_det
+                outputs: [x, y, z]
+                rotation_type: cartesian
+              inputs: [x0, x1]
+              outputs: [x, y, z]
+            - &id010 !<tag:stsci.edu:gwcs/spherical_cartesian-1.3.0>
+              inputs: [x, y, z]
+              name: c2s
+              outputs: [lon, lat]
+              transform_type: cartesian_to_spherical
+              wrap_lon_at: 180
+            inputs: [x0, x1]
+            outputs: [lon, lat]
+          - &id011 !transform/concatenate-1.3.0
+            forward:
+            - &id003 !transform/scale-1.3.0
+              factor: 3600.0
+              inputs: [x]
+              name: deg_to_arcsec_1D
+              outputs: [y]
+            - *id003
+            inputs: [x0, x1]
+            name: deg_to_arcsec_2D
+            outputs: [y0, y1]
+          inputs: [x0, x1]
+          inverse: !transform/compose-1.3.0
+            forward:
+            - !transform/compose-1.3.0
+              forward:
+              - !transform/compose-1.3.0
+                forward:
+                - !transform/compose-1.3.0
+                  forward:
+                  - !transform/compose-1.3.0
+                    forward:
+                    - !transform/compose-1.3.0
+                      forward:
+                      - !transform/compose-1.3.0
+                        forward:
+                        - !transform/compose-1.3.0
+                          forward:
+                          - *id004
+                          - *id005
+                          inputs: [x0, x1]
+                          outputs: [x, y, z]
+                        - *id006
+                        inputs: [x0, x1]
+                        outputs: [x, y, z]
+                      - *id007
+                      inputs: [x0, x1]
+                      outputs: [x0, x1]
+                    - !transform/affine-1.4.0
+                      inputs: [x, y]
+                      matrix: !core/ndarray-1.1.0
+                        source: 10
+                        datatype: float64
+                        byteorder: little
+                        shape: [2, 2]
+                      name: tp_affine_inv
+                      outputs: [x, y]
+                      translation: !core/ndarray-1.1.0
+                        source: 11
+                        datatype: float64
+                        byteorder: little
+                        shape: [2]
+                    inputs: [x0, x1]
+                    outputs: [x, y]
+                  - *id008
+                  inputs: [x0, x1]
+                  outputs: [y, x0, x1]
+                - *id009
+                inputs: [x0, x1]
+                outputs: [x, y, z]
+              - *id010
+              inputs: [x0, x1]
+              outputs: [lon, lat]
+            - *id011
+            inputs: [x0, x1]
+            name: Inverse JWST tangent-plane linear correction. v1
+            outputs: [y0, y1]
+          name: JWST tangent-plane linear correction. v1
+          outputs: [y0, y1]
+      - !<tag:stsci.edu:gwcs/step-1.3.0>
+        frame: !<tag:stsci.edu:gwcs/frame2d-1.2.0>
+          axes_names: [v2, v3]
+          axes_order: [0, 1]
+          axis_physical_types: ['custom:v2', 'custom:v3']
+          name: v2v3corr
+          unit: [!unit/unit-1.0.0 arcsec, !unit/unit-1.0.0 arcsec]
+        transform: !transform/compose-1.3.0
+          forward:
+          - !transform/compose-1.3.0
+            forward:
+            - !transform/compose-1.3.0
+              forward:
+              - !transform/concatenate-1.3.0
+                forward:
+                - !transform/scale-1.3.0
+                  factor: 0.0002777777777777778
+                  inputs: [x]
+                  outputs: [y]
+                - !transform/scale-1.3.0
+                  factor: 0.0002777777777777778
+                  inputs: [x]
+                  outputs: [y]
+                inputs: [x0, x1]
+                outputs: [y0, y1]
+              - !<tag:stsci.edu:gwcs/spherical_cartesian-1.3.0>
+                inputs: [lon, lat]
+                outputs: [x, y, z]
+                transform_type: spherical_to_cartesian
+                wrap_lon_at: 180
+              inputs: [x0, x1]
+              outputs: [x, y, z]
+            - !transform/rotate_sequence_3d-1.1.0
+              angles: [0.3647080959023555, 0.28910704796541764, 59.846679364670365,
+                66.0355095513252, -269.8325254855773]
+              axes_order: zyxyz
+              inputs: [x, y, z]
+              outputs: [x, y, z]
+              rotation_type: cartesian
+            inputs: [x0, x1]
+            outputs: [x, y, z]
+          - !<tag:stsci.edu:gwcs/spherical_cartesian-1.3.0>
+            inputs: [x, y, z]
+            outputs: [lon, lat]
+            transform_type: cartesian_to_spherical
+            wrap_lon_at: 360
+          inputs: [x0, x1]
+          name: v23tosky
+          outputs: [lon, lat]
+      - !<tag:stsci.edu:gwcs/step-1.3.0>
+        frame: !<tag:stsci.edu:gwcs/celestial_frame-1.2.0>
+          axes_names: [lon, lat]
+          axes_order: [0, 1]
+          axis_physical_types: [pos.eq.ra, pos.eq.dec]
+          name: world
+          reference_frame: !<tag:astropy.org:astropy/coordinates/frames/icrs-1.1.0>
+            frame_attributes: {}
+          unit: [!unit/unit-1.0.0 deg, !unit/unit-1.0.0 deg]
+        transform: null
+    wcs_fit_results:
+      <rot>: 2.844338799936102e-05
+      <scale>: 1.0
+      center: [-4.380064906371088, -21.04270513531622]
+      fitgeom: rshift
+      mae: 0.0017111099766289842
+      matrix:
+      - [0.9999999999998768, 4.964307710110721e-07]
+      - [-4.964307710110721e-07, 0.9999999999998768]
+      nmatches: 107
+      proper: true
+      proper_rot: 2.844338799936102e-05
+      rmse: 0.0020857122860393922
+      rot: [2.844338799936102e-05, 2.844338799936102e-05]
+      scale: [1.0, 1.0]
+      shift: [0.0002720710784867062, 6.3471277370164e-05]
+      skew: 0.0
+      status: SUCCESS
+    wcsinfo: {aperture_name: WFI01_FULL, dec_ref: 66.0355095513252, ra_ref: 269.8325254855773,
+      roll_ref: 59.846679364670365, s_region: POLYGON ICRS  269.986946024 65.974265006
+        269.986740333 66.097228503 269.676782993 66.097195626 269.680114359 65.974342053,
+      v2_ref: 1312.9491452484797, v3_ref: -1040.7853726755036, v3yangle: -60.0, vparity: -1}
+...
+”BLK 0                             ˚©õ„õì-;Œ6√KL        œt—gd6?ÌI€°Ñ=æêÂ<ÆÄtΩÿHﬁÚjÙ∆ºéíœ¬®#<XT?º?[mÛÉ> ,5˛ÇBíΩ¿é%=O!∏< `ÓJà<        ﬁ≈0∫bæÄ´â;r™|=P&…œ„∞ºà	(}eº                 @ ò«,ÑΩ ú:Ñ< Ë=—«h$º                        ‡Ô‘–‚§ó<(‘ÜîÙº                                 hÀéËgº                                        ”BLK 0                             n‡‚^˜ß8z¥I·        x“o´k∏ª?¿yh$'å> ¥œ1‘´°Ω Ø8Öô< ê§π¯Ù*<¥´∂ö4?å†˛«Tæ¿añ“»s`ΩpÏ‡∞§ºÊI˜¡3b<        0(Zv&s> (å˛† ìΩ‡¡5¥∑º ¿ L
+<                 È€”ëªg=LêìQ≈ƒº8aØÔº                         tﬂÙ6¶< P⁄	äº                                †Kr˛0µÁª                                        ”BLK 0                             ò-urpˇ∑˛ÓŒ¬˚Keü        ~ÍE˙˛GùøyÙ£ñ.∑Ÿ>’A,c@>©¥`€"»=øp›Äk–VΩ‹ﬂ∂å0 "@*@ËNó=ø"ﬂ‹m{Qa>]R™∞∫ΩtyÇ_IΩ        ˆBÚØ˚∞˙>#⁄50vKæœh–rÙŒ∞=˜∂’¸˝N=                !öŒ€ÔÉQ>…ﬁ|YòµòΩ∞§~•SjV=                        ˆ˙π†ËìΩ±6-J
+4=                                 VSÄF=                                        ”BLK 0                             ñ©ÿsŒHx¨k≈· ÍÈ        ı—ùgx"@≥XZ-¨%ø 6]TLJq>Äâbfn*ûΩ :¥πC _Ω∏@⁄∂ÒöøÙ‰‘Õ¶[Ò> ;‡∆¡™>hùÁ˚à¶=@£5ü_çDΩ        ÔÜxæ8ø Óˆ±Ωb>†∫#ñ´≤= 0ëüP>Ω                0[êfr%6æ∑Mëà‰Xƒ=&K>€ãA=                        @Œ_“å∂ßΩ “{/ìP=                                 Úh∫=                                        ”BLK 0                                Ø<Î ≈IIØÙ[PYR        ™LXËz∂Îø     ‡ø        ”BLK 0                                Ô[Ωñ_dy‘K4ﬁπ£é             ‡?™LXËz∂Îø        ”BLK 0                                Ø<Î ≈IIØÙ[PYR        ™LXËz∂Îø     ‡ø        ”BLK 0                                Ô[Ωñ_dy‘K4ﬁπ£é             ‡?™LXËz∂Îø        ”BLK 0                                ëA›	∫-kΩ˘?ätí‘Â•˚ˇˇˇˇÔ?^mæœN®†>ﬁ`œN®†æØ˚ˇˇˇˇÔ?”BLK 0                             ¡fëèYÃmÑØsi	VxÀÑ»Áå0©>£w!l%ı=”BLK 0                                @êsPªäF∏sWwÙ˝∞˚ˇˇˇˇÔ?_mæœN®†æﬂ`œN®†>¶˚ˇˇˇˇÔ?”BLK 0                             Ó‡p¢π3ÿ•˘‚S i‡`0©æ‹!io%ıΩ#ASDF BLOCK INDEX
+%YAML 1.1
+---
+- 53662
+- 54004
+- 54346
+- 54688
+- 55030
+- 55116
+- 55202
+- 55288
+- 55374
+- 55460
+- 55530
+- 55616
+...

--- a/tests/test-info.sh
+++ b/tests/test-info.sh
@@ -8,4 +8,6 @@ if [ -z "${top_srcdir}" ]; then
   top_srcdir=".."
 fi
 
-"${srcdir}"/shell-test.sh info --blocks $@ "${top_srcdir}"/asdf-standard/reference_files/1.6.0/*.asdf
+"${srcdir}"/shell-test.sh info --blocks $@ \
+  "${top_srcdir}"/asdf-standard/reference_files/1.6.0/*.asdf \
+  "${srcdir}"/fixtures/roman_l2_wcs.asdf


### PR DESCRIPTION
Came up in the case of reading a Roman L2 ASDF file (gh-191) but is not specific to it.  Fixes two issues:

- Truncate long scalar values in the output
- Double free / dangling pointers on the `active_levels` array; this array is meant to be reused by all node levels (it just tracks when printing a line which levels of indent should have a vertical pipe drawn) but if it gets resized during tree traversal the resized active_levels pointer was left dangling on previous node levels; this ensures that they are all sharing the same reference to a node_indent_t structure.

Resolves #191