### PR TITLE
docs: build docs in build directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -128,7 +128,7 @@ tidy:
 
 if BUILD_DOCS
 docs:
-	$(SPHINXBUILD) $(SPHINX_FLAGS) -b html $(srcdir)/docs $(srcdir)/docs/_build/html
+	$(SPHINXBUILD) $(SPHINX_FLAGS) -b html $(srcdir)/docs $(builddir)/docs/_build/html
 
 distcheck-docs:
 	$(MAKE) docs SPHINX_FLAGS=-W

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(SPHINX_FLAGS PARENT_SCOPE)
 
 set(docsrc "${CMAKE_SOURCE_DIR}/docs")
-set(outdir "${CMAKE_CURRENT_BINARY_DIR}/html")
+set(outdir "${CMAKE_CURRENT_BINARY_DIR}/_build/html")
 
 add_custom_target(docs_clean
     COMMAND cmake -E remove_directory "${outdir}"


### PR DESCRIPTION
for VPATH builds output the built docs in the VPATH build directory not the source tree; also fix the cmake output dir consistent with the autotools output dir (both consistent with sphinx's default)