### PR TITLE
docs: guard against NULL history.entries in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,8 +107,9 @@ the ASDF tree, as well as extract block data.  Inline comments provide further e
        // This reads the top-level core/asdf-1.0.0 schema
        err = asdf_get_meta(file, "/", &meta);
        if (err == ASDF_VALUE_OK) {
-           if (meta->history.entries[0]) {
-               // This is a NULL-terminated array of asdf_history_entry_t*
+           // `entries` is NULL when the file has no history, and otherwise a
+           // NULL-terminated array of asdf_history_entry_t*, so check both.
+           if (meta->history.entries && meta->history.entries[0]) {
                printf("first history entry: %s\n", meta->history.entries[0]->description);
            }
        }


### PR DESCRIPTION
Closes #196. The cube example does `meta->history.entries[0]` directly, but `entries` is NULL when the file has no history (it only gets allocated when the history mapping has an "entries" key, see src/core/asdf.c), so the example segfaults on any file without a history entry. Added a NULL check on `entries` itself before indexing it.