### PR TITLE
Adding multiple tag version support in extension registration

### DIFF
--- a/changes/42.feature
+++ b/changes/42.feature
@@ -5,7 +5,8 @@ one written when serializing a newly created or replaced object of that type.
 Values read from a file and left unmodified keep their original tag.
 
 The core ``ndarray`` extension now also reads ``ndarray-1.0.0`` in addition to
-``ndarray-1.1.0``.
+``ndarray-1.1.0``, and the core ``asdf`` extension reads ``asdf-1.0.0`` in
+addition to ``asdf-1.1.0``.
 
 As part of this the extension methods (``serialize``, ``deserialize``,
 ``copy``, and ``dealloc``) moved out of ``asdf_extension_t`` and into a new

--- a/changes/42.feature
+++ b/changes/42.feature
@@ -1,0 +1,13 @@
+Extensions can now be registered for more than one tag, so a single extension
+can read multiple versions of the same schema.  ``ASDF_REGISTER_EXTENSION``
+takes one or more tags as its trailing arguments; the first tag listed is the
+one written when serializing a newly created or replaced object of that type.
+Values read from a file and left unmodified keep their original tag.
+
+The core ``ndarray`` extension now also reads ``ndarray-1.0.0`` in addition to
+``ndarray-1.1.0``.
+
+As part of this the extension methods (``serialize``, ``deserialize``,
+``copy``, and ``dealloc``) moved out of ``asdf_extension_t`` and into a new
+``asdf_extension_vtab_t``, a pointer to which is passed to
+``ASDF_REGISTER_EXTENSION`` in place of the four individual methods.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,6 +114,11 @@ nitpick_ignore = [
     ('c:identifier', 'uint64_t'),
     ('c:identifier', 'uint8_t'),
 
+# Struct tags of opaque types; Hawkmoth references the tag rather than the
+# typedef name, so the tag itself never gets a target
+# https://github.com/jnikula/hawkmoth/issues/11
+    ('c:identifier', 'asdf_value'),
+
 # libasdf identifiers that should be documented but aren't yet
     ('c:identifier', 'asdf_emitter_cfg_t'),
     ('c:identifier', 'asdf_event_t'),

--- a/docs/usage/extensions.rst
+++ b/docs/usage/extensions.rst
@@ -124,6 +124,8 @@ For this example we need to write a few pieces of code:
 
 * An ``asdf_foo_copy`` function
 
+* An `asdf_extension_vtab_t` collecting the four functions above
+
 
 .. code:: c
 
@@ -261,6 +263,17 @@ copy of the object can be created correctly:
   }
 
 
+The four functions are collected into an `asdf_extension_vtab_t`:
+
+.. code:: c
+
+  static const asdf_extension_vtab_t asdf_foo_vtab = {
+      .serialize = asdf_foo_serialize,
+      .deserialize = asdf_foo_deserialize,
+      .copy = asdf_foo_copy,
+      .dealloc = asdf_foo_dealloc,
+  };
+
 Finally, we register the extension by making the following call in the same
 source file as where these functions were defined (or in a different file if
 the functions have external linkage):
@@ -269,44 +282,31 @@ the functions have external linkage):
 
   ASDF_REGISTER_EXTENSION(
       foo,
-      "stsci.edu:asdf/ext/foo-1.0.0",
       asdf_foo_t,
       &asdf_foo_software,
-      asdf_foo_serialize,
-      asdf_foo_deserialize,
-      asdf_foo_copy,
-      asdf_foo_dealloc,
-      NULL
+      &asdf_foo_vtab,
+      NULL,
+      "stsci.edu:asdf/ext/foo-1.0.0"
   )
 
-This is a macro which currently takes 9 arguments:
+This is a macro which takes 5 arguments, followed by one or more tags:
 
 * The base name of the extension type--this is not necessarily the name of the
   C type returned by the extension (though it could be the same).  This defines
   the type name used in the generated ``asdf_get_<type>`` and related functions.
   For example, this defines ``asdf_get_foo``, ``asdf_is_foo``, and so on.
 
-* The tag for which the extension should be registered.  Currently this only
-  supports a single tag, though there are plans to change that, as in many
-  cases the same extension code can support multiple tag versions.
-
-  It is, however, perfectly possible to register multiple extensions under
-  different tags but using the same ``asdf_foo_*`` functions.
-
 * The C-native type returned by the extension--this is our ``asdf_foo_t``.
 
 * An ``asdf_software_t *`` for the software metadata.
 
-* The serialize function we defined
-
-* The deserialize function we defined
-
-* The clone function we defined
-
-* The dealloc function we defined
+* An `asdf_extension_vtab_t` pointer--this is our ``asdf_foo_vtab``.
 
 * A pointer to optional userdata stored by the extension (this is not used yet
   but could be supplied, e.g. at runtime, to configure the extension).
+
+* One or more tags for which the extension should be registered.  See
+  :ref:`extension-tag-versions`.
 
 Finally, if we wish to make our extension usable by external code, we provide
 the following declaration in our ``foo.h`` header:
@@ -328,3 +328,38 @@ Our extension type can now be used in code like:
       printf("the foo: %s\n", foo->foo);
   else
       fprintf(stderr, "invalid foo value");
+
+
+.. _extension-tag-versions:
+
+Supporting multiple tag versions
+--------------------------------
+
+Schema tags are conventionally versioned, and the same extension code can often
+read more than one version of its schema.  Every tag passed to
+`ASDF_REGISTER_EXTENSION` is registered for the extension, so listing several
+of them lets one extension read all of those versions:
+
+.. code:: c
+
+  ASDF_REGISTER_EXTENSION(
+      foo,
+      asdf_foo_t,
+      &asdf_foo_software,
+      &asdf_foo_vtab,
+      NULL,
+      "stsci.edu:asdf/ext/foo-1.1.0",
+      "stsci.edu:asdf/ext/foo-1.0.0"
+  )
+
+Tags are matched exactly, so only the versions listed here are recognized.  A
+``foo-1.2.0`` value in a file is simply an unknown tag, and is read as a plain
+value.
+
+The order matters when *writing*.  A newly created or replaced ``asdf_foo_t``
+is serialized with the **first** tag listed, so put the preferred version
+first.  A value read from a file and left alone keeps the tag it was read with.
+
+If two versions of a schema differ enough to warrant separate deserializers, it
+is also possible to register multiple extensions under different tags, sharing
+whichever of the ``asdf_foo_*`` functions still apply.

--- a/include/asdf/extension.h
+++ b/include/asdf/extension.h
@@ -40,34 +40,61 @@ typedef struct {
 } asdf_software_t;
 
 
+/**
+ * Serialize a native object into an `asdf_value_t`
+ *
+ * :param file: The `asdf_file_t *` the value is created for
+ * :param obj: The native object to serialize
+ * :param userdata: The extension's ``userdata``
+ * :return: The new `asdf_value_t *`, or ``NULL`` on failure
+ */
 typedef asdf_value_t *(*asdf_extension_serialize_t)(
     asdf_file_t *file, const void *obj, const void *userdata);
 
 
+/**
+ * Deserialize an `asdf_value_t` into a native object
+ *
+ * :param value: The raw `asdf_value_t *` read from the file
+ * :param userdata: The extension's ``userdata``
+ * :param out: Set to the newly allocated native object on success
+ * :return: ``ASDF_VALUE_OK`` on success, otherwise an error code
+ */
 typedef asdf_value_err_t (*asdf_extension_deserialize_t)(
     asdf_value_t *value, const void *userdata, void **out);
 
 
+/**
+ * Deep-copy a native object
+ *
+ * :param obj: The native object to copy
+ * :return: The newly allocated copy, or ``NULL`` on failure
+ */
 typedef void *(*asdf_extension_copy_t)(const void *obj);
 
 
+/**
+ * Free a native object produced by an `asdf_extension_deserialize_t`
+ *
+ * :param obj: The native object to free
+ */
 typedef void (*asdf_extension_dealloc_t)(void *obj);
 
 
 /**
- * Table of callbacks implementing an extension's behavior
+ * Table of the methods implementing an extension's behavior
  *
  * Extension authors define one of these statically and pass a pointer to it to
  * `ASDF_REGISTER_EXTENSION`.
  */
 typedef struct {
-    /** Serialize a native object into an `asdf_value_t`, or ``NULL`` */
+    /** Serializer for the extension type, or ``NULL`` if it cannot be written */
     asdf_extension_serialize_t serialize;
-    /** Deserialize an `asdf_value_t` into a native object */
+    /** Deserializer for the extension type */
     asdf_extension_deserialize_t deserialize;
-    /** Deep-copy callback, or ``NULL`` for a shallow copy */
+    /** Deep-copy method, or ``NULL`` for a shallow copy */
     asdf_extension_copy_t copy;
-    /** Free a native object produced by ``deserialize`` */
+    /** Method to free objects produced by ``deserialize`` */
     asdf_extension_dealloc_t dealloc;
 } asdf_extension_vtab_t;
 

--- a/include/asdf/extension.h
+++ b/include/asdf/extension.h
@@ -54,13 +54,34 @@ typedef void *(*asdf_extension_copy_t)(const void *obj);
 typedef void (*asdf_extension_dealloc_t)(void *obj);
 
 
-struct _asdf_extension {
-    const char *tag;
-    asdf_software_t *software;
+/**
+ * Table of callbacks implementing an extension's behavior
+ *
+ * Extension authors define one of these statically and pass a pointer to it to
+ * `ASDF_REGISTER_EXTENSION`.
+ */
+typedef struct {
+    /** Serialize a native object into an `asdf_value_t`, or ``NULL`` */
     asdf_extension_serialize_t serialize;
+    /** Deserialize an `asdf_value_t` into a native object */
     asdf_extension_deserialize_t deserialize;
+    /** Deep-copy callback, or ``NULL`` for a shallow copy */
     asdf_extension_copy_t copy;
+    /** Free a native object produced by ``deserialize`` */
     asdf_extension_dealloc_t dealloc;
+} asdf_extension_vtab_t;
+
+
+struct _asdf_extension {
+    /**
+     * ``NULL``-terminated array of full YAML tags this extension handles
+     *
+     * ``tags[0]`` is written when serializing a newly created or replaced
+     * object of this type; any of the listed tags is recognized when reading.
+     */
+    const char *const *tags;
+    asdf_software_t *software;
+    const asdf_extension_vtab_t *vtab;
     void *userdata;
 };
 
@@ -119,15 +140,15 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
 #define ASDF_EXT_STATIC_NAME(extname) ASDF_EXPAND(ASDF_EXT_PREFIX, _##extname##_extension)
 
 
-#define ASDF_EXT_DEFINE( \
-    extname, _tag, _software, _serialize, _deserialize, _copy, _dealloc, _userdata) \
+#define ASDF_EXT_TAGS_NAME(extname) ASDF_EXPAND(ASDF_EXT_PREFIX, _##extname##_extension_tags)
+
+
+#define ASDF_EXT_DEFINE(extname, _software, _vtab, _userdata, ...) \
+    static const char *const ASDF_EXT_TAGS_NAME(extname)[] = {__VA_ARGS__, NULL}; \
     static asdf_extension_t ASDF_EXT_STATIC_NAME(extname) = { \
-        .tag = (_tag), \
+        .tags = ASDF_EXT_TAGS_NAME(extname), \
         .software = (_software), \
-        .serialize = (_serialize), \
-        .deserialize = (_deserialize), \
-        .copy = (_copy), \
-        .dealloc = (_dealloc), \
+        .vtab = (_vtab), \
         .userdata = (_userdata)}
 
 
@@ -184,14 +205,14 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
         asdf_extension_t *ext = &ASDF_EXT_STATIC_NAME(extname); \
         if (!ext) \
             return NULL; \
-        if (!ext->copy) { \
+        if (!ext->vtab || !ext->vtab->copy) { \
             void *clone = malloc(sizeof(type)); \
             if (!clone) \
                 return NULL; \
             memcpy(clone, object, sizeof(type)); \
             return clone; \
         } \
-        return (type *)ext->copy(object); \
+        return (type *)ext->vtab->copy(object); \
     }
 
 
@@ -228,9 +249,9 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
         if (!object) \
             return; \
         asdf_extension_t *ext = &ASDF_EXT_STATIC_NAME(extname); \
-        if (!ext && ext->dealloc) \
+        if (!ext->vtab || !ext->vtab->dealloc) \
             return; \
-        ext->dealloc(object); \
+        ext->vtab->dealloc(object); \
     }
 
 
@@ -249,23 +270,26 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
  * ``asdf_<extname>_clone``, ``asdf_<extname>_array_clone``, and
  * ``asdf_<extname>_destroy``.
  *
+ * One or more YAML tags are passed as trailing arguments; the extension is
+ * registered for each of them, so a single extension can handle several
+ * versions of the same schema.  At least one tag is required.  When an object
+ * of this type is serialized it is written with the *first* tag listed, so put
+ * the preferred tag first.  Values read from a file and left unmodified keep
+ * the tag they were read with.
+ *
  * :param extname: Base name for the generated functions (need not match the
  *   C ``type``)
- * :param tag: The YAML tag string the extension is registered for
  * :param type: The C type the extension deserializes to (e.g. ``asdf_foo_t``)
  * :param software: Pointer to an `asdf_software_t` describing the software that
  *   implements the extension
- * :param serialize: A ``asdf_extension_serialize_t`` callback, or ``NULL``
- * :param deserialize: A ``asdf_extension_deserialize_t`` callback
- * :param copy: A ``asdf_extension_copy_t`` deep-copy callback, or ``NULL`` for
- *   a shallow copy
- * :param dealloc: A ``asdf_extension_dealloc_t`` callback to free the type
+ * :param vtab: Pointer to an `asdf_extension_vtab_t` holding the extension's
+ *   callbacks
  * :param userdata: Optional ``void *`` passed through to the callbacks, or
  *   ``NULL``
+ * :param ...: One or more YAML tag strings the extension is registered for
  */
-#define ASDF_REGISTER_EXTENSION( \
-    extname, tag, type, software, serialize, deserialize, copy, dealloc, userdata) \
-    ASDF_EXT_DEFINE(extname, tag, software, serialize, deserialize, copy, dealloc, userdata); \
+#define ASDF_REGISTER_EXTENSION(extname, type, software, vtab, userdata, ...) \
+    ASDF_EXT_DEFINE(extname, software, vtab, userdata, __VA_ARGS__); \
     ASDF_EXT_DEFINE_VALUE_AS_TYPE(extname, type) \
     ASDF_EXT_DEFINE_VALUE_IS_TYPE(extname) \
     ASDF_EXT_DEFINE_VALUE_OF_TYPE(extname, type) \

--- a/src/core/asdf.c
+++ b/src/core/asdf.c
@@ -457,7 +457,8 @@ ASDF_REGISTER_EXTENSION(
     &libasdf_software,
     &asdf_meta_vtab,
     NULL,
-    ASDF_CORE_ASDF_TAG);
+    ASDF_CORE_ASDF_TAG,
+    ASDF_CORE_TAG_PREFIX "asdf-1.0.0");
 // clang-format on
 
 

--- a/src/core/asdf.c
+++ b/src/core/asdf.c
@@ -442,16 +442,23 @@ failure:
  * The internal types and methods are named ``asdf_meta_*``, however, to avoid names like
  * ``asdf_asdf_t`` and ``asdf_get_asdf`` and so on.
  */
+static const asdf_extension_vtab_t asdf_meta_vtab = {
+    .serialize = asdf_meta_serialize,
+    .deserialize = asdf_meta_deserialize,
+    .copy = asdf_meta_copy,
+    .dealloc = asdf_meta_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     meta,
-    ASDF_CORE_ASDF_TAG,
     asdf_meta_t,
     &libasdf_software,
-    asdf_meta_serialize,
-    asdf_meta_deserialize,
-    asdf_meta_copy,
-    asdf_meta_dealloc,
-    NULL);
+    &asdf_meta_vtab,
+    NULL,
+    ASDF_CORE_ASDF_TAG);
+// clang-format on
 
 
 ASDF_CONSTRUCTOR static void asdf_libasdf_version_init() {

--- a/src/core/datatype.c
+++ b/src/core/datatype.c
@@ -129,9 +129,6 @@ const char *asdf_scalar_datatype_to_string(asdf_scalar_datatype_t datatype) {
 
 
 #ifdef ASDF_LOG_ENABLED
-static void warn_unsupported_datatype(UNUSED(asdf_value_t *value)) {
-}
-#else
 static void warn_unsupported_datatype(asdf_value_t *value) {
     const char *path = asdf_value_path(value);
     ASDF_LOG(
@@ -141,6 +138,9 @@ static void warn_unsupported_datatype(asdf_value_t *value) {
         "that the current version only supports basic scalar numeric (non-string) "
         "datatypes",
         path);
+}
+#else
+static void warn_unsupported_datatype(UNUSED(asdf_value_t *value)) {
 }
 #endif
 

--- a/src/core/datatype.c
+++ b/src/core/datatype.c
@@ -777,16 +777,23 @@ static asdf_value_t *asdf_datatype_serialize(
 
 
 // Declare the extension for datatype-1.0.0
+static const asdf_extension_vtab_t asdf_datatype_vtab = {
+    .serialize = asdf_datatype_serialize,
+    .deserialize = asdf_datatype_deserialize,
+    .copy = NULL, /* TODO: copy */
+    .dealloc = asdf_datatype_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     datatype,
-    ASDF_CORE_DATATYPE_TAG,
     asdf_datatype_t,
     &libasdf_software,
-    asdf_datatype_serialize,
-    asdf_datatype_deserialize,
-    NULL, /* TODO: copy */
-    asdf_datatype_dealloc,
-    NULL);
+    &asdf_datatype_vtab,
+    NULL,
+    ASDF_CORE_DATATYPE_TAG);
+// clang-format on
 
 
 /** Additional public datatype APIs */

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -199,13 +199,20 @@ failure:
 }
 
 
+static const asdf_extension_vtab_t asdf_extension_metadata_vtab = {
+    .serialize = asdf_extension_metadata_serialize,
+    .deserialize = asdf_extension_metadata_deserialize,
+    .copy = asdf_extension_metadata_copy,
+    .dealloc = asdf_extension_metadata_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     extension_metadata,
-    ASDF_CORE_EXTENSION_METADATA_TAG,
     asdf_extension_metadata_t,
     &libasdf_software,
-    asdf_extension_metadata_serialize,
-    asdf_extension_metadata_deserialize,
-    asdf_extension_metadata_copy,
-    asdf_extension_metadata_dealloc,
-    NULL);
+    &asdf_extension_metadata_vtab,
+    NULL,
+    ASDF_CORE_EXTENSION_METADATA_TAG);
+// clang-format on

--- a/src/core/history_entry.c
+++ b/src/core/history_entry.c
@@ -178,7 +178,7 @@ static asdf_value_err_t asdf_history_entry_deserialize(
         const asdf_extension_t *time_ext = asdf_extension_get(value->file, ASDF_CORE_TIME_TAG);
         if (time_ext) {
             bool valid_time = false;
-            time_ext->deserialize(prop, NULL, (void *)&time);
+            time_ext->vtab->deserialize(prop, NULL, (void *)&time);
 
             if (time) {
                 valid_time = true;
@@ -298,16 +298,23 @@ failure:
 /* Define the extension for the core/history_entry-1.0.0 schema
  *
  */
+static const asdf_extension_vtab_t asdf_history_entry_vtab = {
+    .serialize = asdf_history_entry_serialize,
+    .deserialize = asdf_history_entry_deserialize,
+    .copy = asdf_history_entry_copy,
+    .dealloc = asdf_history_entry_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     history_entry,
-    ASDF_CORE_HISTORY_ENTRY_TAG,
     asdf_history_entry_t,
     &libasdf_software,
-    asdf_history_entry_serialize,
-    asdf_history_entry_deserialize,
-    asdf_history_entry_copy,
-    asdf_history_entry_dealloc,
-    NULL);
+    &asdf_history_entry_vtab,
+    NULL,
+    ASDF_CORE_HISTORY_ENTRY_TAG);
+// clang-format on
 
 
 /** Additional history entry methods */

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/mman.h>
 
 #ifdef HAVE_CONFIG_H
@@ -69,6 +70,73 @@ static void warn_invalid_strides(asdf_value_t *value) {
         path);
 }
 #endif
+
+
+typedef struct {
+    asdf_scalar_datatype_t type;
+    unsigned int major;
+    unsigned int minor;
+} ndarray_datatype_version_t;
+
+
+/* Scalar datatypes introduced after ndarray-1.0.0 */
+static const ndarray_datatype_version_t ndarray_datatype_versions[] = {
+    {ASDF_DATATYPE_FLOAT16, 1, 1},
+};
+
+
+/*
+ * Warn if a datatype is used under an ndarray tag older than the schema
+ * version that introduced it; the value is still read
+ */
+static void warn_datatype_tag_version(asdf_value_t *value, const asdf_datatype_t *datatype) {
+#ifdef ASDF_LOG_ENABLED
+    const char *tag = asdf_value_tag(value);
+
+    if (!tag)
+        return;
+
+    asdf_tag_t *parsed = asdf_tag_parse(tag);
+
+    if (!parsed)
+        return;
+
+    const asdf_version_t *version = parsed->version;
+
+    /* A version that did not parse as MAJOR.MINOR.PATCH is left all-zero */
+    if (!version || (0 == version->major && 0 == version->minor && 0 == version->patch))
+        goto cleanup;
+
+    for (size_t idx = 0; idx < ARRAY_SIZE(ndarray_datatype_versions); idx++) {
+        const ndarray_datatype_version_t *introduced = &ndarray_datatype_versions[idx];
+
+        if (introduced->type != datatype->type)
+            continue;
+
+        if (version->major > introduced->major ||
+            (version->major == introduced->major && version->minor >= introduced->minor))
+            continue;
+
+        const char *path = asdf_value_path(value);
+        ASDF_LOG(
+            value->file,
+            ASDF_LOG_WARN,
+            "ndarray at %s has a %s datatype, which was only introduced in %s-%u.%u.0",
+            path,
+            asdf_scalar_datatype_to_string(datatype->type),
+            parsed->name,
+            introduced->major,
+            introduced->minor);
+        break;
+    }
+
+cleanup:
+    asdf_tag_destroy(parsed);
+#else
+    (void)value;
+    (void)datatype;
+#endif
+}
 
 
 /**
@@ -635,6 +703,8 @@ static asdf_value_err_t asdf_ndarray_deserialize_inline(
     /* Mark as inline so the same ndarray re-serializes inline by default */
     ndarray->internal->array_storage = ASDF_ARRAY_STORAGE_INLINE;
 
+    warn_datatype_tag_version(value, &ndarray->datatype);
+
     *out = ndarray;
     err = ASDF_VALUE_OK;
 
@@ -751,6 +821,8 @@ static asdf_value_err_t asdf_ndarray_deserialize(
 
     if (ASDF_IS_ERR(err))
         goto cleanup;
+
+    warn_datatype_tag_version(value, &ndarray->datatype);
 
     ndarray->source = source;
     internal->file = value->file;
@@ -1295,7 +1367,10 @@ ASDF_REGISTER_EXTENSION(
     &libasdf_software,
     &asdf_ndarray_vtab,
     NULL,
-    ASDF_CORE_NDARRAY_TAG);
+    ASDF_CORE_NDARRAY_TAG,
+    /* ndarray-1.1.0 adds float16 and requires one of source/data; otherwise
+     * 1.0.0 is read by the same deserializer */
+    ASDF_CORE_TAG_PREFIX "ndarray-1.0.0");
 // clang-format on
 
 

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -57,9 +57,6 @@ asdf_block_t *asdf_ndarray_block(asdf_ndarray_t *ndarray) {
 
 
 #ifdef ASDF_LOG_ENABLED
-static void warn_invalid_strides(UNUSED(asdf_value_t *value)) {
-}
-#else
 static void warn_invalid_strides(asdf_value_t *value) {
     const char *path = asdf_value_path(value);
     ASDF_LOG(
@@ -69,9 +66,13 @@ static void warn_invalid_strides(asdf_value_t *value) {
         "non-zero integers with the same length as shape",
         path);
 }
+#else
+static void warn_invalid_strides(UNUSED(asdf_value_t *value)) {
+}
 #endif
 
 
+#ifdef ASDF_LOG_ENABLED
 typedef struct {
     asdf_scalar_datatype_t type;
     unsigned int major;
@@ -90,7 +91,6 @@ static const ndarray_datatype_version_t ndarray_datatype_versions[] = {
  * version that introduced it; the value is still read
  */
 static void warn_datatype_tag_version(asdf_value_t *value, const asdf_datatype_t *datatype) {
-#ifdef ASDF_LOG_ENABLED
     const char *tag = asdf_value_tag(value);
 
     if (!tag)
@@ -132,11 +132,11 @@ static void warn_datatype_tag_version(asdf_value_t *value, const asdf_datatype_t
 
 cleanup:
     asdf_tag_destroy(parsed);
-#else
-    (void)value;
-    (void)datatype;
-#endif
 }
+#else
+static void warn_datatype_tag_version(asdf_value_t *value, const asdf_datatype_t *datatype) {
+}
+#endif
 
 
 /**

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -1280,16 +1280,23 @@ cleanup:
  *
  * TODO: Also support ndarray-1.0.0
  */
+static const asdf_extension_vtab_t asdf_ndarray_vtab = {
+    .serialize = asdf_ndarray_serialize,
+    .deserialize = asdf_ndarray_deserialize,
+    .copy = NULL, /* TODO: copy */
+    .dealloc = asdf_ndarray_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     ndarray,
-    ASDF_CORE_NDARRAY_TAG,
     asdf_ndarray_t,
     &libasdf_software,
-    asdf_ndarray_serialize,
-    asdf_ndarray_deserialize,
-    NULL, /* TODO: copy */
-    asdf_ndarray_dealloc,
-    NULL);
+    &asdf_ndarray_vtab,
+    NULL,
+    ASDF_CORE_NDARRAY_TAG);
+// clang-format on
 
 
 /* ndarray methods */

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -1348,9 +1348,7 @@ cleanup:
 
 
 /*
- * Define the extension for the core/ndarray-1.1.0 schema
- *
- * TODO: Also support ndarray-1.0.0
+ * Define the extension for the core/ndarray-x.y.z schema
  */
 static const asdf_extension_vtab_t asdf_ndarray_vtab = {
     .serialize = asdf_ndarray_serialize,

--- a/src/core/software.c
+++ b/src/core/software.c
@@ -195,16 +195,23 @@ failure:
 }
 
 
+static const asdf_extension_vtab_t asdf_software_vtab = {
+    .serialize = asdf_software_serialize,
+    .deserialize = asdf_software_deserialize,
+    .copy = asdf_software_copy,
+    .dealloc = asdf_software_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     software,
-    ASDF_CORE_SOFTWARE_TAG,
     asdf_software_t,
     &libasdf_software,
-    asdf_software_serialize,
-    asdf_software_deserialize,
-    asdf_software_copy,
-    asdf_software_dealloc,
-    NULL);
+    &asdf_software_vtab,
+    NULL,
+    ASDF_CORE_SOFTWARE_TAG);
+// clang-format on
 
 
 /** Additional software-related methods */

--- a/src/core/software.c
+++ b/src/core/software.c
@@ -104,14 +104,14 @@ static asdf_value_err_t asdf_software_deserialize(
     asdf_value_destroy(prop);
 
     prop = asdf_mapping_get(software_map, "homepage");
-    if (ASDF_VALUE_OK != asdf_value_as_string0(prop, &homepage))
+    if (prop && ASDF_VALUE_OK != asdf_value_as_string0(prop, &homepage))
         ASDF_LOG(
             value->file, ASDF_LOG_WARN, "ignoring invalid value for for homepage in software tag");
 
     asdf_value_destroy(prop);
 
     prop = asdf_mapping_get(software_map, "author");
-    if (ASDF_VALUE_OK != asdf_value_as_string0(prop, &author))
+    if (prop && ASDF_VALUE_OK != asdf_value_as_string0(prop, &author))
         ASDF_LOG(
             value->file, ASDF_LOG_WARN, "ignoring invalid value for for author in software tag");
 

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -915,13 +915,20 @@ static void asdf_time_dealloc(void *value) {
 }
 
 
+static const asdf_extension_vtab_t asdf_time_vtab = {
+    .serialize = asdf_time_serialize,
+    .deserialize = asdf_time_deserialize,
+    .copy = asdf_time_copy,
+    .dealloc = asdf_time_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     time,
-    ASDF_CORE_TIME_TAG,
     asdf_time_t,
     &libasdf_software,
-    asdf_time_serialize,
-    asdf_time_deserialize,
-    asdf_time_copy,
-    asdf_time_dealloc,
-    NULL);
+    &asdf_time_vtab,
+    NULL,
+    ASDF_CORE_TIME_TAG);
+// clang-format on

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -111,7 +111,7 @@ static const char *ASDF_TIME_SFMT_UNIX[] = {"%s"};
                 (HAS_TIME) = true; \
                 break; \
             } \
-        } while (idx++ && idx < sizeof((TYPE)) / sizeof(*(TYPE))); \
+        } while (idx++ && idx < ARRAY_SIZE(TYPE)); \
     }
 
 #define JD_B1900 2415020.31352
@@ -484,7 +484,7 @@ static const char *const asdf_time_scale_names[] = {
 
 
 const char *asdf_time_format_string(asdf_time_format_t format) {
-    const size_t nformats = sizeof(asdf_time_format_names) / sizeof(asdf_time_format_names[0]);
+    const size_t nformats = ARRAY_SIZE(asdf_time_format_names);
 
     if (format < 0 || format > nformats)
         return NULL;
@@ -496,7 +496,7 @@ const char *asdf_time_format_string(asdf_time_format_t format) {
 /* Helpers for format detection and range validation */
 
 static bool asdf_time_format_parse(const char *name, asdf_time_format_t *out) {
-    const size_t nformats = sizeof(asdf_time_format_names) / sizeof(asdf_time_format_names[0]);
+    const size_t nformats = ARRAY_SIZE(asdf_time_format_names);
     for (size_t idx = 0; idx < nformats; idx++) {
         if (asdf_time_format_names[idx] && !strcmp(name, asdf_time_format_names[idx])) {
             *out = (asdf_time_format_t)idx;
@@ -508,7 +508,7 @@ static bool asdf_time_format_parse(const char *name, asdf_time_format_t *out) {
 
 
 static bool asdf_time_scale_parse(const char *name, asdf_time_scale_t *out) {
-    const size_t nscales = sizeof(asdf_time_scale_names) / sizeof(asdf_time_scale_names[0]);
+    const size_t nscales = ARRAY_SIZE(asdf_time_scale_names);
     for (size_t idx = 0; idx < nscales; idx++) {
         if (asdf_time_scale_names[idx] && !strcmp(name, asdf_time_scale_names[idx])) {
             *out = (asdf_time_scale_t)idx;
@@ -637,7 +637,7 @@ static asdf_value_t *asdf_time_serialize(
         goto cleanup;
     }
 
-    const size_t nformats = sizeof(asdf_time_format_names) / sizeof(asdf_time_format_names[0]);
+    const size_t nformats = ARRAY_SIZE(asdf_time_format_names);
     if ((size_t)t->format >= nformats || !asdf_time_format_names[t->format]) {
         ASDF_LOG(file, ASDF_LOG_WARN, ASDF_CORE_TIME_TAG " unknown or reserved format type");
         goto cleanup;
@@ -657,7 +657,7 @@ static asdf_value_t *asdf_time_serialize(
 
     /* Write scale only if non-UTC */
     if (t->scale != ASDF_TIME_SCALE_UTC) {
-        const size_t nscales = sizeof(asdf_time_scale_names) / sizeof(asdf_time_scale_names[0]);
+        const size_t nscales = ARRAY_SIZE(asdf_time_scale_names);
         if ((size_t)t->scale < nscales) {
             const char *scale = asdf_time_scale_names[t->scale];
 

--- a/src/extension_registry.c
+++ b/src/extension_registry.c
@@ -56,28 +56,39 @@ void asdf_extension_register(asdf_extension_t *ext) {
     /* TODO: Handle tag overlaps on registration */
     // Ensure extension map initialized
     asdf_extension_map_create();
-    const char *tag = ext->tag;
+
+    const char *tag = NULL;
+    char *full_tag = NULL;
 
 #ifdef ASDF_LOG_ENABLED
     asdf_global_context_t *ctx = asdf_global_context_get();
 #endif
 
-    char *full_tag = asdf_yaml_tag_canonicalize(tag);
-    if (!full_tag) {
-#ifdef ASDF_LOG_ENABLED
-        ASDF_LOG(ctx, ASDF_LOG_FATAL, "failed to allocate memory for extension tag %s", tag);
-#endif
+    if (!ext->tags)
         return;
-    }
-    asdf_extension_map_result res = asdf_extension_map_emplace(&extension_map, full_tag, ext);
+
+    // The extension is registered once per tag it declares support for; all
+    // entries map to the same asdf_extension_t
+    for (size_t idx = 0; (tag = ext->tags[idx]); idx++) {
+        full_tag = asdf_yaml_tag_canonicalize(tag);
+        if (!full_tag) {
+#ifdef ASDF_LOG_ENABLED
+            ASDF_LOG(ctx, ASDF_LOG_FATAL, "failed to allocate memory for extension tag %s", tag);
+#endif
+            return;
+        }
+        asdf_extension_map_result res = asdf_extension_map_emplace(&extension_map, full_tag, ext);
 
 #ifdef ASDF_LOG_ENABLED
-    /* TODO: Improve extension registration logging; more details about each extension */
-    if (res.inserted)
-        ASDF_LOG(ctx, ASDF_LOG_DEBUG, "registered extension for tag %s", full_tag);
-    else
-        ASDF_LOG(ctx, ASDF_LOG_WARN, "failed to register extension for tag %s", full_tag);
+        /* TODO: Improve extension registration logging; more details about each extension */
+        if (res.inserted)
+            ASDF_LOG(ctx, ASDF_LOG_DEBUG, "registered extension for tag %s", full_tag);
+        else
+            ASDF_LOG(ctx, ASDF_LOG_WARN, "failed to register extension for tag %s", full_tag);
+#else
+        (void)res;
 #endif
 
-    free(full_tag);
+        free(full_tag);
+    }
 }

--- a/src/log.c
+++ b/src/log.c
@@ -31,7 +31,7 @@ static const char *level_names[] = {"NONE", "TRACE", "DEBUG", "INFO", "WARN", "E
 
 
 _Static_assert(
-    ASDF_LOG_NUM_LEVELS == (sizeof(level_names) / sizeof(level_names[0])),
+    ASDF_LOG_NUM_LEVELS == ARRAY_SIZE(level_names),
     "Mismatch between log level enum and level_strings array");
 
 
@@ -39,7 +39,7 @@ _Static_assert(
 static const char *level_colors[] = {
     "", COLOR_BRIGHT_BLUE, COLOR_CYAN, COLOR_GREEN, COLOR_YELLOW, COLOR_RED, COLOR_MAGENTA};
 _Static_assert(
-    ASDF_LOG_NUM_LEVELS == (sizeof(level_colors) / sizeof(level_colors[0])),
+    ASDF_LOG_NUM_LEVELS == ARRAY_SIZE(level_colors),
     "Mismatch between log level enum and level_strings array");
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 #include "file.h"
 #include "info.h"
 #include "parser.h"
+#include "util.h"
 
 const char *argp_program_version = PACKAGE_STRING;
 const char *argp_program_bug_address = PACKAGE_BUGREPORT;
@@ -671,7 +672,7 @@ static const asdf_subcmd_def_t subcmds[] = {
     [ASDF_SUBCMD_VERIFY_CHECKSUMS] = {"verify-checksums", verify_checksums_doc, verify_checksums_main},
 };
 // clang-format on
-#define N_SUBCMDS (sizeof(subcmds) / sizeof(subcmds[0]))
+#define N_SUBCMDS ARRAY_SIZE(subcmds)
 
 
 /* Help filter for the global parser.  Intercepts ARGP_KEY_HELP_PRE_DOC to

--- a/src/util.h
+++ b/src/util.h
@@ -38,6 +38,10 @@
 #define FIELD_SIZEOF(t, f) (sizeof(((t *)0)->f))
 
 
+/* Number of elements in a fixed-size array */
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+
 /* Cast memset to volatile to prevent opt-away */
 #define ZERO_MEMORY(ptr, size) \
     do { \

--- a/src/value.c
+++ b/src/value.c
@@ -1487,7 +1487,7 @@ asdf_value_err_t asdf_value_as_extension_type(
         return ASDF_VALUE_OK;
     }
 
-    assert(ext->deserialize);
+    assert(ext->vtab && ext->vtab->deserialize);
     // Clone the raw value without existing extension inference to pass to the the extension's
     // deserialize method.
     asdf_value_t *raw_value = asdf_value_clone_impl(value, true);
@@ -1497,7 +1497,7 @@ asdf_value_err_t asdf_value_as_extension_type(
         return ASDF_VALUE_ERR_OOM;
     }
 
-    asdf_value_err_t err = ext->deserialize(raw_value, ext->userdata, out);
+    asdf_value_err_t err = ext->vtab->deserialize(raw_value, ext->userdata, out);
     asdf_value_destroy(raw_value);
 
     if (ASDF_VALUE_OK == err)
@@ -1511,8 +1511,12 @@ asdf_value_err_t asdf_value_as_extension_type(
 asdf_value_t *asdf_value_of_extension_type(
     asdf_file_t *file, const void *obj, const asdf_extension_t *ext) {
 
-    if (!ext->serialize) {
-        ASDF_ERROR_COMMON(file, ASDF_ERR_EXTENSION_NOT_FOUND, ext->tag);
+    // The first tag registered with an extension is the one written for newly
+    // serialized objects
+    const char *tag = (ext->tags && ext->tags[0]) ? ext->tags[0] : NULL;
+
+    if (!tag || !ext->vtab || !ext->vtab->serialize) {
+        ASDF_ERROR_COMMON(file, ASDF_ERR_EXTENSION_NOT_FOUND, tag ? tag : "(untagged)");
         return NULL;
     }
 
@@ -1530,7 +1534,7 @@ asdf_value_t *asdf_value_of_extension_type(
     //
     // Should also look into better managing exactly when to attach a new block
     // to the file for an ndarray; look to the Python library for inspiration
-    asdf_value_t *value = ext->serialize(file, obj, ext->userdata);
+    asdf_value_t *value = ext->vtab->serialize(file, obj, ext->userdata);
 
     // TODO: Might be better if serialize also returned an asdf_value_t so we
     // can report serialization errors better
@@ -1546,9 +1550,9 @@ asdf_value_t *asdf_value_of_extension_type(
     value->scalar.ext = new_ext;
     value->extension_checked = true;
     value->type = ASDF_VALUE_EXTENSION;
-    value->tag = strdup(ext->tag);
+    value->tag = strdup(tag);
 
-    const char *normalized_tag = asdf_file_tag_normalize(file, ext->tag);
+    const char *normalized_tag = asdf_file_tag_normalize(file, tag);
 
     if (!normalized_tag) {
         ASDF_ERROR_OOM(file);

--- a/src/yaml.c
+++ b/src/yaml.c
@@ -11,6 +11,7 @@
 
 #include "event.h"
 #include "file.h"
+#include "util.h"
 #include "yaml.h"
 
 
@@ -45,7 +46,7 @@ asdf_yaml_event_type_t asdf_yaml_event_type(const asdf_event_t *event) {
         return ASDF_YAML_NONE_EVENT;
 
     enum fy_event_type type = event->payload.yaml->type;
-    if (type < 0 || type >= (int)(sizeof(fyet_to_asdf_event) / sizeof(fyet_to_asdf_event[0]))) {
+    if (type < 0 || type >= (int)ARRAY_SIZE(fyet_to_asdf_event)) {
         abort();
     }
     return fyet_to_asdf_event[type];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,8 +68,14 @@ foreach(source_file ${source_files})
     add_executable(${test_executable} ${source_file})
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
         target_compile_options(${test_executable} PRIVATE ${nix_cflags} ${nix_gnu_cflags})
+        # Make __FILE__ names relative to source root
+        target_compile_options(${test_executable} PRIVATE
+            -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
     elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
         target_compile_options(${test_executable} PRIVATE ${nix_cflags} ${nix_clang_cflags})
+        # Make __FILE__ names relative to source root
+        target_compile_options(${test_executable} PRIVATE
+            -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
     elseif (CMAKE_C_COMPILER_ID STREQUAL "MSVC")
         target_compile_options(${test_executable} PRIVATE ${win_cflags} ${win_msvc_cflags})
     endif()

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ check_PROGRAMS = \
     test-ndarray.unit \
     test-parse-util.unit \
     test-parser.unit \
+    test-reference-files.unit \
     test-stream.unit \
     test-tag.unit \
     test-tests.unit \
@@ -173,6 +174,13 @@ test_emitter_unit_CFLAGS = $(unit_test_cflags)
 test_emitter_unit_LDFLAGS = $(unit_test_ldflags)
 test_emitter_unit_LDADD = libmunit.a $(top_builddir)/libasdf_static.la
 endif
+
+# test-reference-files.unit
+test_reference_files_unit_SOURCES = test-reference-files.c
+test_reference_files_unit_CPPFLAGS = $(unit_test_cppflags)
+test_reference_files_unit_CFLAGS = $(unit_test_cflags)
+test_reference_files_unit_LDFLAGS = $(unit_test_ldflags)
+test_reference_files_unit_LDADD = $(unit_test_ldadd)
 
 # test-stream.unit
 test_stream_unit_SOURCES = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,7 +59,8 @@ unit_test_cppflags = \
     $(unit_test_base_cppflags)
 
 unit_test_cflags = \
-    $(munit_cflags) $(FYAML_CFLAGS) $(STATGRAB_CFLAGS) $(LZ4_CFLAGS) $(CODE_COVERAGE_CFLAGS) $(ASDF_CFLAGS)
+    $(munit_cflags) $(FYAML_CFLAGS) $(STATGRAB_CFLAGS) $(LZ4_CFLAGS) $(CODE_COVERAGE_CFLAGS) $(ASDF_CFLAGS) \
+    -fmacro-prefix-map=$(top_srcdir)/=
 unit_test_ldflags =
 
 if DEBUG

--- a/tests/fixtures/trivial-extension.asdf
+++ b/tests/fixtures/trivial-extension.asdf
@@ -8,5 +8,5 @@ asdf_library: !core/software-1.0.0
   version: 0.0.0
   author: The libasdf Developers
   homepage: https://github.com/asdf-format/libasdf
-foo: !tests/foo-1.0.0 foo
+foo: !tests/foo-1.1.0 foo
 ...

--- a/tests/test-core-extensions.c
+++ b/tests/test-core-extensions.c
@@ -385,7 +385,7 @@ MU_TEST(datatype) {
     // implicit tags
     asdf_value_t *value = asdf_get_value(file, "data/datatype");
     assert_not_null(value);
-    asdf_value_err_t err = ext->deserialize(value, NULL, (void **)&datatype);
+    asdf_value_err_t err = ext->vtab->deserialize(value, NULL, (void **)&datatype);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_not_null(datatype);
     asdf_value_destroy(value);
@@ -410,7 +410,7 @@ MU_TEST(datatype) {
     datatype = NULL;
     value = asdf_get_value(file, "structured/datatype");
     assert_not_null(value);
-    err = ext->deserialize(value, NULL, (void **)&datatype);
+    err = ext->vtab->deserialize(value, NULL, (void **)&datatype);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_not_null(datatype);
     asdf_value_destroy(value);

--- a/tests/test-core-extensions.c
+++ b/tests/test-core-extensions.c
@@ -5,16 +5,16 @@
 #include "munit.h"
 #include "util.h"
 
-#include <asdf/core/asdf.h>
-#include <asdf/core/datatype.h>
-#include <asdf/core/extension_metadata.h>
-#include <asdf/core/time.h>
-#include <asdf/core/history_entry.h>
-#include <asdf/core/ndarray.h>
-#include <asdf/core/software.h>
-#include <asdf/extension.h>
-#include <asdf/file.h>
-#include <asdf/value.h>
+#include "asdf/core/asdf.h"
+#include "asdf/core/datatype.h"
+#include "asdf/core/extension_metadata.h"
+#include "asdf/core/time.h"
+#include "asdf/core/history_entry.h"
+#include "asdf/core/ndarray.h"
+#include "asdf/core/software.h"
+#include "asdf/extension.h"
+#include "asdf/file.h"
+#include "asdf/value.h"
 
 
 /* TODO: Should have more tests for this, for now just using one test case that's already lying

--- a/tests/test-event.c
+++ b/tests/test-event.c
@@ -1,9 +1,9 @@
 #include <string.h>
 
-#include <asdf/event.h>
-#include <asdf/log.h>
-#include <asdf/parser.h>
-#include <asdf/yaml.h>
+#include "asdf/event.h"
+#include "asdf/log.h"
+#include "asdf/parser.h"
+#include "asdf/yaml.h"
 
 #include "munit.h"
 #include "util.h"

--- a/tests/test-extension.c
+++ b/tests/test-extension.c
@@ -4,11 +4,11 @@
 #include "munit.h"
 #include "util.h"
 
-#include <asdf/core/software.h>
-#include <asdf/extension.h>
-#include <asdf/file.h>
-#include <asdf/util.h>
-#include <asdf/version.h>
+#include "asdf/core/software.h"
+#include "asdf/extension.h"
+#include "asdf/file.h"
+#include "asdf/util.h"
+#include "asdf/version.h"
 
 
 /* Struct that represents the "foo" type extension */

--- a/tests/test-extension.c
+++ b/tests/test-extension.c
@@ -121,24 +121,32 @@ failure:
 }
 
 
+static const asdf_extension_vtab_t asdf_foo_vtab = {
+    .serialize = asdf_foo_serialize,
+    .deserialize = asdf_foo_deserialize,
+    .copy = asdf_foo_copy,
+    .dealloc = asdf_foo_dealloc,
+};
+
+
+// clang-format off
 ASDF_REGISTER_EXTENSION(
     foo,
-    "stsci.edu:asdf/tests/foo-1.0.0",
     asdf_foo_t,
     &asdf_foo_software,
-    asdf_foo_serialize,
-    asdf_foo_deserialize,
-    asdf_foo_copy,
-    asdf_foo_dealloc,
-    NULL
+    &asdf_foo_vtab,
+    NULL,
+    "stsci.edu:asdf/tests/foo-1.1.0",
+    "stsci.edu:asdf/tests/foo-1.0.0"
 )
+// clang-format on
 
 
 MU_TEST(extension_registered) {
     const char *path = get_fixture_file_path("trivial-extension.asdf");
     asdf_file_t *file = asdf_open(path, "r");
     assert_not_null(file);
-    const asdf_extension_t *ext = asdf_extension_get(file, "stsci.edu:asdf/tests/foo-1.0.0");
+    const asdf_extension_t *ext = asdf_extension_get(file, "stsci.edu:asdf/tests/foo-1.1.0");
     assert_not_null(ext);
     assert_ptr_equal(ext, &asdf_foo_extension);
     asdf_close(file);
@@ -152,6 +160,50 @@ MU_TEST(extension_get_unregistered) {
     assert_not_null(file);
     const asdf_extension_t *ext = asdf_extension_get(file, "unregistered-tag");
     assert_null(ext);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/* Every tag listed in the registration resolves to the same extension, and any
+ * version not listed resolves to none */
+MU_TEST(extension_registered_multiple_versions) {
+    const char *path = get_fixture_file_path("trivial-extension.asdf");
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+    const asdf_extension_t *ext_110 = asdf_extension_get(file, "stsci.edu:asdf/tests/foo-1.1.0");
+    const asdf_extension_t *ext_100 = asdf_extension_get(file, "stsci.edu:asdf/tests/foo-1.0.0");
+    assert_not_null(ext_110);
+    assert_ptr_equal(ext_110, ext_100);
+    assert_null(asdf_extension_get(file, "stsci.edu:asdf/tests/foo-2.0.0"));
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/* A value tagged with an older registered version still deserializes through
+ * the same extension */
+MU_TEST(test_asdf_value_as_foo_1_0_0) {
+    static const char contents[] =
+        "#ASDF 1.0.0\n"
+        "#ASDF_STANDARD 1.6.0\n"
+        "%YAML 1.1\n"
+        "%TAG ! tag:stsci.edu:asdf/\n"
+        "--- !core/asdf-1.1.0\n"
+        "foo: !tests/foo-1.0.0 foo\n"
+        "...\n";
+
+    asdf_file_t *file = asdf_open_mem(contents, sizeof(contents) - 1);
+    assert_not_null(file);
+    asdf_value_t *value = asdf_get_value(file, "foo");
+    assert_not_null(value);
+    assert_true(asdf_value_is_foo(value));
+    asdf_foo_t *foo = NULL;
+    assert_int(asdf_value_as_foo(value, &foo), ==, ASDF_VALUE_OK);
+    assert_not_null(foo);
+    assert_string_equal(foo->foo, "foo:foo");
+    asdf_value_destroy(value);
+    asdf_foo_destroy(foo);
     asdf_close(file);
     return MUNIT_OK;
 }
@@ -267,8 +319,10 @@ MU_TEST_SUITE(
     extension,
     MU_RUN_TEST(extension_registered),
     MU_RUN_TEST(extension_get_unregistered),
+    MU_RUN_TEST(extension_registered_multiple_versions),
     MU_RUN_TEST(test_asdf_value_is_foo),
     MU_RUN_TEST(test_asdf_value_as_foo),
+    MU_RUN_TEST(test_asdf_value_as_foo_1_0_0),
     MU_RUN_TEST(test_asdf_value_of_foo),
     MU_RUN_TEST(test_asdf_is_foo),
     MU_RUN_TEST(test_asdf_get_foo),

--- a/tests/test-reference-files.c
+++ b/tests/test-reference-files.c
@@ -1,0 +1,303 @@
+/*
+ * Smoke test over the reference files from the asdf-standard submodule
+ *
+ * For every reference file, across all standard versions: each tagged value
+ * must resolve to a registered extension and deserialize through it, and each
+ * binary block carrying a checksum must have a valid one.  Values covered by
+ * the exceptions below are skipped.
+ */
+#include <dirent.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "munit.h"
+#include "util.h"
+
+#include "asdf.h"
+#include "asdf/extension.h"
+#include "asdf/version.h"
+
+
+/*
+ * Tagged values that cannot be read yet because the feature behind them is
+ * unimplemented, keyed on the reference file's basename and the value's path
+ * in the tree
+ */
+typedef struct {
+    const char *filename;
+    const char *path;
+    const char *reason;
+} unsupported_value_t;
+
+
+static const unsupported_value_t unsupported_values[] = {
+    {"exploded.asdf", "//data", "external arrays (a source referring to another file)"},
+    {"stream.asdf", "//my_stream", "streamed arrays (a source of -1)"},
+};
+
+
+/* Returns the matching exception, or NULL if the value is expected to read */
+static const unsupported_value_t *get_unsupported(const char *filename, const char *path) {
+    size_t nunsupported = sizeof(unsupported_values) / sizeof(unsupported_values[0]);
+
+    for (size_t idx = 0; idx < nunsupported; idx++) {
+        const unsupported_value_t *unsupported = &unsupported_values[idx];
+
+        if (0 == strcmp(filename, unsupported->filename) && path &&
+            0 == strcmp(path, unsupported->path))
+            return unsupported;
+    }
+
+    return NULL;
+}
+
+
+static bool value_has_tag(asdf_value_t *value) {
+    return NULL != asdf_value_tag(value);
+}
+
+
+/* The checksum field is optional, and is left zeroed when it is not written */
+static bool block_has_checksum(const unsigned char *checksum) {
+    for (size_t idx = 0; idx < ASDF_BLOCK_CHECKSUM_DIGEST_SIZE; idx++) {
+        if (checksum[idx])
+            return true;
+    }
+
+    return false;
+}
+
+
+/* Returns the number of blocks in the file with an invalid checksum */
+static int check_block_checksums(asdf_file_t *file, const char *relative_path) {
+    int failures = 0;
+    size_t nblocks = asdf_block_count(file);
+
+    for (size_t idx = 0; idx < nblocks; idx++) {
+        asdf_block_t *block = asdf_block_open(file, idx);
+
+        if (!block) {
+            munit_logf(MUNIT_LOG_WARNING, "%s: could not open block %zu", relative_path, idx);
+            failures++;
+            continue;
+        }
+
+        const unsigned char *checksum = asdf_block_checksum(block);
+
+        if (!checksum || !block_has_checksum(checksum)) {
+            munit_logf(
+                MUNIT_LOG_INFO, "%s: block %zu has no checksum to verify", relative_path, idx);
+            asdf_block_close(block);
+            continue;
+        }
+
+        if (!asdf_block_checksum_verify(block, NULL)) {
+            munit_logf(MUNIT_LOG_WARNING, "%s: block %zu has an invalid checksum",
+                relative_path, idx);
+            failures++;
+        }
+
+        asdf_block_close(block);
+    }
+
+    return failures;
+}
+
+
+/* Returns the number of tagged values in the file that could not be read */
+static int check_reference_file(const char *dirname, const char *filename) {
+    char relative_path[NAME_MAX * 2 + 2] = {0};
+    snprintf(relative_path, sizeof(relative_path), "%s/%s", dirname, filename);
+
+    asdf_file_t *file = asdf_open(get_reference_file_path(relative_path), "r");
+
+    if (!file) {
+        munit_logf(MUNIT_LOG_WARNING, "%s: could not be opened", relative_path);
+        return 1;
+    }
+
+    asdf_value_t *root = asdf_get_value(file, "");
+
+    if (!root) {
+        munit_logf(MUNIT_LOG_WARNING, "%s: has no tree", relative_path);
+        asdf_close(file);
+        return 1;
+    }
+
+    int failures = 0;
+    /* The iterator yields the root itself when it matches the predicate */
+    asdf_find_iter_t *iter = asdf_find_iter_init(root, value_has_tag);
+
+    while (iter && asdf_value_find_iter_next(&iter)) {
+        asdf_value_t *value = iter->value;
+        const char *tag = asdf_value_tag(value);
+        const char *path = asdf_value_path(value);
+
+        const unsupported_value_t *unsupported = get_unsupported(filename, path);
+
+        if (unsupported) {
+            munit_logf(
+                MUNIT_LOG_INFO,
+                "%s: skipping %s at %s; libasdf does not support %s",
+                relative_path,
+                tag,
+                path,
+                unsupported->reason);
+            continue;
+        }
+
+        const asdf_extension_t *ext = asdf_extension_get(file, tag);
+
+        if (!ext) {
+            munit_logf(
+                MUNIT_LOG_WARNING, "%s: no extension for tag %s at %s", relative_path, tag, path);
+            failures++;
+            continue;
+        }
+
+        void *obj = NULL;
+        asdf_value_err_t err = asdf_value_as_extension_type(value, ext, &obj);
+
+        if (ASDF_VALUE_OK != err) {
+            munit_logf(
+                MUNIT_LOG_WARNING,
+                "%s: failed to deserialize %s at %s (error %d)",
+                relative_path,
+                tag,
+                path,
+                (int)err);
+            failures++;
+            continue;
+        }
+
+        if (ext->vtab && ext->vtab->dealloc)
+            ext->vtab->dealloc(obj);
+    }
+
+    failures += check_block_checksums(file, relative_path);
+
+    asdf_value_destroy(root);
+    asdf_close(file);
+    return failures;
+}
+
+
+static int compare_names(const void *a, const void *b) {
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+
+/*
+ * Returns a sorted, NULL-terminated array of the names in ``path`` for which
+ * ``accept`` returns true; the caller frees it with free_names
+ */
+static char **list_dir(const char *path, bool (*accept)(const struct dirent *)) {
+    DIR *dir = opendir(path);
+
+    if (!dir)
+        return NULL;
+
+    size_t count = 0;
+    size_t capacity = 16;
+    char **names = malloc(capacity * sizeof(char *));
+
+    if (!names) {
+        closedir(dir);
+        return NULL;
+    }
+
+    const struct dirent *entry = NULL;
+
+    while ((entry = readdir(dir))) {
+        if (!accept(entry))
+            continue;
+
+        if (count + 2 > capacity) {
+            capacity *= 2;
+            char **grown = realloc(names, capacity * sizeof(char *));
+
+            if (!grown)
+                break;
+
+            names = grown;
+        }
+
+        names[count++] = strdup(entry->d_name);
+    }
+
+    closedir(dir);
+    names[count] = NULL;
+    qsort(names, count, sizeof(char *), compare_names);
+    return names;
+}
+
+
+static void free_names(char **names) {
+    for (char **name = names; name && *name; name++)
+        free(*name);
+
+    free(names);
+}
+
+
+static bool is_version_dir(const struct dirent *entry) {
+    if (DT_DIR != entry->d_type)
+        return false;
+
+    /* The reference file directories are named for the standard version */
+    asdf_version_t *version = asdf_version_parse(entry->d_name);
+
+    if (!version)
+        return false;
+
+    /* A name that is not MAJOR.MINOR.PATCH is left all-zero */
+    bool is_version = version->major || version->minor || version->patch;
+    asdf_version_destroy(version);
+    return is_version;
+}
+
+
+static bool is_asdf_file(const struct dirent *entry) {
+    const char *ext = strrchr(entry->d_name, '.');
+    return ext && 0 == strcmp(ext, ".asdf");
+}
+
+
+MU_TEST(reference_files_deserialize) {
+    char **versions = list_dir(REFERENCE_FILES_DIR, is_version_dir);
+    assert_not_null(versions);
+    assert_not_null(versions[0]);
+
+    int failures = 0;
+    int checked = 0;
+
+    for (char **version = versions; *version; version++) {
+        char **filenames = list_dir(get_reference_file_path(*version), is_asdf_file);
+        assert_not_null(filenames);
+
+        for (char **filename = filenames; *filename; filename++) {
+            failures += check_reference_file(*version, *filename);
+            checked++;
+        }
+
+        free_names(filenames);
+    }
+
+    free_names(versions);
+
+    /* Guard against the reference files having gone missing entirely */
+    assert_int(checked, >, 0);
+    assert_int(failures, ==, 0);
+    return MUNIT_OK;
+}
+
+
+MU_TEST_SUITE(
+    reference_files,
+    MU_RUN_TEST(reference_files_deserialize)
+);
+
+
+MU_RUN_SUITE(reference_files);

--- a/tests/test-reference-files.c
+++ b/tests/test-reference-files.c
@@ -106,10 +106,14 @@ static int check_block_checksums(asdf_file_t *file, const char *relative_path) {
 }
 
 
-/* Returns the number of tagged values in the file that could not be read */
-static int check_reference_file(const char *dirname, const char *filename) {
-    char relative_path[NAME_MAX * 2 + 2] = {0};
-    snprintf(relative_path, sizeof(relative_path), "%s/%s", dirname, filename);
+/*
+ * Returns the number of problems found in the file: tagged values that could
+ * not be read, plus blocks with an invalid checksum
+ */
+static int check_reference_file(const char *relative_path) {
+    /* The exceptions are keyed on the basename, not the version directory */
+    const char *sep = strrchr(relative_path, '/');
+    const char *filename = sep ? sep + 1 : relative_path;
 
     asdf_file_t *file = asdf_open(get_reference_file_path(relative_path), "r");
 
@@ -264,39 +268,98 @@ static bool is_asdf_file(const struct dirent *entry) {
     return ext && 0 == strcmp(ext, ".asdf");
 }
 
+#define DEFINE_INT_WITH_LINENO(name, value) \
+    enum { name = (value), name##_LINENO = __LINE__ }
 
-MU_TEST(reference_files_deserialize) {
+/*
+ * The reference files are discovered at runtime rather than listed here, so
+ * that new ones are picked up automatically.  They are stored statically: the
+ * parameter array must outlive main, and freeing it from a destructor would
+ * run after LeakSanitizer has already reported it.
+ */
+DEFINE_INT_WITH_LINENO(MAX_REFERENCE_FILES, 256);
+#define MAX_RELATIVE_PATH (NAME_MAX * 2 + 2)
+
+
+static char reference_file_paths[MAX_REFERENCE_FILES][MAX_RELATIVE_PATH];
+static char *reference_file_values[MAX_REFERENCE_FILES + 1];
+static size_t reference_file_count = 0;
+static bool reference_files_overflowed = false;
+
+
+static MunitParameterEnum reference_file_params[] = {
+    {"file", NULL},
+    {NULL, NULL},
+};
+
+
+__attribute__((constructor)) static void collect_reference_files(void) {
     char **versions = list_dir(REFERENCE_FILES_DIR, is_version_dir);
-    assert_not_null(versions);
-    assert_not_null(versions[0]);
 
-    int failures = 0;
-    int checked = 0;
+    if (!versions)
+        return;
 
     for (char **version = versions; *version; version++) {
         char **filenames = list_dir(get_reference_file_path(*version), is_asdf_file);
-        assert_not_null(filenames);
+
+        if (!filenames)
+            continue;
 
         for (char **filename = filenames; *filename; filename++) {
-            failures += check_reference_file(*version, *filename);
-            checked++;
+            if (reference_file_count >= MAX_REFERENCE_FILES) {
+                reference_files_overflowed = true;
+            }
+
+            if (!reference_files_overflowed) {
+                char *path = reference_file_paths[reference_file_count];
+                snprintf(path, MAX_RELATIVE_PATH, "%s/%s", *version, *filename);
+                reference_file_values[reference_file_count] = path;
+            }
+            reference_file_count++;
         }
 
         free_names(filenames);
     }
 
     free_names(versions);
+    reference_file_values[reference_file_count] = NULL;
+    reference_file_params[0].values = reference_file_values;
+}
 
-    /* Guard against the reference files having gone missing entirely */
-    assert_int(checked, >, 0);
-    assert_int(failures, ==, 0);
+
+/* Guards against the reference files having gone missing, or outgrown the array
+ *
+ * If this test fails it means the number of reference files has outgrown
+ * the `MAX_REFERENCE_FILES` defined above.  In that case just increase
+ * `MAX_REFERENCE_FILES`.
+ */
+MU_TEST(reference_files_found) {
+    assert_size(reference_file_count, >, 0);
+    if (!reference_files_overflowed)
+        return MUNIT_OK;
+
+    munit_logf(MUNIT_LOG_ERROR, "number of reference files in %s has outgrown "
+               "MAX_REFERENCE_FILES defined at %s:%d (%zu > %d); in this case "
+               "the value of MAX_REFERENCE_FILES must be increased and the "
+               "test recompiled", REFERENCE_FILES_DIR, __FILE__,
+               MAX_REFERENCE_FILES_LINENO, reference_file_count,
+               MAX_REFERENCE_FILES);
+    return MUNIT_FAIL;
+}
+
+
+MU_TEST(reference_file) {
+    const char *relative_path = munit_parameters_get(params, "file");
+    assert_not_null(relative_path);
+    assert_int(check_reference_file(relative_path), ==, 0);
     return MUNIT_OK;
 }
 
 
 MU_TEST_SUITE(
     reference_files,
-    MU_RUN_TEST(reference_files_deserialize)
+    MU_RUN_TEST(reference_files_found),
+    MU_RUN_TEST(reference_file, reference_file_params)
 );
 
 

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -4,10 +4,10 @@
 #include "munit.h"
 #include "util.h"
 
-#include <asdf/core/asdf.h>
-#include <asdf/core/time.h>
-#include <asdf/file.h>
-#include <asdf/value.h>
+#include "asdf/core/asdf.h"
+#include "asdf/core/time.h"
+#include "asdf/file.h"
+#include "asdf/value.h"
 
 
 MU_TEST(test_asdf_time) {

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -6,10 +6,10 @@
 
 #include <libfyaml.h>
 
-#include <asdf/core/asdf.h>
-#include <asdf/core/ndarray.h>
-#include <asdf/file.h>
-#include <asdf/value.h>
+#include "asdf/core/asdf.h"
+#include "asdf/core/ndarray.h"
+#include "asdf/file.h"
+#include "asdf/value.h"
 
 #include "munit.h"
 #include "util.h"


### PR DESCRIPTION
## Description

Implements #42 with one caveat: I decided to omit support for wildcards for now.  This actually turns out to be even more of a can of worms than I thought, and the discussion in https://github.com/asdf-format/asdf/pull/1048 provides a good rationale against them, and is the reason Python asdf also dropped support for this in its Converters for now.  I think there might still be a way to support this sensibly but it requires more careful consideration.

Also adds #155 which I almost forgot there was an issue for.  Since this overcomes the small existing hurdle to reading some of the older reference files, I wanted to add such a test as a smoke test for what other tag versions might need to be added (not many it turns out, at least for the existing supported core tags).

## AI Disclosure

No AI tools used.
