### PR TITLE
New array element accessor methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ config.log
 config.status
 configure
 configure~
+include/asdf/config.h
 stamp-h1
 Makefile.in
 */Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -195,6 +195,7 @@ CMAKE_DIST = \
     cmake/ASDFDependencies.cmake \
     cmake/ASDFOptions.cmake \
     cmake/SubmoduleInit.cmake \
+    cmake/UndefinedBehaviorAnalyzer.cmake \
     config.h.cmake \
     src/CMakeLists.txt
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,7 @@ src_headers = \
 include_dir = $(top_srcdir)/include
 
 AM_CFLAGS = $(ASDF_CFLAGS) -fvisibility=hidden -fmacro-prefix-map=$(top_srcdir)/=
-AM_CPPFLAGS = $(ASDF_CPPFLAGS) -I$(top_srcdir)/third_party/STC/include -I$(top_srcdir)/include
+AM_CPPFLAGS = $(ASDF_CPPFLAGS) -I$(top_srcdir)/third_party/STC/include -I$(top_srcdir)/include -I$(top_builddir)/include
 AM_LDFLAGS = $(ASDF_LDFLAGS)
 ACLOCAL_AMFLAGS = -Im4
 

--- a/changes/227.feature
+++ b/changes/227.feature
@@ -1,0 +1,7 @@
+Added functions for reading a single ndarray element with datatype and byte
+order conversion: ``asdf_ndarray_read_at`` copies the element into a caller
+buffer, and the ``asdf_ndarray_read_<type>_at`` family returns it as a named C
+type.  For C the ``asdf_ndarray_at`` and ``asdf_ndarray_at_err`` macros pick
+the right one from the destination type.  These also read the element safely
+when the block data is not aligned for its type, which the pointer from
+``asdf_ndarray_data`` may not be.

--- a/cmake/ASDFConfig.cmake
+++ b/cmake/ASDFConfig.cmake
@@ -145,3 +145,34 @@ include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
 
 # Write out the header
 configure_file(config.h.cmake include/config.h @ONLY)
+
+
+# Substitutions for the installed include/asdf/config.h.  Unlike config.h above
+# this is limited to the macros that are part of the public API; the template is
+# shared with the Autotools build, so it uses plain @VAR@ substitutions rather
+# than #cmakedefine.
+if(HAVE_FLOAT16)
+    set(ASDF_HAVE_FLOAT16_DEFINE "#define ASDF_HAVE_FLOAT16 1")
+else()
+    set(ASDF_HAVE_FLOAT16_DEFINE "/* #undef ASDF_HAVE_FLOAT16 */")
+endif()
+
+if(ASDF_LOG_ENABLED)
+    set(ASDF_LOG_ENABLED_DEFINE "#define ASDF_LOG_ENABLED 1")
+else()
+    set(ASDF_LOG_ENABLED_DEFINE "/* #undef ASDF_LOG_ENABLED */")
+endif()
+
+if(ASDF_LOG_COLOR)
+    set(ASDF_LOG_COLOR_DEFINE "#define ASDF_LOG_COLOR 1")
+else()
+    set(ASDF_LOG_COLOR_DEFINE "/* #undef ASDF_LOG_COLOR */")
+endif()
+
+set(ASDF_LOG_DEFAULT_LEVEL_DEFINE "#define ASDF_LOG_DEFAULT_LEVEL ASDF_LOG_${LOG_DEFAULT}")
+set(ASDF_LOG_MIN_LEVEL_DEFINE "#define ASDF_LOG_MIN_LEVEL ASDF_LOG_${LOG_MIN}")
+
+configure_file(
+    ${CMAKE_SOURCE_DIR}/include/asdf/config.h.in
+    ${CMAKE_BINARY_DIR}/include/asdf/config.h
+    @ONLY)

--- a/cmake/ASDFOptions.cmake
+++ b/cmake/ASDFOptions.cmake
@@ -1,5 +1,6 @@
 # Configure options for ASDF library
 include(AddressAnalyzer)
+include(UndefinedBehaviorAnalyzer)
 
 # Logging (mirrors the Autotools --enable-logging / --enable-log-color /
 # --with-log-default / --with-log-min options)

--- a/cmake/UndefinedBehaviorAnalyzer.cmake
+++ b/cmake/UndefinedBehaviorAnalyzer.cmake
@@ -1,0 +1,6 @@
+option(ENABLE_UBSAN "Enable UndefinedBehaviorAnalyzer" OFF)
+
+if(ENABLE_UBSAN)
+    add_compile_options(-fsanitize=undefined -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=undefined)
+endif()

--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,21 @@ AS_IF([test "x$with_asan" = "xyes"], [
   ASDF_BUILD_MODE="${ASDF_BUILD_MODE}asan "
 ])
 
+# --with-ubsan
+AC_ARG_WITH([ubsan],
+  [AS_HELP_STRING([--with-ubsan], [Build with UndefinedBehaviorSanitizer support])],
+  [with_ubsan=yes],
+  [with_ubsan=no])
+
+AS_IF([test "x$with_ubsan" = "xyes"], [
+  ASDF_CFLAGS="$ASDF_CFLAGS -O1 -g -fsanitize=undefined -fno-omit-frame-pointer"
+  ASDF_LDFLAGS="$ASDF_LDFLAGS -fsanitize=undefined"
+  AC_DEFINE([WITH_UBSAN], [1], [Defined if building with UndefinedBehaviorSanitizer])
+  ASDF_BUILD_MODE="${ASDF_BUILD_MODE}ubsan "
+])
+
+AM_CONDITIONAL([UBSAN], [test "x$with_ubsan" = "xyes"])
+
 # Logging flags
 AC_ARG_ENABLE([logging],
   [AS_HELP_STRING([--enable-logging], [Enable logging (default: yes)])],

--- a/configure.ac
+++ b/configure.ac
@@ -214,6 +214,32 @@ AC_DEFINE_UNQUOTED([ASDF_LOG_MIN_LEVEL], [ASDF_LOG_$with_log_min],
                    [Compile-time minimum log level])
 
 
+# Substitutions for the installed include/asdf/config.h.  Unlike the internal
+# config.h this is limited to the macros that are part of the public API, and
+# is written with plain @VAR@ substitutions so that the same template can be
+# used by the CMake build.
+AS_IF([test "x$have_float16" = "xyes"],
+  [ASDF_HAVE_FLOAT16_DEFINE="#define ASDF_HAVE_FLOAT16 1"],
+  [ASDF_HAVE_FLOAT16_DEFINE="/* #undef ASDF_HAVE_FLOAT16 */"])
+AC_SUBST([ASDF_HAVE_FLOAT16_DEFINE])
+
+AS_IF([test "x$enable_logging" = "xyes"],
+  [ASDF_LOG_ENABLED_DEFINE="#define ASDF_LOG_ENABLED 1"],
+  [ASDF_LOG_ENABLED_DEFINE="/* #undef ASDF_LOG_ENABLED */"])
+AC_SUBST([ASDF_LOG_ENABLED_DEFINE])
+
+AS_IF([test "x$enable_log_color" = "xyes"],
+  [ASDF_LOG_COLOR_DEFINE="#define ASDF_LOG_COLOR 1"],
+  [ASDF_LOG_COLOR_DEFINE="/* #undef ASDF_LOG_COLOR */"])
+AC_SUBST([ASDF_LOG_COLOR_DEFINE])
+
+ASDF_LOG_DEFAULT_LEVEL_DEFINE="#define ASDF_LOG_DEFAULT_LEVEL ASDF_LOG_$with_log_default"
+AC_SUBST([ASDF_LOG_DEFAULT_LEVEL_DEFINE])
+
+ASDF_LOG_MIN_LEVEL_DEFINE="#define ASDF_LOG_MIN_LEVEL ASDF_LOG_$with_log_min"
+AC_SUBST([ASDF_LOG_MIN_LEVEL_DEFINE])
+
+
 # Initalize submodules needed for the build
 AS_IF([test ! -f "$srcdir/third_party/STC/LICENSE"],
   [AC_MSG_NOTICE([Initializing submodule third_party/STC...])
@@ -335,7 +361,7 @@ AC_SUBST([PYTHON3])
 AC_SUBST([ASDF_CFLAGS])
 AC_SUBST([ASDF_LDFLAGS])
 AC_CONFIG_HEADERS([config.h]) # use config.h instead of passing -D in the command line
-AC_CONFIG_FILES([Makefile include/Makefile tests/Makefile third_party/Makefile docs/Makefile libasdf.pc])
+AC_CONFIG_FILES([Makefile include/Makefile tests/Makefile third_party/Makefile docs/Makefile libasdf.pc include/asdf/config.h])
 
 AC_OUTPUT
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,6 +93,7 @@ nitpicky = True
 # (someone should write one!) so we list most of those here when they come up
 # in the docs.  Try to keep this sorted...
 nitpick_ignore = [
+    ('c:identifier', '_Float16'),
     ('c:identifier', 'ERANGE'),
     ('c:identifier', 'FILE'),
     ('c:identifier', 'NULL'),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,4 @@
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -138,12 +139,48 @@ extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.todo', 'hawkmoth']
 
 hawkmoth_root = Path(__file__).parent.parent
 
+
+def _config_h_includedir():
+    """
+    Locate an include directory containing the generated ``asdf/config.h``.
+
+    ``asdf/util.h`` includes it, so hawkmoth cannot parse any public header
+    without it.  Set ``ASDF_BUILD_INCLUDEDIR`` to the ``include`` directory of a
+    configured build tree to use its real config.h.  Otherwise one is generated
+    from the template with the optional features enabled, so that the whole API
+    is documented.
+    """
+    from_env = os.environ.get('ASDF_BUILD_INCLUDEDIR')
+
+    if from_env:
+        return from_env
+
+    substitutions = {
+        'ASDF_HAVE_FLOAT16_DEFINE': '#define ASDF_HAVE_FLOAT16 1',
+        'ASDF_LOG_ENABLED_DEFINE': '#define ASDF_LOG_ENABLED 1',
+        'ASDF_LOG_COLOR_DEFINE': '#define ASDF_LOG_COLOR 1',
+        'ASDF_LOG_DEFAULT_LEVEL_DEFINE': '#define ASDF_LOG_DEFAULT_LEVEL ASDF_LOG_WARN',
+        'ASDF_LOG_MIN_LEVEL_DEFINE': '#define ASDF_LOG_MIN_LEVEL ASDF_LOG_TRACE',
+    }
+
+    template = (hawkmoth_root / 'include' / 'asdf' / 'config.h.in').read_text()
+
+    for name, define in substitutions.items():
+        template = template.replace(f'@{name}@', define)
+
+    includedir = Path(__file__).parent / '_build' / 'gen'
+    (includedir / 'asdf').mkdir(parents=True, exist_ok=True)
+    (includedir / 'asdf' / 'config.h').write_text(template)
+    return str(includedir)
+
+
 # These are options that should be passed to the compiler when hawkmoth processes
 # files.
 #
 # Should see if we can glean what we need here from configure/automake output
 # For now see what we can get away with by simply hard-coding...
-hawkmoth_clang = [f'-I{hawkmoth_root}/include', '-Iinclude']
+hawkmoth_clang = [
+    f'-I{hawkmoth_root}/include', f'-I{_config_h_includedir()}', '-Iinclude']
 
 
 # -- Options for theme and HTML output -----------------------------------------

--- a/docs/usage/ndarrays.rst
+++ b/docs/usage/ndarrays.rst
@@ -3,7 +3,7 @@
 Working with ndarrays
 =====================
 
-The :ref:`overview <ndarrays>` introduced the **ndarray** -- a typed,
+The :ref:`overview <ndarrays>` introduced the **ndarray**--a typed,
 multi-dimensional array whose bulk numeric data lives in a binary block while
 its shape, datatype, and byte order are described by metadata in the YAML tree.
 This page is a practical guide to *doing things* with ndarrays in libasdf:
@@ -126,7 +126,7 @@ a pointer to the (decompressed) bytes and optionally their size:
    const void *data = asdf_ndarray_data(array, &nbytes);
 
 This pointer is owned by ``array`` and must not be freed.  The data is in the
-array's *source* datatype and byte order, exactly as stored -- no conversion is
+array's *source* datatype and byte order, exactly as stored--no conversion is
 performed.  Two helpers describe the array's extent without touching the data:
 
 * `asdf_ndarray_size` -- total number of elements (the product of the shape).
@@ -137,9 +137,11 @@ returns the still-compressed bytes without decompressing them; for uncompressed
 arrays it is equivalent to `asdf_ndarray_data`.
 
 Because `asdf_ndarray_data` exposes the data in its original layout, you are
-responsible for honoring ``byteorder`` and ``datatype`` yourself.  When you want
-the data converted to a convenient host type, use the reading functions in the
-next section instead.
+responsible for honoring ``byteorder`` and ``datatype`` yourself.  The pointer
+is also not necessarily aligned for the element type, so it should not simply
+be cast and indexed; see :ref:`ndarray-read-element`.  When you want the data
+converted to a convenient host type, use the reading functions in the next
+section instead.
 
 
 .. _ndarray-read-convert:
@@ -211,13 +213,75 @@ array):
        /* plane_origin= */ NULL, ASDF_DATATYPE_FLOAT32, (void **)&tile);
 
 
+.. _ndarray-read-element:
+
+Reading single elements
+~~~~~~~~~~~~~~~~~~~~~~~
+
+To pick out one element, `asdf_ndarray_at` reads it and returns it as the type
+you ask for.  You name the type and the indices; the number of indices must
+match the array's ``ndim``:
+
+.. code:: c
+
+   double value = asdf_ndarray_at(array, double, 3, 7);
+
+This does the same work as the tile functions, for one element: it converts
+from the array's stored datatype to the type you named, and from the file's
+byte order to the host's.  So an ``int32`` array stored big-endian can be read
+as ``double`` on a little-endian machine without you doing anything.
+
+It also side-steps a portability trap.  It is tempting to take the pointer from
+`asdf_ndarray_data` and index it as an array of the element type:
+
+.. code:: c
+
+   /* Don't do this */
+   const void *data = asdf_ndarray_data(array, NULL);
+   int64_t value = ((const int64_t *)data)[3];
+
+The data of an uncompressed array is mapped straight from the file, beginning
+wherever the binary block happens to start.  That offset depends on how long
+the YAML tree above it is, so the pointer usually is *not* aligned for its
+element type.  Casting and dereferencing it is undefined behavior in C: it
+happens to work on x86, but it can crash on other processors, and compilers
+are free to assume the alignment holds.  `asdf_ndarray_at` reads the element
+safely regardless of where it sits.
+
+By default nothing is reported if the read fails--an out-of-range index, or
+the wrong number of indices, simply yields zero, which you cannot tell apart
+from an element that really is zero.  Where that matters, `asdf_ndarray_at_err`
+takes a pointer to an `asdf_ndarray_err_t` before the indices:
+
+.. code:: c
+
+   asdf_ndarray_err_t err = ASDF_NDARRAY_OK;
+   double value = asdf_ndarray_at_err(array, double, &err, 3, 7);
+
+   if (err != ASDF_NDARRAY_OK)
+       fprintf(stderr, "could not read element\n");
+
+Both are macros, and each call converts one element on its own.  That is a fine
+way to sample scattered points, but a poor way to walk a large part of an
+array: reach for `asdf_ndarray_read_tile_ndim` or `asdf_ndarray_read_all` to
+convert a whole region in one pass, then loop over the resulting buffer, which
+is aligned and already in host byte order.
+
+.. note::
+
+   C++ code cannot use the macros; it calls the underlying functions directly,
+   either `asdf_ndarray_read_at` (which copies into a destination you provide)
+   or one of the ``asdf_ndarray_read_<type>_at`` functions such as
+   `asdf_ndarray_read_float64_at`.
+
+
 .. _ndarray-datatypes:
 
 Datatypes and byte order
 ------------------------
 
 An element datatype is described by `asdf_datatype_t`, whose ``type`` field is
-one of the `asdf_scalar_datatype_t` enums -- for example ``ASDF_DATATYPE_UINT8``,
+one of the `asdf_scalar_datatype_t` enums--for example ``ASDF_DATATYPE_UINT8``,
 ``ASDF_DATATYPE_INT32``, ``ASDF_DATATYPE_FLOAT32``, or ``ASDF_DATATYPE_FLOAT64``.
 For simple numeric arrays setting ``type`` is all that is required;
 `asdf_datatype_size` then reports the size of a single element in bytes.
@@ -267,7 +331,7 @@ with `asdf_ndarray_data_dealloc` (safe to call after `asdf_close`):
 .. note::
 
    When building an ndarray *inside* an extension's serialize callback, use
-   `asdf_ndarray_data_alloc_temp` instead -- its buffer is freed automatically
+   `asdf_ndarray_data_alloc_temp` instead, its buffer is freed automatically
    once the write completes.
 
 See :ref:`writing` for the surrounding file-writing workflow.

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -7,6 +7,7 @@ install(
 
 install(
     FILES
+        ${CMAKE_BINARY_DIR}/include/asdf/config.h
         asdf/emitter.h
         asdf/error.h
         asdf/event.h

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -20,6 +20,8 @@ nobase_include_HEADERS = \
     asdf/version.h \
     asdf/yaml.h
 
+# Generated into the build directory by config.status
+nobase_nodist_include_HEADERS = asdf/config.h
 
 
 # CMake-related files to include in the distribution

--- a/include/asdf/config.h.in
+++ b/include/asdf/config.h.in
@@ -1,0 +1,56 @@
+/**
+ * .. _asdf/config.h:
+ *
+ * Build-time configuration of the libasdf that is installed
+ *
+ * This header is generated when libasdf is built and records the options it
+ * was built with.  It is included by ``asdf/util.h``, so it is available to
+ * every public header; there is normally no need to include it directly.
+ *
+ * Each macro below is defined only if the corresponding feature was enabled.
+ */
+
+#ifndef ASDF_CONFIG_H
+#define ASDF_CONFIG_H
+
+/**
+ * Defined to 1 if libasdf's internal log statements were compiled into the
+ * library
+ *
+ * When it is not defined `ASDF_LOG` expands to nothing.  See
+ * :ref:`asdf/log.h`.
+ */
+@ASDF_LOG_ENABLED_DEFINE@
+
+/**
+ * The default runtime log level, as an `asdf_log_level_t`
+ *
+ * This is the threshold used when none is set explicitly through
+ * `asdf_config_t` or the ``ASDF_LOG_LEVEL`` environment variable.
+ */
+@ASDF_LOG_DEFAULT_LEVEL_DEFINE@
+
+/**
+ * The compile-time minimum log level, as an `asdf_log_level_t`
+ *
+ * Log statements below this level were compiled out of the library.
+ */
+@ASDF_LOG_MIN_LEVEL_DEFINE@
+
+
+/**
+ * Defined to 1 if log messages are colorized when written to a terminal
+ */
+@ASDF_LOG_COLOR_DEFINE@
+
+/**
+ * Defined to 1 if the ``_Float16`` type is usable
+ *
+ * When it is not defined the ``float16`` datatype can still be read, but
+ * only converted to another datatype; the APIs taking or returning a
+ * ``_Float16`` directly are not declared.
+ */
+@ASDF_HAVE_FLOAT16_DEFINE@
+
+
+#endif /* ASDF_CONFIG_H */

--- a/include/asdf/core/ndarray.h
+++ b/include/asdf/core/ndarray.h
@@ -493,6 +493,196 @@ ASDF_EXPORT asdf_ndarray_err_t asdf_ndarray_read_tile_2d(
     asdf_scalar_datatype_t dst_t,
     void **dst);
 
+// Forward-declaration for documentation; the real implementations of
+// asdf_read_at and asdf_read_at_err are later in this file.
+
+/**
+ * Read the element at the given indices, converted to ``type``
+ *
+ * ``type`` must be one of the C scalar types named by the
+ * ``asdf_ndarray_read_<type>_at`` functions.  The number of indices is taken
+ * from the number of arguments, and must equal the array's
+ * :c:member:`ndim <asdf_ndarray_t.ndim>`.  At least one index is required::
+ *
+ *   double value = asdf_ndarray_at(ndarray, double, 3, 7);
+ *
+ * Errors are not reported: on any error the value is zero, which is
+ * indistinguishable from an element whose value is zero.  Use
+ * `asdf_ndarray_at_err` where that matters.
+ *
+ * This is a macro and is unavailable in C++; use the
+ * ``asdf_ndarray_read_<type>_at`` functions instead.
+ *
+ * :param ndarray: The `asdf_ndarray_t *` handle to the ndarray
+ * :param type: The C scalar type to convert the element to
+ * :param ...: The indices of the element to read
+ * :return: The element converted to ``type``, or zero on error
+ */
+#define asdf_ndarray_at(ndarray, type, ...)
+#undef asdf_ndarray_at
+
+/**
+ * Like `asdf_ndarray_at` but reporting errors through ``err``
+ *
+ * The indices are given as a variadic argument list after ``err``::
+ *
+ *   asdf_ndarray_err_t err = ASDF_NDARRAY_OK;
+ *   double value = asdf_ndarray_at_err(ndarray, double, &err, 3, 7);
+ *
+ * :param ndarray: The `asdf_ndarray_t *` handle to the ndarray
+ * :param type: The C scalar type to convert the element to
+ * :param err: An `asdf_ndarray_err_t *` receiving the error code, or ``NULL``
+ * :param ...: The indices of the element to read
+ * :return: The element converted to ``type``, or zero on error
+ */
+#define asdf_ndarray_at_err(ndarray, type, err, ...)
+#undef asdf_ndarray_at_err
+
+
+/**
+ * Read a single element of the ndarray, converting it as `asdf_ndarray_read_all`
+ * does
+ *
+ * The element is copied into ``dst``, which must have room for one value of
+ * ``dst_t``.  ``dst`` need not be aligned for its type.
+ *
+ * For C code the `asdf_ndarray_at` and `asdf_ndarray_at_err` macros are more
+ * convenient.
+ *
+ * .. note::
+ *
+ *   If reading many elements of an array in a loop this call is inefficient;
+ *   it is better to read multiple elements in a single pass using
+ *   `asdf_ndarray_read_tile_ndim`, `asdf_ndarray_read_tile_2d` or
+ *   `asdf_ndarray_read_all` depending on the use case.  This method can still
+ *   be useful for a few incidental single-element reads.
+ *
+ * ``indices`` must have :c:member:`ndim <asdf_ndarray_t.ndim>` entries; that
+ * many are read from it.
+ *
+ * :param ndarray: The `asdf_ndarray_t *` handle to the ndarray
+ * :param indices: The indices of the element to read--an array of size
+ *   :c:member:`ndim <asdf_ndarray_t.ndim>`
+ * :param dst_t: An `asdf_scalar_datatype_t` to convert to, or
+ *   `ASDF_DATATYPE_SOURCE` to keep the original source datatype
+ * :param dst: Pointer to storage receiving the element
+ * :return: An `asdf_ndarray_err_t`; `ASDF_NDARRAY_OK` if the element was read
+ *   successfully, `ASDF_NDARRAY_ERR_OUT_OF_BOUNDS` if any index is outside the
+ *   array's shape; otherwise the relevant error code.
+ */
+ASDF_EXPORT asdf_ndarray_err_t asdf_ndarray_read_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_scalar_datatype_t dst_t, void *dst);
+
+
+/**
+ * Read a single element of the ndarray, converted to the named type
+ *
+ * These are the same as `asdf_ndarray_read_at` with ``dst_t`` fixed by the
+ * function name, except that the element is returned rather than copied into
+ * ``dst``.  On error the returned value is zero and, if ``err`` is not
+ * ``NULL``, the error code is stored in it.
+ *
+ * The `asdf_ndarray_at` and `asdf_ndarray_at_err` macros select among these
+ * automatically and are usually easier to read.  They are unavailable in C++,
+ * which must call these directly.
+ *
+ * ``indices`` must have :c:member:`ndim <asdf_ndarray_t.ndim>` entries; that
+ * many are read from it.
+ *
+ * :param ndarray: The `asdf_ndarray_t *` handle to the ndarray
+ * :param indices: The indices of the element to read--an array of size
+ *   :c:member:`ndim <asdf_ndarray_t.ndim>`
+ * :param err: Optional `asdf_ndarray_err_t *` receiving the error code, or
+ *   ``NULL`` to ignore errors
+ * :return: The element converted to the function's type, or zero on error
+ */
+ASDF_EXPORT int8_t asdf_ndarray_read_int8_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT uint8_t asdf_ndarray_read_uint8_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT int16_t asdf_ndarray_read_int16_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT uint16_t asdf_ndarray_read_uint16_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT int32_t asdf_ndarray_read_int32_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT uint32_t asdf_ndarray_read_uint32_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT int64_t asdf_ndarray_read_int64_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT uint64_t asdf_ndarray_read_uint64_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+#ifdef ASDF_HAVE_FLOAT16
+/** See `asdf_ndarray_read_int8_at`; declared only if ``ASDF_HAVE_FLOAT16`` */
+ASDF_EXPORT _Float16 asdf_ndarray_read_float16_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+#endif
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT float asdf_ndarray_read_float32_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+/** See `asdf_ndarray_read_int8_at` */
+ASDF_EXPORT double asdf_ndarray_read_float64_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err);
+
+
+#ifndef __cplusplus
+#ifdef ASDF_HAVE_FLOAT16
+#define ASDF__READ_AT_FLOAT16 _Float16 : asdf_ndarray_read_float16_at,
+#else
+#define ASDF__READ_AT_FLOAT16
+#endif
+
+
+/* Selects the asdf_ndarray_read_<type>_at function for a C scalar type */
+// clang-format off
+#define ASDF__READ_AT_FN(type) \
+    _Generic( \
+        ((type){0}), \
+        ASDF__READ_AT_FLOAT16 \
+        int8_t: asdf_ndarray_read_int8_at, \
+        uint8_t: asdf_ndarray_read_uint8_at, \
+        int16_t: asdf_ndarray_read_int16_at, \
+        uint16_t: asdf_ndarray_read_uint16_at, \
+        int32_t: asdf_ndarray_read_int32_at, \
+        uint32_t: asdf_ndarray_read_uint32_at, \
+        int64_t: asdf_ndarray_read_int64_at, \
+        uint64_t: asdf_ndarray_read_uint64_at, \
+        float: asdf_ndarray_read_float32_at, \
+        double: asdf_ndarray_read_float64_at)
+// clang-format on
+
+
+/* The indices appear twice, but the operand of sizeof is not evaluated */
+#define ASDF__INDICES(...) ((const uint64_t[]){__VA_ARGS__})
+#define ASDF__NINDICES(...) (sizeof(ASDF__INDICES(__VA_ARGS__)) / sizeof(uint64_t))
+
+
+/*
+ * The read functions take ndim indices, so passing the wrong number of them
+ * would read past the end of the array built above.  Substitute NULL in that
+ * case, which the read functions reject with ASDF_NDARRAY_ERR_INVAL.
+ */
+#define ASDF__AT_INDICES(ndarray, ...) \
+    (ASDF__NINDICES(__VA_ARGS__) == (ndarray)->ndim ? ASDF__INDICES(__VA_ARGS__) : NULL)
+
+
+/* Implementation of asdf_ndarray_at; see documentation further up */
+#define asdf_ndarray_at(ndarray, type, ...) \
+    ASDF__READ_AT_FN(type)((ndarray), ASDF__AT_INDICES((ndarray), __VA_ARGS__), NULL)
+
+
+/* Implementation of asdf_ndarray_at_err; see documentation further up */
+#define asdf_ndarray_at_err(ndarray, type, err, ...) \
+    ASDF__READ_AT_FN(type)((ndarray), ASDF__AT_INDICES((ndarray), __VA_ARGS__), (err))
+#endif /* __cplusplus */
+
 
 ASDF_END_DECLS
 

--- a/include/asdf/util.h
+++ b/include/asdf/util.h
@@ -1,6 +1,8 @@
 #ifndef ASDF_UTIL_H
 #define ASDF_UTIL_H
 
+#include <asdf/config.h> // IWYU pragma: export
+
 #if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 4)
 #define ASDF_EXPORT __attribute__((visibility("default")))
 #define ASDF_LOCAL __attribute__((visibility("hidden")))

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -1761,6 +1761,71 @@ asdf_ndarray_err_t asdf_ndarray_read_all(
 }
 
 
+/* Dimensions handled without allocating a shape array in asdf_ndarray_read_at */
+#define ASDF_NDARRAY_READ_AT_STACK_NDIM 8
+
+
+asdf_ndarray_err_t asdf_ndarray_read_at(
+    asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_scalar_datatype_t dst_t, void *dst) {
+    if (UNLIKELY(!ndarray || !indices || !dst))
+        return ASDF_NDARRAY_ERR_INVAL;
+
+    uint32_t ndim = ndarray->ndim;
+
+    /* A zero-dimensional array has no element to index */
+    if (UNLIKELY(ndim == 0))
+        return ASDF_NDARRAY_ERR_INVAL;
+
+    uint64_t stack_shape[ASDF_NDARRAY_READ_AT_STACK_NDIM] = {0};
+    uint64_t *shape = stack_shape;
+
+    if (UNLIKELY(ndim > ASDF_NDARRAY_READ_AT_STACK_NDIM)) {
+        shape = malloc(ndim * sizeof(uint64_t));
+
+        if (UNLIKELY(!shape))
+            return ASDF_NDARRAY_ERR_OOM;
+    }
+
+    /* A single element is a tile of unit shape */
+    for (uint32_t dim = 0; dim < ndim; dim++)
+        shape[dim] = 1;
+
+    asdf_ndarray_err_t err = asdf_ndarray_read_tile_ndim(ndarray, indices, shape, dst_t, &dst);
+
+    if (UNLIKELY(shape != stack_shape))
+        free(shape);
+
+    return err;
+}
+
+
+/* Generates the asdf_ndarray_read_<name>_at family */
+#define ASDF_DEFINE_READ_AT(name, type, datatype) \
+    type asdf_ndarray_read_##name##_at( \
+        asdf_ndarray_t *ndarray, const uint64_t *indices, asdf_ndarray_err_t *err) { \
+        type value = 0; \
+        asdf_ndarray_err_t res = asdf_ndarray_read_at(ndarray, indices, (datatype), &value); \
+        if (err) \
+            *err = res; \
+        return value; \
+    }
+
+
+ASDF_DEFINE_READ_AT(int8, int8_t, ASDF_DATATYPE_INT8)
+ASDF_DEFINE_READ_AT(uint8, uint8_t, ASDF_DATATYPE_UINT8)
+ASDF_DEFINE_READ_AT(int16, int16_t, ASDF_DATATYPE_INT16)
+ASDF_DEFINE_READ_AT(uint16, uint16_t, ASDF_DATATYPE_UINT16)
+ASDF_DEFINE_READ_AT(int32, int32_t, ASDF_DATATYPE_INT32)
+ASDF_DEFINE_READ_AT(uint32, uint32_t, ASDF_DATATYPE_UINT32)
+ASDF_DEFINE_READ_AT(int64, int64_t, ASDF_DATATYPE_INT64)
+ASDF_DEFINE_READ_AT(uint64, uint64_t, ASDF_DATATYPE_UINT64)
+#ifdef HAVE_FLOAT16
+ASDF_DEFINE_READ_AT(float16, _Float16, ASDF_DATATYPE_FLOAT16)
+#endif
+ASDF_DEFINE_READ_AT(float32, float, ASDF_DATATYPE_FLOAT32)
+ASDF_DEFINE_READ_AT(float64, double, ASDF_DATATYPE_FLOAT64)
+
+
 asdf_ndarray_err_t asdf_ndarray_read_tile_2d(
     asdf_ndarray_t *ndarray,
     uint64_t x, // NOLINT(readability-identifier-length,bugprone-easily-swappable-parameters)

--- a/src/core/ndarray_convert.c
+++ b/src/core/ndarray_convert.c
@@ -94,9 +94,10 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_GENERIC_CONV_FN(src_t, dst_t, name, bswap) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         dst_t *_dst = (dst_t *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *_src = (const src_t *)src; \
+        const char *_src = (const char *)src; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = _src[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, _src + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             _dst[idx] = (dst_t)val; \
         } \
@@ -114,10 +115,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_CLAMP_CONV_FN(src_t, dst_t, name, bswap, minval, maxval) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         dst_t *_dst = (dst_t *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *_src = (const src_t *)src; \
+        const char *_src = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = _src[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, _src + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             if (val < (src_t)(minval)) { \
                 _dst[idx] = minval; \
@@ -145,10 +147,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_CLAMP_FLOAT_CONV_FN(src_t, dst_t, name, bswap, minval, maxval) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         dst_t *_dst = (dst_t *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *_src = (const src_t *)src; \
+        const char *_src = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = _src[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, _src + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             if (isinf(val)) { \
                 _dst[idx] = (dst_t)val; \
@@ -175,10 +178,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_INT_TO_HALF_CONV_FN(src_t, name, bswap, minval, maxval) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         half *_dst = (half *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *_src = (const src_t *)src; \
+        const char *_src = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = _src[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, _src + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             if (val < (src_t)(minval)) { \
                 _dst[idx] = (half)(-INFINITY); \
@@ -205,10 +209,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_UINT_TO_HALF_CONV_FN(src_t, name, bswap, maxval) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         half *_dst = (half *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *_src = (const src_t *)src; \
+        const char *_src = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = _src[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, _src + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             if (val > (src_t)(maxval)) { \
                 _dst[idx] = (half)(INFINITY); \
@@ -241,10 +246,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_HALF_TO_INT_CONV_FN(dst_t, name, bswap, minval, maxval) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         dst_t *_dst = (dst_t *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const half *_src = (const half *)src; \
+        const char *_src = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            half hval = _src[idx]; \
+            half hval; \
+            LOAD_UNALIGNED(hval, _src + idx * sizeof(half)); \
             _DO_BSWAP_##bswap(half, hval); \
             float val = (float)hval; \
             if (isnan(val)) { \
@@ -269,10 +275,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_CLAMP_MAX_CONV_FN(src_t, dst_t, name, bswap, maxval) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         dst_t *_dst = (dst_t *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *_src = (const src_t *)src; \
+        const char *_src = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = _src[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, _src + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             if (val > (src_t)(maxval)) { \
                 _dst[idx] = maxval; \
@@ -292,10 +299,11 @@ static atomic_bool conversion_table_initialized = false;
 #define _DEFINE_TRUNCATE_CONV_FN(src_t, dst_t, name, bswap) \
     static int convert_##name(void *dst, const void *src, size_t count, UNUSED(size_t elsize)) { \
         dst_t *cdst = (dst_t *)dst; /* NOLINT(bugprone-macro-parentheses) */ \
-        const src_t *csrc = (const src_t *)src; \
+        const char *csrc = (const char *)src; \
         int overflow = 0; \
         for (size_t idx = 0; idx < count; idx++) { \
-            src_t val = csrc[idx]; \
+            src_t val; \
+            LOAD_UNALIGNED(val, csrc + idx * sizeof(src_t)); \
             _DO_BSWAP_##bswap(src_t, val); \
             if (val < (src_t)(0)) { \
                 val = (src_t)(0); \

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,16 @@
     } while (0)
 
 
+/*
+ * Read sizeof(dst) bytes from src into dst without assuming src is aligned
+ *
+ * Block data is mapped at whatever offset it occupies in the file, so pointers
+ * into it carry that offset's alignment.  Compilers lower a fixed-size memcpy
+ * to the same load a typed dereference would use, so this costs nothing.
+ */
+#define LOAD_UNALIGNED(dst, src) memcpy(&(dst), (src), sizeof(dst))
+
+
 ASDF_LOCAL size_t asdf_util_get_total_memory(void);
 
 

--- a/src/value.c
+++ b/src/value.c
@@ -490,6 +490,9 @@ asdf_mapping_t *asdf_mapping_clone(asdf_mapping_t *mapping) {
 
 
 void asdf_mapping_destroy(asdf_mapping_t *mapping) {
+    if (UNLIKELY(!mapping))
+        return;
+
     asdf_value_destroy(&mapping->value);
 }
 
@@ -888,6 +891,9 @@ void asdf_sequence_set_style(asdf_sequence_t *sequence, asdf_yaml_node_style_t s
 
 
 void asdf_sequence_destroy(asdf_sequence_t *sequence) {
+    if (UNLIKELY(!sequence))
+        return;
+
     asdf_value_destroy(&sequence->value);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,12 @@ add_compile_definitions(TEMP_DIR=\"${TEMP_DIR}\")
 
 set(runtime "WITH_CMAKE=set:YES;OBJC_DISABLE_INITIALIZE_FORK_SAFETY=set:YES;srcdir=set:${CMAKE_CURRENT_SOURCE_DIR};top_srcdir=set:${CMAKE_SOURCE_DIR};top_builddir=set:${CMAKE_BINARY_DIR};LD_LIBRARY_PATH=path_list_prepend:${CMAKE_BINARY_DIR}/src")
 
+# UBSan reports go to stderr, which munit captures and discards unless the test
+# fails; halt_on_error turns a report into an abort so the report is surfaced
+if (ENABLE_UBSAN)
+    string(APPEND runtime ";UBSAN_OPTIONS=set:print_stacktrace=1:halt_on_error=1")
+endif()
+
 # -------- Run optional shell command tests ----------------------------------
 if (BASH_PROGRAM AND ENABLE_TESTING_SHELL)
     foreach(shell_file ${shell_files})

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,6 +2,7 @@
 # 'check' comes from 'make check'
 AM_CPPFLAGS = \
     -I$(top_srcdir)/include \
+    -I$(top_builddir)/include \
     -I$(top_srcdir)/third_party/STC/include \
     -I$(top_srcdir)/src
 
@@ -284,6 +285,7 @@ $(cpp_header_test): $(asdf_public_headers) $(srcdir)/scripts/generate_test_cpp_h
 
 test-cpp-headers$(EXEEXT): $(cpp_header_test) $(top_builddir)/libasdf.la
 	$(AM_V_at)$(LIBTOOL) --mode=link $(CXX) -std=c++17 -I$(top_srcdir)/include \
+	    -I$(top_builddir)/include \
 	    $(ASDF_LDFLAGS) $(unit_test_ldflags) $(cpp_header_test) $(top_builddir)/libasdf.la $(ASDF_LIBS) \
 	    -o $@ $(QUIET_OUT)
 
@@ -316,6 +318,7 @@ $(DOC_EXAMPLES_DIR)/test-doc-examples.sh: $(DOC_EXAMPLE_DEPS)
 	$(AM_V_at)for f in $(DOC_EXAMPLES_DIR)/*.c; do \
 	    exe=$${f%.c}; \
 	    $(LIBTOOL) --mode=link $(CC) $(ASDF_CFLAGS) -I$(top_srcdir)/include \
+	      -I$(top_builddir)/include \
 	      $(ASDF_LDFLAGS) $(unit_test_ldflags) $$f $(top_builddir)/libasdf.la $(ASDF_LIBS) \
 	      -o $$exe $(QUIET_OUT); \
 	done

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,6 +45,16 @@ check_PROGRAMS = \
     test-yaml.unit
 
 TESTS_ENVIRONMENT = top_builddir=$(top_builddir) top_srcdir=$(top_srcdir)
+
+if UBSAN
+# UBSan reports go to stderr, which munit captures and discards unless the test
+# fails; halt_on_error turns a report into an abort so the report is surfaced.
+# Override UBSAN_OPTIONS in the environment to change this, e.g. to collect
+# every report rather than stopping at the first:
+#   make check UBSAN_OPTIONS=print_stacktrace=1:log_path=$PWD/ubsan
+TESTS_ENVIRONMENT += UBSAN_OPTIONS="$${UBSAN_OPTIONS:-print_stacktrace=1:halt_on_error=1}"
+endif
+
 TESTS = $(check_PROGRAMS)
 
 unit_test_base_cppflags = \

--- a/tests/test-core-extensions.c
+++ b/tests/test-core-extensions.c
@@ -567,8 +567,8 @@ MU_TEST(ndarray) {
     assert_not_null(data);
     assert_int(size, ==, sizeof(int64_t) * 8);
     // The actual array in this file is just 64-bit ints 0 through 7
-    for (int64_t idx = 0; idx < 8; idx++) {
-        assert_int(((int64_t *)data)[idx], ==, idx);
+    for (uint64_t idx = 0; idx < 8; idx++) {
+        assert_int(asdf_ndarray_at(ndarray, int64_t, idx), ==, (int64_t)idx);
     }
     asdf_ndarray_destroy(ndarray);
     asdf_close(file);

--- a/tests/test-file.c
+++ b/tests/test-file.c
@@ -293,8 +293,8 @@ MU_TEST(test_asdf_block_count) {
 static int test_multi_block_asdf_content(asdf_file_t *file) {
     assert_int(asdf_block_count(file), ==, 4);
 
-    char key[2];
-    for (int idx = 1; idx <= 4; idx++) {
+    char key[3];
+    for (uint8_t idx = 1; idx <= 4; idx++) {
         snprintf(key, 2, "%d", idx);
         asdf_ndarray_t *ndarray = NULL;
         assert_int(asdf_get_ndarray(file, key, &ndarray), ==, ASDF_VALUE_OK);

--- a/tests/test-ndarray.c
+++ b/tests/test-ndarray.c
@@ -1036,6 +1036,69 @@ MU_TEST(ndarray_data_alloc_temp_storage_set_ordering) {
 }
 
 
+/* Reading single elements with asdf_ndarray_at and friends */
+MU_TEST(ndarray_read_at) {
+    const char *path = get_fixture_file_path("tiles.asdf");
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    asdf_ndarray_t *nd1 = NULL;
+    asdf_ndarray_t *nd2 = NULL;
+    assert_int(asdf_get_ndarray(file, "1d", &nd1), ==, ASDF_VALUE_OK);
+    assert_int(asdf_get_ndarray(file, "2d", &nd2), ==, ASDF_VALUE_OK);
+
+    asdf_ndarray_err_t err = ASDF_NDARRAY_ERR_INVAL;
+
+    /* The 1-D array holds 1, 2, 3, 4 */
+    assert_int(asdf_ndarray_at_err(nd1, uint8_t, &err, 1), ==, 2);
+    assert_int(err, ==, ASDF_NDARRAY_OK);
+
+    /* The element is converted to the requested type */
+    assert_double(asdf_ndarray_at_err(nd1, double, &err, 2), ==, 3.0);
+    assert_int(err, ==, ASDF_NDARRAY_OK);
+
+    assert_int(asdf_ndarray_at_err(nd2, uint16_t, &err, 1, 1), ==, 22);
+    assert_int(err, ==, ASDF_NDARRAY_OK);
+
+    /* An index beyond the array's shape is out of bounds, not invalid */
+    assert_int(asdf_ndarray_at_err(nd1, uint8_t, &err, 4), ==, 0);
+    assert_int(err, ==, ASDF_NDARRAY_ERR_OUT_OF_BOUNDS);
+
+    /* Too few indices for the array's ndim */
+    assert_int(asdf_ndarray_at_err(nd2, uint16_t, &err, 1), ==, 0);
+    assert_int(err, ==, ASDF_NDARRAY_ERR_INVAL);
+
+    /* Too many indices for the array's ndim */
+    assert_int(asdf_ndarray_at_err(nd1, uint8_t, &err, 1, 1), ==, 0);
+    assert_int(err, ==, ASDF_NDARRAY_ERR_INVAL);
+
+    /* The same conditions through the underlying functions */
+    const uint64_t indices[] = {1, 1};
+    assert_int(asdf_ndarray_read_uint16_at(nd2, indices, &err), ==, 22);
+    assert_int(err, ==, ASDF_NDARRAY_OK);
+
+    uint16_t value = 0;
+    assert_int(
+        asdf_ndarray_read_at(nd2, indices, ASDF_DATATYPE_UINT16, &value), ==, ASDF_NDARRAY_OK);
+    assert_int(value, ==, 22);
+
+    /* NULL indices, as the at() macros pass when given the wrong number */
+    assert_int(
+        asdf_ndarray_read_at(nd2, NULL, ASDF_DATATYPE_UINT16, &value), ==,
+        ASDF_NDARRAY_ERR_INVAL);
+    assert_int(asdf_ndarray_read_uint16_at(nd2, NULL, &err), ==, 0);
+    assert_int(err, ==, ASDF_NDARRAY_ERR_INVAL);
+
+    /* Errors are silent without the _err variant; the value is zero */
+    assert_int(asdf_ndarray_at(nd2, uint16_t, 1), ==, 0);
+
+    asdf_ndarray_destroy(nd1);
+    asdf_ndarray_destroy(nd2);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     ndarray,
     MU_RUN_TEST(ndarray_read_1d_tile_contiguous),
@@ -1050,7 +1113,8 @@ MU_TEST_SUITE(
     MU_RUN_TEST(ndarray_inline_warning_thresh),
     MU_RUN_TEST(ndarray_array_storage_override, ndarray_array_storage_params),
     MU_RUN_TEST(heap_use_after_free_issue_63),
-    MU_RUN_TEST(ndarray_data_alloc_temp_storage_set_ordering)
+    MU_RUN_TEST(ndarray_data_alloc_temp_storage_set_ordering),
+    MU_RUN_TEST(ndarray_read_at)
 );
 
 


### PR DESCRIPTION
## Description

This resolves #227 by providing a suite of functions (and convenience macros) for accessing single elements of an ndarray safely regardless of word alignment, endianness, or source datatype.  It complements the other `asdf_ndarray_read_*` methods.

Also takes care of UB surrounding word alignment on the general read conversions as well.

Adds support for builds with UBSan enabled (which raised this issue in the first place) and updates the docs accordingly.

Also takes care of the long-standing problem (but for which there was not a written issue) of not shipping certain configured defines in the installed headers (esp. `ASDF_LOG_ENABLED`).

## AI Disclosure

No AI tools used.