### PR TITLE
Expose ASDF_ERROR_ macros and extension copy updates

### DIFF
--- a/include/asdf/error.h
+++ b/include/asdf/error.h
@@ -1,7 +1,8 @@
 /**
  * .. _asdf/error.h:
  *
- * Public error codes for the libasdf error-handling API.
+ * Public error codes for the libasdf error-handling API, and internal error
+ * reporting macros.
  */
 
 //
@@ -50,17 +51,137 @@ typedef enum {
     ASDF_ERR_OUT_OF_MEMORY,
     /** OS-level error; see `asdf_error_errno` for the original ``errno`` */
     ASDF_ERR_SYSTEM,
-    /** Invalid argument */
+    /** Invalid argument
+     *
+     * When set with `ASDF_ERROR_COMMON` takes two parameters:
+     *
+     * - ``char *`` - the name of the function argument passed an invalid value
+     * - ``char *`` - a string representation of the invalid value passed
+     */
     ASDF_ERR_INVALID_ARGUMENT,
-    /** Unknown compression type */
+    /** Unknown compression type
+     *
+     * When set with `ASDF_ERROR_COMMON` takes one parameter:
+     *
+     * - ``char *`` - the unknown compression type string, NULL-terminated
+     */
     ASDF_ERR_UNKNOWN_COMPRESSION,
-    /** Compression or decompression error */
+    /** Compression or decompression error
+     *
+     * When set with `ASDF_ERROR_COMMON` takes one parameter:
+     *
+     * - ``char *`` - additional compression/decompression error details,
+     *   typically passed from the underlying compression library or
+     *   compressor extension.
+     */
     ASDF_ERR_COMPRESSION_FAILED,
-    /** No serializer registered for extension */
+    /**
+     * No serializer registered for extension
+     *
+     * When set with `ASDF_ERROR_COMMON` takes one parameter:
+     *
+     * - ``char *`` - the key naming the extension (typically a YAML tag)
+     */
     ASDF_ERR_EXTENSION_NOT_FOUND,
-    /** A system limit has been reached */
+    /**
+     * A system limit has been reached
+     *
+     * When set with `ASDF_ERROR_COMMON` takes one parameter:
+     *
+     * - ``char *`` - additional details of the limit that that was surpassed
+     */
     ASDF_ERR_OVER_LIMIT
 } asdf_error_code_t;
+
+/**
+ * Reporting errors
+ * ----------------
+ *
+ * The following macros are intended for setting internal error states in
+ * libasdf.  Normally these are meant for internal use, but are exposed in
+ * the public API for use by extension authors as well. Application code
+ * (outside libasdf) should not use these, as they set error codes in libasdf
+ * itself.
+ *
+ * Each of these macros also causes a log message to be emitted at
+ * `ASDF_LOG_ERROR` or greater if compiled with ``ASDF_LOG_ENABLED``.
+ */
+
+// Forward declarations
+typedef struct asdf_file asdf_file_t;
+typedef struct asdf_value asdf_value_t;
+
+// clang-format off
+
+/**
+ * Set an error with a code from `asdf_error_code_t`; optional variadic args
+ * are the format parameters for the per-code format string, which depends
+ * on the error code (some do not take any parameters).
+ *
+ * .. note::
+ *
+ *   These format strings are defined in the source at ``src/error.c``.  The
+ *   per-code parameters are noted in the per-code documentation at
+ *   `asdf_error_code_t` as best as possible, though refer to the source as
+ *   the final arbiter.
+ *
+ * :param obj: The libasdf handle in which to record the error: an
+ *   `asdf_file_t *`, or an `asdf_value_t *` (which records against its file).
+ * :param code: The `asdf_error_code_t` to set
+ * :param ...: Error code-specific additional parameters
+ */
+#define ASDF_ERROR_COMMON(obj, code, ...) _Generic((obj), \
+    asdf_file_t *: asdf_file_error_common, \
+    asdf_value_t *: asdf_value_error_common \
+    )((obj), (code), __FILE__, __LINE__, ##__VA_ARGS__)
+
+
+/**
+ * Special case for reporting a memory error (e.g. failed allocation)
+ *
+ * This is roughly equivalent to setting
+ * ``ASDF_ERROR_COMMON(obj, ASDF_ERR_OUT_OF_MEMORY)`` with some extra
+ * precautions taken; use this as a shortcut for allocation failure error
+ * paths.
+ *
+ * :param obj: The libasdf handle in which to record the error: an
+ *   `asdf_file_t *`, or an `asdf_value_t *` (which records against its file).
+ */
+#define ASDF_ERROR_OOM(obj) _Generic((obj), \
+    asdf_file_t *: asdf_file_error_oom, \
+    asdf_value_t *: asdf_value_error_oom \
+    )((obj), __FILE__, __LINE__)
+
+/**
+ * Set a system (OS) error from an errno value
+ *
+ * This sets an error in libasdf but with an error message derived from
+ * ``strerror``.
+ *
+ * :param obj: The libasdf handle in which to record the error: an
+ *   `asdf_file_t *`, or an `asdf_value_t *` (which records against its file).
+ * :param errnum: An error, e.g. from a system call, retrieved from ``errno``
+ */
+#define ASDF_ERROR_SYSTEM(obj, errnum) \
+    _Generic( \
+        (obj), asdf_file_t *: asdf_file_error_system, asdf_value_t *: asdf_value_error_system)( \
+        (obj), (errnum), __FILE__, __LINE__)
+
+// clang-format on
+
+// The following symbols must be exported for the above macros, but are
+// intentionally left undocumented.
+
+ASDF_EXPORT void asdf_file_error_common(
+    asdf_file_t *file, asdf_error_code_t code, const char *src_file, int lineno, ...);
+ASDF_EXPORT void asdf_value_error_common(
+    asdf_value_t *file, asdf_error_code_t code, const char *src_file, int lineno, ...);
+ASDF_EXPORT void asdf_file_error_oom(asdf_file_t *file, const char *src_file, int lineno);
+ASDF_EXPORT void asdf_value_error_oom(asdf_value_t *file, const char *src_file, int lineno);
+ASDF_EXPORT void asdf_file_error_system(
+    asdf_file_t *value, int errnum, const char *src_file, int lineno);
+ASDF_EXPORT void asdf_value_error_system(
+    asdf_value_t *value, int errnum, const char *src_file, int lineno);
 
 ASDF_END_DECLS
 

--- a/include/asdf/extension.h
+++ b/include/asdf/extension.h
@@ -67,10 +67,11 @@ typedef asdf_value_err_t (*asdf_extension_deserialize_t)(
 /**
  * Deep-copy a native object
  *
+ * :param file: A handle to the file to which the object belongs
  * :param obj: The native object to copy
  * :return: The newly allocated copy, or ``NULL`` on failure
  */
-typedef void *(*asdf_extension_copy_t)(const void *obj);
+typedef void *(*asdf_extension_copy_t)(asdf_file_t *file, const void *obj);
 
 
 /**
@@ -226,7 +227,7 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
  * sure to implement this if the extension object contains nested data structures.
  */
 #define ASDF_EXT_DEFINE_CLONE(extname, type) \
-    ASDF_EXPORT type *asdf_##extname##_clone(const type *object) { \
+    ASDF_EXPORT type *asdf_##extname##_clone(asdf_file_t *file, const type *object) { \
         if (!object) \
             return NULL; \
         asdf_extension_t *ext = &ASDF_EXT_STATIC_NAME(extname); \
@@ -239,7 +240,7 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
             memcpy(clone, object, sizeof(type)); \
             return clone; \
         } \
-        return (type *)ext->vtab->copy(object); \
+        return (type *)ext->vtab->copy(file, object); \
     }
 
 
@@ -249,7 +250,7 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
  * For example, clones an `asdf_history_entry_t **` array.
  */
 #define ASDF_EXT_DEFINE_ARRAY_CLONE(extname, type) \
-    ASDF_EXPORT type **asdf_##extname##_array_clone(const type **src) { \
+    ASDF_EXPORT type **asdf_##extname##_array_clone(asdf_file_t *file, const type **src) { \
         size_t nelem = 0; \
         while (src[nelem]) \
             nelem++; \
@@ -257,7 +258,7 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
         if (!dst) \
             return NULL; \
         for (size_t idx = 0; idx < nelem; idx++) { \
-            dst[idx] = asdf_##extname##_clone(src[idx]); \
+            dst[idx] = asdf_##extname##_clone(file, src[idx]); \
             if (!dst[idx]) { \
                 for (size_t jdx = 0; jdx < idx; jdx++) \
                     asdf_##extname##_destroy(dst[jdx]); \
@@ -352,8 +353,8 @@ ASDF_EXPORT void asdf_tag_destroy(asdf_tag_t *tag);
         asdf_file_t *file, const char *path, type **out); \
     ASDF_EXPORT asdf_value_err_t asdf_set_##extname( \
         asdf_file_t *file, const char *path, const type *obj); \
-    ASDF_EXPORT type *asdf_##extname##_clone(const type *object); \
-    ASDF_EXPORT type **asdf_##extname##_array_clone(const type **src); \
+    ASDF_EXPORT type *asdf_##extname##_clone(asdf_file_t *file, const type *object); \
+    ASDF_EXPORT type **asdf_##extname##_array_clone(asdf_file_t *file, const type **src); \
     ASDF_EXPORT void asdf_##extname##_destroy(type *object)
 
 ASDF_END_DECLS

--- a/src/context.h
+++ b/src/context.h
@@ -57,7 +57,7 @@ ASDF_LOCAL void asdf_context_release(asdf_context_t *ctx);
 ASDF_LOCAL asdf_global_context_t *asdf_global_context_get(void);
 
 
-static inline asdf_context_t *asdf_get_context_helper(void *obj) {
+static inline asdf_context_t *asdf_context_get(void *obj) {
     if (obj == NULL)
         return asdf_global_context_get()->base.ctx;
 
@@ -66,6 +66,3 @@ static inline asdf_context_t *asdf_get_context_helper(void *obj) {
 #endif
     return ((asdf_base_t *)obj)->ctx;
 }
-
-
-#define ASDF_GET_CONTEXT(obj) asdf_context_t *__ctx = asdf_get_context_helper(obj);

--- a/src/core/asdf.c
+++ b/src/core/asdf.c
@@ -351,7 +351,7 @@ static void asdf_meta_dealloc(void *value) {
 }
 
 
-static void *asdf_meta_copy(const void *value) {
+static void *asdf_meta_copy(asdf_file_t *file, const void *value) {
     if (!value)
         return NULL;
 
@@ -364,7 +364,7 @@ static void *asdf_meta_copy(const void *value) {
     }
 
     if (meta->asdf_library) {
-        copy->asdf_library = asdf_software_clone(meta->asdf_library);
+        copy->asdf_library = asdf_software_clone(file, meta->asdf_library);
 
         if (!copy->asdf_library)
             goto failure;
@@ -372,7 +372,7 @@ static void *asdf_meta_copy(const void *value) {
 
     if (meta->history.extensions) {
         copy->history.extensions = (const asdf_extension_metadata_t **)
-            asdf_extension_metadata_array_clone(meta->history.extensions);
+            asdf_extension_metadata_array_clone(file, meta->history.extensions);
 
         if (!copy->history.extensions)
             goto failure;
@@ -380,7 +380,7 @@ static void *asdf_meta_copy(const void *value) {
 
     if (meta->history.entries) {
         copy->history.entries = (const asdf_history_entry_t **)asdf_history_entry_array_clone(
-            meta->history.entries);
+            file, meta->history.entries);
 
         if (!copy->history.entries)
             goto failure;
@@ -390,6 +390,7 @@ static void *asdf_meta_copy(const void *value) {
 
 failure:
     asdf_meta_dealloc(copy);
+    ASDF_ERROR_OOM(file);
     return NULL;
 }
 

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -158,7 +158,7 @@ static void asdf_extension_metadata_dealloc(void *value) {
 }
 
 
-static void *asdf_extension_metadata_copy(const void *value) {
+static void *asdf_extension_metadata_copy(asdf_file_t *file, const void *value) {
     if (!value)
         return NULL;
 
@@ -177,7 +177,7 @@ static void *asdf_extension_metadata_copy(const void *value) {
     }
 
     if (metadata->package) {
-        copy->package = asdf_software_clone(metadata->package);
+        copy->package = asdf_software_clone(file, metadata->package);
 
         if (!copy->package)
             goto failure;
@@ -194,7 +194,7 @@ static void *asdf_extension_metadata_copy(const void *value) {
 
 failure:
     asdf_extension_metadata_dealloc(copy);
-    ASDF_ERROR_OOM(NULL);
+    ASDF_ERROR_OOM(file);
     return NULL;
 }
 

--- a/src/core/history_entry.c
+++ b/src/core/history_entry.c
@@ -255,7 +255,7 @@ static void asdf_history_entry_dealloc(void *value) {
 }
 
 
-static void *asdf_history_entry_copy(const void *value) {
+static void *asdf_history_entry_copy(asdf_file_t *file, const void *value) {
     if (!value)
         return NULL;
 
@@ -274,14 +274,14 @@ static void *asdf_history_entry_copy(const void *value) {
     }
 
     if (entry->time) {
-        copy->time = asdf_time_clone(entry->time);
+        copy->time = asdf_time_clone(file, entry->time);
 
         if (!copy->time)
             goto failure;
     }
 
     if (entry->software) {
-        copy->software = (const asdf_software_t **)asdf_software_array_clone(entry->software);
+        copy->software = (const asdf_software_t **)asdf_software_array_clone(file, entry->software);
 
         if (!copy->software)
             goto failure;
@@ -290,7 +290,7 @@ static void *asdf_history_entry_copy(const void *value) {
     return copy;
 failure:
     asdf_history_entry_destroy(copy);
-    ASDF_ERROR_OOM(NULL);
+    ASDF_ERROR_OOM(file);
     return NULL;
 }
 
@@ -335,7 +335,7 @@ int asdf_history_entry_add(asdf_file_t *file, const char *description) {
         goto failure;
 
     asdf_software_t *asdf_library = file->asdf_library ? file->asdf_library : &libasdf_software;
-    entry->software[0] = asdf_software_clone(asdf_library);
+    entry->software[0] = asdf_software_clone(file, asdf_library);
 
     if (!entry->software[0])
         goto failure;

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -1533,9 +1533,9 @@ void asdf_ndarray_data_dealloc(asdf_ndarray_t *ndarray) {
     if (UNLIKELY(!internal || (!internal->data && !internal->data_is_empty))) {
         asdf_context_t *ctx = NULL;
         if (ndarray->internal)
-            ctx = asdf_get_context_helper(ndarray->internal->file);
+            ctx = asdf_context_get(ndarray->internal->file);
         else
-            ctx = asdf_get_context_helper(NULL);
+            ctx = asdf_context_get(NULL);
 
         ASDF_LOG_CTX(
             ctx,

--- a/src/core/software.c
+++ b/src/core/software.c
@@ -149,7 +149,7 @@ static void asdf_software_dealloc(void *value) {
 }
 
 
-static void *asdf_software_copy(const void *value) {
+static void *asdf_software_copy(asdf_file_t *file, const void *value) {
     if (!value)
         return NULL;
 
@@ -190,7 +190,7 @@ static void *asdf_software_copy(const void *value) {
     return copy;
 failure:
     asdf_software_dealloc(copy);
-    ASDF_ERROR_OOM(NULL);
+    ASDF_ERROR_OOM(file);
     return NULL;
 }
 
@@ -216,17 +216,15 @@ ASDF_REGISTER_EXTENSION(
 
 /** Additional software-related methods */
 void asdf_library_set(asdf_file_t *file, const asdf_software_t *software) {
-    file->asdf_library = asdf_software_clone(software);
+    file->asdf_library = asdf_software_clone(file, software);
 }
 
 
 void asdf_library_set_version(asdf_file_t *file, const char *version) {
-    asdf_software_t *software = asdf_software_clone(&libasdf_software);
+    asdf_software_t *software = asdf_software_clone(file, &libasdf_software);
 
-    if (!software) {
-        ASDF_ERROR_OOM(file);
+    if (!software)
         return;
-    }
 
     if (software->version)
         asdf_version_destroy((asdf_version_t *)software->version);

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -891,20 +891,27 @@ failure:
 }
 
 
-static void *asdf_time_copy(const void *obj) {
+static void *asdf_time_copy(asdf_file_t *file, const void *obj) {
     if (!obj)
         return NULL;
 
     const asdf_time_t *tm = obj;
     asdf_time_t *copy = calloc(1, sizeof(asdf_time_t));
 
-    if (!copy)
-        return NULL;
+    if (UNLIKELY(!copy))
+        goto failure;
 
     *copy = *tm;
     copy->value = tm->value ? strdup(tm->value) : NULL;
 
+    if (UNLIKELY(tm->value && !copy->value))
+        goto failure;
+
     return copy;
+failure:
+    ASDF_ERROR_OOM(file);
+    free(copy);
+    return NULL;
 }
 
 

--- a/src/emitter.c
+++ b/src/emitter.c
@@ -291,7 +291,7 @@ static int emit_prepare_root_node(asdf_emitter_t *emitter) {
         meta = calloc(1, sizeof(asdf_meta_t));
     } else {
         asdf_meta_t *orig_meta = meta;
-        meta = asdf_meta_clone(orig_meta);
+        meta = asdf_meta_clone(file, orig_meta);
         asdf_meta_destroy(orig_meta);
     }
 
@@ -305,7 +305,7 @@ static int emit_prepare_root_node(asdf_emitter_t *emitter) {
         meta->asdf_library = NULL;
     } else {
         asdf_software_t *asdf_library = file->asdf_library ? file->asdf_library : &libasdf_software;
-        meta->asdf_library = asdf_software_clone(asdf_library);
+        meta->asdf_library = asdf_software_clone(file, asdf_library);
 
         if (!meta->asdf_library)
             goto cleanup;

--- a/src/error.c
+++ b/src/error.c
@@ -6,13 +6,21 @@
 
 #include "context.h"
 #include "error.h"
+#include "file.h"
 #include "log.h"
+#include "value.h"
 
 
 /* Per-code format strings.  Codes whose format is NULL either carry no
  * message (ASDF_ERR_NONE) or compute the message dynamically
  * (ASDF_ERR_SYSTEM).  Codes whose format string contains no '%' are stored
- * as static strings with no heap allocation. */
+ * as static strings with no heap allocation.
+ *
+ * These are documented in the public API documentation for ``asdf/error.h``
+ * so when adding or updating any of these please make sure to update the
+ * documentation for parameters associated with each error code (if any--most
+ * are not parameterized).
+ */
 static const char *const asdf_error_formats[] = {
     [ASDF_ERR_NONE] = NULL,
     [ASDF_ERR_UNKNOWN_STATE] = "unknown parser state",
@@ -56,7 +64,7 @@ static const asdf_log_level_t asdf_error_log_levels[] = {
 
 /* Internal helper: replace the stored error string with a static (non-heap) one.
  * This never allocates, so it is safe to use from OOM paths. */
-static void asdf_context_error_set_static(asdf_context_t *ctx, const char *error) {
+static void asdf_context_error_static(asdf_context_t *ctx, const char *error) {
     if (ctx->error_type == ASDF_ERROR_HEAP)
         free((void *)ctx->error);
 
@@ -89,10 +97,39 @@ int asdf_context_saved_errno_get(asdf_context_t *ctx) {
 }
 
 
-void asdf_context_error_set_common(
-    asdf_context_t *ctx, asdf_error_code_t code, const char *src_file, int lineno, ...) {
+/* Format string has specifiers--build the message on the heap */
+static void asdf_context_error_heapv(asdf_context_t *ctx, const char *fmt, va_list args) {
+    /* Clear any existing heap-allocated error */
+    if (ctx->error_type == ASDF_ERROR_HEAP)
+        free((void *)ctx->error);
+
+    ctx->error = NULL;
+
+    va_list args_size;
+    va_copy(args_size, args);
+    int size = vsnprintf(NULL, 0, fmt, args_size);
+    va_end(args_size);
+
+    char *error = malloc(size + 1);
+
+    if (!error) {
+        /* OOM while setting error--fall back to the static OOM message */
+        ctx->error = asdf_error_formats[ASDF_ERR_OUT_OF_MEMORY];
+        ctx->error_type = ASDF_ERROR_STATIC;
+        ctx->error_code = ASDF_ERR_OUT_OF_MEMORY;
+        return;
+    }
+
+    vsnprintf(error, size + 1, fmt, args);
+    ctx->error = error;
+    ctx->error_type = ASDF_ERROR_HEAP;
+}
+
+
+static void asdf_context_error_commonv(
+    asdf_context_t *ctx, asdf_error_code_t code, const char *src_file, int lineno, va_list args) {
     assert(ctx);
-    assert(code != ASDF_ERR_SYSTEM); /* use asdf_context_error_set_system for OS errors */
+    assert(code != ASDF_ERR_SYSTEM); /* use asdf_context_error_system for OS errors */
 
     const char *fmt = asdf_error_formats[code];
     asdf_log_level_t level = asdf_error_log_levels[code];
@@ -111,36 +148,9 @@ void asdf_context_error_set_common(
 
     if (!strchr(fmt, '%')) {
         /* No format specifiers -- use the table string directly (no allocation) */
-        asdf_context_error_set_static(ctx, fmt);
+        asdf_context_error_static(ctx, fmt);
     } else {
-        /* Format string has specifiers -- build the message on the heap */
-        if (ctx->error_type == ASDF_ERROR_HEAP)
-            free((void *)ctx->error);
-
-        ctx->error = NULL;
-
-        va_list args;
-        va_start(args, lineno);
-        // NOLINTNEXTLINE(clang-analyzer-valist.Uninitialized)
-        int size = vsnprintf(NULL, 0, fmt, args);
-        va_end(args);
-
-        char *error = malloc(size + 1);
-
-        if (!error) {
-            /* OOM while setting error -- fall back to the static OOM message */
-            ctx->error = asdf_error_formats[ASDF_ERR_OUT_OF_MEMORY];
-            ctx->error_type = ASDF_ERROR_STATIC;
-            ctx->error_code = ASDF_ERR_OUT_OF_MEMORY;
-            return;
-        }
-
-        va_start(args, lineno);
-        vsnprintf(error, size + 1, fmt, args);
-        va_end(args);
-
-        ctx->error = error;
-        ctx->error_type = ASDF_ERROR_HEAP;
+        asdf_context_error_heapv(ctx, fmt, args);
     }
 
 #ifdef ASDF_LOG_ENABLED
@@ -154,9 +164,18 @@ void asdf_context_error_set_common(
 }
 
 
-void asdf_context_error_set_oom(asdf_context_t *ctx, const char *src_file, int lineno) {
+void asdf_context_error_common(
+    asdf_context_t *ctx, asdf_error_code_t code, const char *src_file, int lineno, ...) {
+    va_list args;
+    va_start(args, lineno);
+    asdf_context_error_commonv(ctx, code, src_file, lineno, args);
+    va_end(args);
+}
+
+
+void asdf_context_error_oom(asdf_context_t *ctx, const char *src_file, int lineno) {
     /* Never allocates -- safe to call from OOM paths */
-    asdf_context_error_set_static(ctx, asdf_error_formats[ASDF_ERR_OUT_OF_MEMORY]);
+    asdf_context_error_static(ctx, asdf_error_formats[ASDF_ERR_OUT_OF_MEMORY]);
     ctx->error_code = ASDF_ERR_OUT_OF_MEMORY;
     ctx->saved_errno = 0;
 
@@ -170,8 +189,7 @@ void asdf_context_error_set_oom(asdf_context_t *ctx, const char *src_file, int l
 }
 
 
-void asdf_context_error_set_system(
-    asdf_context_t *ctx, int errnum, const char *src_file, int lineno) {
+void asdf_context_error_system(asdf_context_t *ctx, int errnum, const char *src_file, int lineno) {
     assert(ctx);
 
     if (ctx->error_type == ASDF_ERROR_HEAP)
@@ -194,10 +212,10 @@ void asdf_context_error_set_system(
 
 void asdf_context_error_copy(asdf_context_t *dst, const asdf_context_t *src) {
     if (!dst)
-        dst = asdf_get_context_helper(NULL);
+        dst = asdf_context_get(NULL);
 
     if (!src)
-        src = asdf_get_context_helper(NULL);
+        src = asdf_context_get(NULL);
 
     if (dst == src || !dst || !src)
         return;
@@ -210,4 +228,48 @@ void asdf_context_error_copy(asdf_context_t *dst, const asdf_context_t *src) {
     dst->error_type = src->error_type;
     dst->error_code = src->error_code;
     dst->saved_errno = src->saved_errno;
+}
+
+
+/* External wrappers */
+void asdf_file_error_common(
+    asdf_file_t *file, asdf_error_code_t code, const char *src_file, int lineno, ...) {
+    va_list args;
+    va_start(args, lineno);
+    asdf_context_t *ctx = asdf_context_get(file);
+    asdf_context_error_commonv(ctx, code, src_file, lineno, args);
+    va_end(args);
+}
+
+void asdf_value_error_common(
+    asdf_value_t *value, asdf_error_code_t code, const char *src_file, int lineno, ...) {
+    va_list args;
+    va_start(args, lineno);
+    asdf_context_t *ctx = asdf_context_get(value ? value->file : NULL);
+    asdf_context_error_commonv(ctx, code, src_file, lineno, args);
+    va_end(args);
+}
+
+
+void asdf_file_error_oom(asdf_file_t *file, const char *src_file, int lineno) {
+    asdf_context_t *ctx = asdf_context_get(file);
+    asdf_context_error_oom(ctx, src_file, lineno);
+}
+
+
+void asdf_value_error_oom(asdf_value_t *value, const char *src_file, int lineno) {
+    asdf_context_t *ctx = asdf_context_get(value ? value->file : NULL);
+    asdf_context_error_oom(ctx, src_file, lineno);
+}
+
+
+void asdf_file_error_system(asdf_file_t *file, int errnum, const char *src_file, int lineno) {
+    asdf_context_t *ctx = asdf_context_get(file);
+    asdf_context_error_system(ctx, errnum, src_file, lineno);
+}
+
+
+void asdf_value_error_system(asdf_value_t *value, int errnum, const char *src_file, int lineno) {
+    asdf_context_t *ctx = asdf_context_get(value ? value->file : NULL);
+    asdf_context_error_system(ctx, errnum, src_file, lineno);
 }

--- a/src/error.h
+++ b/src/error.h
@@ -11,10 +11,10 @@ ASDF_LOCAL int asdf_context_saved_errno_get(asdf_context_t *ctx);
 
 /* These take __FILE__ / __LINE__ from the call-site macro so that log messages
  * show the correct source location rather than a line inside error.c. */
-ASDF_LOCAL void asdf_context_error_set_common(
+ASDF_LOCAL void asdf_context_error_common(
     asdf_context_t *ctx, asdf_error_code_t code, const char *file, int lineno, ...);
-ASDF_LOCAL void asdf_context_error_set_oom(asdf_context_t *ctx, const char *file, int lineno);
-ASDF_LOCAL void asdf_context_error_set_system(
+ASDF_LOCAL void asdf_context_error_oom(asdf_context_t *ctx, const char *file, int lineno);
+ASDF_LOCAL void asdf_context_error_system(
     asdf_context_t *ctx, int errnum, const char *file, int lineno);
 ASDF_LOCAL void asdf_context_error_copy(asdf_context_t *dst, const asdf_context_t *src);
 
@@ -23,6 +23,10 @@ ASDF_LOCAL void asdf_context_error_copy(asdf_context_t *dst, const asdf_context_
  * Macros for setting errors on arbitrary ASDF base types
  *
  * These should be used more generally than the ``asdf_context_error_*`` functions.
+ *
+ * Versions of these are also defined in the public ``asdf/error.h`` header, but
+ * that don't expose the ``asdf_context_t`` internals.  Internally these versions
+ * are used instead.
  */
 
 /* Read the current error message string */
@@ -33,22 +37,15 @@ ASDF_LOCAL void asdf_context_error_copy(asdf_context_t *dst, const asdf_context_
 
 /* Set an error with a code; optional variadic args are the format parameters for
  * the per-code format string defined in error.c */
+#undef ASDF_ERROR_COMMON
 #define ASDF_ERROR_COMMON(obj, code, ...) \
-    do { \
-        ASDF_GET_CONTEXT(obj); \
-        asdf_context_error_set_common(__ctx, (code), __FILE__, __LINE__, ##__VA_ARGS__); \
-    } while (0)
+    asdf_context_error_common(asdf_context_get(obj), (code), __FILE__, __LINE__, ##__VA_ARGS__)
 
 /* Set an out-of-memory error (never allocates) */
-#define ASDF_ERROR_OOM(obj) \
-    do { \
-        ASDF_GET_CONTEXT(obj); \
-        asdf_context_error_set_oom(__ctx, __FILE__, __LINE__); \
-    } while (0)
+#undef ASDF_ERROR_OOM
+#define ASDF_ERROR_OOM(obj) asdf_context_error_oom(asdf_context_get(obj), __FILE__, __LINE__)
 
 /* Set a system (OS) error from an errno value */
+#undef ASDF_ERROR_SYSTEM
 #define ASDF_ERROR_SYSTEM(obj, errnum) \
-    do { \
-        ASDF_GET_CONTEXT(obj); \
-        asdf_context_error_set_system(__ctx, (errnum), __FILE__, __LINE__); \
-    } while (0)
+    asdf_context_error_system(asdf_context_get(obj), (errnum), __FILE__, __LINE__)

--- a/src/log.c
+++ b/src/log.c
@@ -162,7 +162,7 @@ void asdf_file_log(
     int lineno,
     const char *fmt,
     ...) {
-    asdf_context_t *ctx = asdf_get_context_helper((void *)file);
+    asdf_context_t *ctx = asdf_context_get((void *)file);
     va_list args;
     va_start(args, fmt);
     if (!ctx || !ctx->log.stream) {

--- a/src/log.h
+++ b/src/log.h
@@ -34,8 +34,7 @@
 #define ASDF_LOG(obj, level, ...) \
     do { \
         if ((level) >= ASDF_LOG_MIN_LEVEL) { \
-            ASDF_GET_CONTEXT(obj); \
-            asdf_context_log(__ctx, (level), __FILE__, __LINE__, __VA_ARGS__); \
+            asdf_context_log(asdf_context_get(obj), (level), __FILE__, __LINE__, __VA_ARGS__); \
         } \
     } while (0)
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -695,7 +695,7 @@ asdf_stream_t *asdf_stream_from_file(asdf_context_t *ctx, const char *filename, 
     if (!file && is_writeable && errno == ENOENT)
         file = fopen(filename, "w+b");
     if (!file) {
-        asdf_context_error_set_system(ctx, errno, __FILE__, __LINE__);
+        asdf_context_error_system(ctx, errno, __FILE__, __LINE__);
         return NULL;
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,7 @@ check_PROGRAMS = \
     test-block.unit \
     test-compression.unit \
     test-core-extensions.unit \
+    test-error.unit \
     test-event.unit \
     test-extension.unit \
     test-file.unit \
@@ -109,13 +110,20 @@ test_core_extensions_unit_CFLAGS = $(unit_test_cflags)
 test_core_extensions_unit_LDFLAGS = $(unit_test_ldflags)
 test_core_extensions_unit_LDADD = $(unit_test_ldadd)
 
+# test-error.unit
+test_error_unit_SOURCES = test-error.c
+test_error_unit_CPPFLAGS = $(unit_test_cppflags)
+test_error_unit_CFLAGS = $(unit_test_cflags)
+test_error_unit_LDFLAGS = $(unit_test_ldflags)
+test_error_unit_LDADD = $(unit_test_ldadd)
+
 # test-event.unit
 test_event_unit_SOURCES = test-event.c
 test_event_unit_CPPFLAGS = $(unit_test_cppflags)
 test_event_unit_CFLAGS = $(unit_test_cflags)
 test_event_unit_LDFLAGS = $(unit_test_ldflags)
 test_event_unit_LDADD = $(unit_test_ldadd)
-#
+
 # test-extension.unit
 test_extension_unit_SOURCES = test-extension.c
 test_extension_unit_CPPFLAGS = $(unit_test_cppflags)

--- a/tests/test-error.c
+++ b/tests/test-error.c
@@ -1,0 +1,70 @@
+/** Tests for public error APIs */
+
+#include <errno.h>
+
+#include "asdf/error.h"
+#include "asdf/file.h"
+
+#include "munit.h"
+
+
+MU_TEST(test_asdf_error_common) {
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+    ASDF_ERROR_COMMON(file, ASDF_ERR_YAML_PARSE_FAILED);
+    asdf_error_code_t code = asdf_error_code(file);
+    assert_int(code, ==, ASDF_ERR_YAML_PARSE_FAILED);
+    const char *message = asdf_error(file);
+    assert_string_equal(message, "YAML parsing failed");
+
+    /* Set a new parameterized error via the value */
+    asdf_value_t *value = asdf_get_value(file, "");
+    assert_not_null(value);
+    ASDF_ERROR_COMMON(value, ASDF_ERR_INVALID_ARGUMENT, "foo", "bar");
+    code = asdf_error_code(file);
+    assert_int(code, ==, ASDF_ERR_INVALID_ARGUMENT);
+    message = asdf_error(file);
+    assert_string_equal(message, "invalid argument for foo: bar");
+    asdf_value_destroy(value);
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+MU_TEST(test_asdf_error_oom) {
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+    ASDF_ERROR_OOM(file);
+    asdf_error_code_t code = asdf_error_code(file);
+    assert_int(code, ==, ASDF_ERR_OUT_OF_MEMORY);
+    const char *message = asdf_error(file);
+    assert_string_equal(message, "out of memory");
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+MU_TEST(test_asdf_error_system) {
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+    ASDF_ERROR_SYSTEM(file, EINVAL);
+    asdf_error_code_t code = asdf_error_code(file);
+    assert_int(code, ==, ASDF_ERR_SYSTEM);
+    assert_int(asdf_error_errno(file), ==, EINVAL);
+    const char *message = asdf_error(file);
+    /* May be platform or locale-dependent ...*/
+    assert_string_equal(message, "Invalid argument");
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+MU_TEST_SUITE(
+    error,
+    MU_RUN_TEST(test_asdf_error_common),
+    MU_RUN_TEST(test_asdf_error_oom),
+    MU_RUN_TEST(test_asdf_error_system)
+);
+
+
+MU_RUN_SUITE(error);

--- a/tests/test-extension.c
+++ b/tests/test-extension.c
@@ -97,7 +97,7 @@ static void asdf_foo_dealloc(void *value) {
 }
 
 
-static void *asdf_foo_copy(const void *value) {
+static void *asdf_foo_copy(asdf_file_t *file, const void *value) {
     if (!value)
         return NULL;
 
@@ -288,20 +288,25 @@ MU_TEST(test_asdf_get_foo) {
 
 
 MU_TEST(test_asdf_foo_clone) {
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
     asdf_foo_t foo = {.foo = "foo:foo"};
-    asdf_foo_t *clone = asdf_foo_clone(&foo);
+    asdf_foo_t *clone = asdf_foo_clone(file, &foo);
     assert_not_null(clone);
     assert_ptr_not_equal(foo.foo, clone->foo);
     assert_string_equal(foo.foo, clone->foo);
     asdf_foo_destroy(clone);
+    asdf_close(file);
     return MUNIT_OK;
 }
 
 
 MU_TEST(test_asdf_foo_array_clone) {
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
     asdf_foo_t foo = {.foo = "foo:foo"};
     const asdf_foo_t *foos[] = {&foo, NULL};
-    asdf_foo_t **clone = asdf_foo_array_clone(foos);
+    asdf_foo_t **clone = asdf_foo_array_clone(file, foos);
     assert_not_null(clone[0]);
     assert_null(clone[1]);
     assert_ptr_not_equal(clone[0], foos[0]);
@@ -311,6 +316,7 @@ MU_TEST(test_asdf_foo_array_clone) {
         asdf_foo_destroy(*fp);
     }
     free((void *)clone);
+    asdf_close(file);
     return MUNIT_OK;
 }
 


### PR DESCRIPTION
## Description

Resolves #229 and improves the ability to report errors in `asdf_<extension>_clone` methods.

## AI Disclosure

No AI tools used.