### PR TITLE
refactor: more rename of _clone -> _copy in public API

### DIFF
--- a/include/asdf/value.h
+++ b/include/asdf/value.h
@@ -203,20 +203,20 @@ ASDF_EXPORT void asdf_value_destroy(asdf_value_t *value);
 
 
 /**
- * Clone an `asdf_value_t`
+ * Copy an `asdf_value_t`
  *
  * This performs a deep-copy of a value and may be used in certain cases
  * (such as container iteration) when the user needs an owned copy of the
  * value.
  *
- * The new cloned value is not initially attached to the YAML tree, so
+ * The new copied value is not initially attached to the YAML tree, so
  * modification to its underlying value is not reflected in the YAML; it
  * may be inserted elsewhere in the tree later.
  *
- * :param value: The `asdf_value_t *` to clone
+ * :param value: The `asdf_value_t *` to copy
  * :return: A new deep-copied `asdf_value_t *`, or ``NULL`` on failure
  */
-ASDF_EXPORT asdf_value_t *asdf_value_clone(asdf_value_t *value);
+ASDF_EXPORT asdf_value_t *asdf_value_copy(asdf_value_t *value);
 
 /**
  * Get the specific `asdf_value_type_t` of a generic `asdf_value_t`
@@ -346,10 +346,10 @@ ASDF_EXPORT void asdf_mapping_set_style(asdf_mapping_t *mapping, asdf_yaml_node_
  * The returned mapping is not attached to the tree; it may be inserted
  * elsewhere later or released with `asdf_mapping_destroy`.
  *
- * :param mapping: The `asdf_mapping_t *` to clone
+ * :param mapping: The `asdf_mapping_t *` to copy
  * :return: A new `asdf_mapping_t *`, or ``NULL`` on failure
  */
-ASDF_EXPORT asdf_mapping_t *asdf_mapping_clone(asdf_mapping_t *mapping);
+ASDF_EXPORT asdf_mapping_t *asdf_mapping_copy(asdf_mapping_t *mapping);
 
 /**
  * Free a mapping and all values it contains
@@ -381,7 +381,7 @@ ASDF_EXPORT asdf_value_t *asdf_mapping_get(asdf_mapping_t *mapping, const char *
  * `asdf_mapping_iter_next`, the ``key`` and ``value`` fields hold the current
  * mapping entry and are valid until the next call to `asdf_mapping_iter_next`
  * or `asdf_mapping_iter_destroy`.  If the value must outlive the current
- * iteration step, clone it with `asdf_value_clone`.
+ * iteration step, copy it with `asdf_value_copy`.
  *
  * .. warning::
  *
@@ -1143,7 +1143,7 @@ typedef bool (*asdf_value_pred_t)(asdf_value_t *value);
  * After each successful call to `asdf_value_find_iter_next`, the ``value``
  * field holds the matching value and is valid until the next call to
  * `asdf_value_find_iter_next` or `asdf_find_iter_destroy`.  If the value must
- * persist further, clone it with `asdf_value_clone`.
+ * persist further, copy it with `asdf_value_copy`.
  */
 typedef struct {
     /** Current matching value */
@@ -1279,7 +1279,7 @@ ASDF_EXPORT asdf_find_iter_t *asdf_find_iter_init_ex(
  *
  *   asdf_find_iter_t *iter = asdf_find_iter_init(root, pred);
  *   while (asdf_value_find_iter_next(&iter)) {
- *       // iter->value is valid here; use asdf_value_clone if it must persist
+ *       // iter->value is valid here; use asdf_value_copy if it must persist
  *   }
  *
  * :param iter: Pointer to the iterator handle; set to ``NULL`` on exhaustion

--- a/src/core/extension_metadata.c
+++ b/src/core/extension_metadata.c
@@ -67,7 +67,7 @@ static asdf_value_t *asdf_extension_metadata_serialize(
 
             // Make a deep copy of the metadata mapping's value since inserting
             // it into a new mapping steals ownership of the value
-            asdf_value_t *val = asdf_value_clone_deep(iter->value);
+            asdf_value_t *val = asdf_value_copy_deep(iter->value);
 
             if (iter->value && !val) {
                 err = ASDF_VALUE_ERR_OOM;
@@ -137,7 +137,7 @@ static asdf_value_err_t asdf_extension_metadata_deserialize(
     metadata->package = package;
     // Clone the mapping value into the metadata so that additional properties can be looked up on
     // it
-    metadata->metadata = (asdf_mapping_t *)asdf_value_clone(value);
+    metadata->metadata = (asdf_mapping_t *)asdf_value_copy(value);
     *out = metadata;
     return ASDF_VALUE_OK;
 failure:
@@ -178,7 +178,7 @@ static bool asdf_extension_metadata_copy_impl(asdf_file_t *file, const void *src
     }
 
     if (metadata->metadata) {
-        copy->metadata = asdf_mapping_clone(metadata->metadata);
+        copy->metadata = asdf_mapping_copy(metadata->metadata);
 
         if (!copy->metadata)
             return false;

--- a/src/core/ndarray.c
+++ b/src/core/ndarray.c
@@ -578,7 +578,7 @@ static asdf_value_err_t asdf_ndarray_parse_inline_data(asdf_ndarray_t *ndarray, 
  * Helper routine for handling deserialization of ndarrays with inline data
  *
  * The inline data is not fully parsed at this stage--that occurs lazily when
- * the data is first accessed.  At this stage we store a clone of the inline
+ * the data is first accessed.  At this stage we store a copy of the inline
  * data sequence and perform basic validations (shape, datatype).
  *
  * ``ndarray_map`` may be NULL in case of a plain inline array, or it
@@ -693,7 +693,7 @@ static asdf_value_err_t asdf_ndarray_deserialize_inline(
     ndarray->byteorder = asdf_host_byteorder();
 
     /* Clone and stash the YAML sequence for lazy conversion in data_raw */
-    internal->inline_data = (asdf_sequence_t *)asdf_value_clone(&ndarray_seq->value);
+    internal->inline_data = (asdf_sequence_t *)asdf_value_copy(&ndarray_seq->value);
 
     if (UNLIKELY(!internal->inline_data)) {
         err = ASDF_VALUE_ERR_OOM;

--- a/src/value.c
+++ b/src/value.c
@@ -154,7 +154,7 @@ void asdf_value_destroy(asdf_value_t *value) {
 }
 
 
-static asdf_value_t *asdf_value_clone_impl(asdf_value_t *value, bool raw_shallow) {
+static asdf_value_t *asdf_value_copy_impl(asdf_value_t *value, bool raw_shallow) {
 
     if (!value)
         return NULL;
@@ -181,7 +181,7 @@ static asdf_value_t *asdf_value_clone_impl(asdf_value_t *value, bool raw_shallow
     if (value->path)
         new_value->path = strdup(value->path);
     else
-        // We must look up the full path of the node to store on the clone or
+        // We must look up the full path of the node to store on the copy or
         // else it will be lost; see issue #69
         new_value->path = fy_node_get_path(value->node);
 
@@ -215,14 +215,14 @@ static asdf_value_t *asdf_value_clone_impl(asdf_value_t *value, bool raw_shallow
 }
 
 
-/* Shallow clone that preserves all type information from the source value
+/* Shallow copy that preserves all type information from the source value
  *
  * Only valid for nodes that are attached to a document (where the document owns
  * the fy_node); fy_node_free() is a no-op on attached nodes so the shallow
  * reference is always safe.
  *
- * Unlike asdf_value_clone_impl(value, true) ("raw shallow"), this preserves the
- * computed type, extension type information, and scalar cache so the clone is
+ * Unlike asdf_value_copy_impl(value, true) ("raw shallow"), this preserves the
+ * computed type, extension type information, and scalar cache so the copy is
  * immediately usable without re-inferring anything.  Extension values get a new
  * ext wrapper struct that shares the already-deserialized object pointer; only
  * the wrapper is freed on destroy, not the object itself (consistent with the
@@ -230,9 +230,9 @@ static asdf_value_t *asdf_value_clone_impl(asdf_value_t *value, bool raw_shallow
  *
  * .. todo::
  *
- *   Merge this into asdf_value_clone_impl
+ *   Merge this into asdf_value_copy_impl
  */
-static asdf_value_t *asdf_value_clone_shallow(asdf_value_t *value) {
+static asdf_value_t *asdf_value_copy_shallow(asdf_value_t *value) {
     if (!value)
         return NULL;
 
@@ -272,25 +272,25 @@ static asdf_value_t *asdf_value_clone_shallow(asdf_value_t *value) {
 }
 
 
-asdf_value_t *asdf_value_clone(asdf_value_t *value) {
+asdf_value_t *asdf_value_copy(asdf_value_t *value) {
     if (!value)
         return NULL;
 
     // For nodes owned by a document (attached or document root), use a shallow
-    // clone: the document manages the fy_node lifetime, fy_node_free() is a
+    // copy: the document manages the fy_node lifetime, fy_node_free() is a
     // no-op, and avoiding a full deep copy prevents failures on deeply nested
     // structures (libfyaml has a hard limit on recursive copy depth).
     if (value->node && (fy_node_is_attached(value->node) || is_root_node(value->node)))
-        return asdf_value_clone_shallow(value);
+        return asdf_value_copy_shallow(value);
 
-    return asdf_value_clone_impl(value, false);
+    return asdf_value_copy_impl(value, false);
 }
 
 
-// Deep-clone variant for when an independent (detached) copy is truly needed,
+// Deep-copy variant for when an independent (detached) copy is truly needed,
 // e.g. when moving a value from one document/container into another.
-asdf_value_t *asdf_value_clone_deep(asdf_value_t *value) {
-    return asdf_value_clone_impl(value, false);
+asdf_value_t *asdf_value_copy_deep(asdf_value_t *value) {
+    return asdf_value_copy_impl(value, false);
 }
 
 
@@ -483,9 +483,9 @@ void asdf_mapping_set_style(asdf_mapping_t *mapping, asdf_yaml_node_style_t styl
 }
 
 
-asdf_mapping_t *asdf_mapping_clone(asdf_mapping_t *mapping) {
-    asdf_value_t *clone = asdf_value_clone_deep(&mapping->value);
-    return (asdf_mapping_t *)clone;
+asdf_mapping_t *asdf_mapping_copy(asdf_mapping_t *mapping) {
+    asdf_value_t *copy = asdf_value_copy_deep(&mapping->value);
+    return (asdf_mapping_t *)copy;
 }
 
 
@@ -759,12 +759,12 @@ asdf_value_err_t asdf_mapping_update_ex(
     asdf_value_err_t err = ASDF_VALUE_OK;
 
     while (asdf_mapping_iter_next(&iter)) {
-        asdf_value_t *clone = asdf_value_clone_deep(iter->value);
-        if (!clone) {
+        asdf_value_t *copy = asdf_value_copy_deep(iter->value);
+        if (!copy) {
             asdf_mapping_iter_destroy(iter);
             return ASDF_VALUE_ERR_OOM;
         }
-        err = asdf_mapping_set_ex(mapping, iter->key, clone, prepend);
+        err = asdf_mapping_set_ex(mapping, iter->key, copy, prepend);
         if (err) {
             asdf_mapping_iter_destroy(iter);
             break;
@@ -1494,9 +1494,9 @@ asdf_value_err_t asdf_value_as_extension_type(
     }
 
     assert(ext->vtab && ext->vtab->deserialize);
-    // Clone the raw value without existing extension inference to pass to the the extension's
+    // copy the raw value without existing extension inference to pass to the the extension's
     // deserialize method.
-    asdf_value_t *raw_value = asdf_value_clone_impl(value, true);
+    asdf_value_t *raw_value = asdf_value_copy_impl(value, true);
 
     if (!raw_value) {
         ASDF_ERROR_OOM(value->file);
@@ -2764,7 +2764,7 @@ asdf_value_err_t asdf_value_as_type(asdf_value_t *value, asdf_value_type_t type,
     switch (type) {
     case ASDF_VALUE_UNKNOWN:
         if (LIKELY(out))
-            (*(asdf_value_t **)out) = asdf_value_clone(value);
+            (*(asdf_value_t **)out) = asdf_value_copy(value);
 
         return ASDF_VALUE_OK;
     case ASDF_VALUE_SEQUENCE:
@@ -2772,7 +2772,7 @@ asdf_value_err_t asdf_value_as_type(asdf_value_t *value, asdf_value_type_t type,
             return ASDF_VALUE_ERR_TYPE_MISMATCH;
 
         if (LIKELY(out))
-            (*(asdf_value_t **)out) = asdf_value_clone(value);
+            (*(asdf_value_t **)out) = asdf_value_copy(value);
 
         return ASDF_VALUE_OK;
     case ASDF_VALUE_MAPPING:
@@ -2780,7 +2780,7 @@ asdf_value_err_t asdf_value_as_type(asdf_value_t *value, asdf_value_type_t type,
             return ASDF_VALUE_ERR_TYPE_MISMATCH;
 
         if (LIKELY(out))
-            (*(asdf_value_t **)out) = asdf_value_clone(value);
+            (*(asdf_value_t **)out) = asdf_value_copy(value);
 
         return ASDF_VALUE_OK;
     case ASDF_VALUE_SCALAR:
@@ -3056,10 +3056,10 @@ static asdf_value_t *asdf_find_iter_next_bfs(asdf_find_iter_impl_t *iter) {
     while (asdf_container_iter_next(&frame->iter)) {
         asdf_value_t *child = frame->iter->value;
         if (asdf_value_is_container(child)) {
-            // In BFS, clone the child before pushing: the next container_iter_next
+            // In BFS, copy the child before pushing: the next container_iter_next
             // call will destroy the original value wrapper.
             asdf_find_frame_t *new_frame = asdf_find_iter_push_frame(
-                iter, asdf_value_clone(child), frame->depth + 1);
+                iter, asdf_value_copy(child), frame->depth + 1);
 
             if (!new_frame)
                 return NULL;
@@ -3160,7 +3160,7 @@ asdf_value_t *asdf_value_find_ex(
     ssize_t max_depth) {
     if (!asdf_value_is_container(root)) {
         if (!pred || pred(root))
-            return asdf_value_clone(root);
+            return asdf_value_copy(root);
         return NULL;
     }
 
@@ -3172,7 +3172,7 @@ asdf_value_t *asdf_value_find_ex(
     if (!asdf_value_find_iter_next(&iter))
         return NULL;
 
-    asdf_value_t *result = asdf_value_clone(iter->value);
+    asdf_value_t *result = asdf_value_copy(iter->value);
     asdf_find_iter_destroy(iter);
     return result;
 }

--- a/src/value.h
+++ b/src/value.h
@@ -185,6 +185,6 @@ ASDF_LOCAL struct fy_node *asdf_value_normalize_node(asdf_value_t *value);
  * but I'm thinking it might want to take a more extended flag set for other options */
 ASDF_LOCAL asdf_value_err_t
 asdf_mapping_update_ex(asdf_mapping_t *mapping, asdf_mapping_t *update, bool prepend);
-ASDF_LOCAL asdf_value_t *asdf_value_clone_deep(asdf_value_t *value);
+ASDF_LOCAL asdf_value_t *asdf_value_copy_deep(asdf_value_t *value);
 ASDF_LOCAL asdf_value_err_t asdf_node_insert_at(
     struct fy_document *doc, const char *path, struct fy_node *node, bool materialize);

--- a/tests/test-value.c
+++ b/tests/test-value.c
@@ -1582,19 +1582,19 @@ MU_TEST(test_value_copy_with_parent_path) {
 
     // The test: Cloned values should still retain their original path, as should any
     // child values retrieved from them.
-    asdf_value_t *value_clone = asdf_value_clone(value);
-    assert_string_equal(asdf_value_path(value_clone), "/history/extensions/0");
-    asdf_mapping_t *value_clone_map = NULL;
-    asdf_value_as_mapping(value_clone, &value_clone_map);
-    assert_not_null(value_clone_map);
-    asdf_value_t *ext_uri_clone = asdf_mapping_get(value_clone_map, "extension_uri");
-    assert_string_equal(asdf_value_path(ext_uri_clone), "/history/extensions/0/extension_uri");
+    asdf_value_t *value_copy = asdf_value_copy(value);
+    assert_string_equal(asdf_value_path(value_copy), "/history/extensions/0");
+    asdf_mapping_t *value_copy_map = NULL;
+    asdf_value_as_mapping(value_copy, &value_copy_map);
+    assert_not_null(value_copy_map);
+    asdf_value_t *ext_uri_copy = asdf_mapping_get(value_copy_map, "extension_uri");
+    assert_string_equal(asdf_value_path(ext_uri_copy), "/history/extensions/0/extension_uri");
 
     // Crucially, it has the full path; this is just the control case
     assert_string_equal(asdf_value_path(ext_uri), "/history/extensions/0/extension_uri");
 
-    asdf_value_destroy(ext_uri_clone);
-    asdf_value_destroy(value_clone);
+    asdf_value_destroy(ext_uri_copy);
+    asdf_value_destroy(value_copy);
     asdf_value_destroy(ext_uri);
     asdf_value_destroy(value);
     asdf_close(file);
@@ -1878,7 +1878,7 @@ MU_TEST(test_asdf_value_path) {
     asdf_value_t *value = asdf_get_value(file, "/d/0");
     assert_not_null(value);
     assert_string_equal(asdf_value_path(value), "/d/0");
-    asdf_value_t *clone = asdf_value_clone(value);
+    asdf_value_t *clone = asdf_value_copy(value);
     assert_string_equal(asdf_value_path(clone), "/d/0");
     asdf_value_destroy(value);
     asdf_value_destroy(clone);
@@ -1996,14 +1996,14 @@ MU_TEST(anchors) {
 
 
 /** Regression test for double-free bug on cloned extension values */
-MU_TEST(regression_clone_extension_value) {
+MU_TEST(regression_copy_extension_value) {
     const char *path = get_reference_file_path("1.6.0/basic.asdf");
     asdf_file_t *file = asdf_open(path, "r");
     assert_not_null(file);
     asdf_value_t *value = asdf_get_value(file, "data");
     assert_not_null(value);
     assert_true(asdf_value_is_ndarray(value));
-    asdf_value_t *cloned = asdf_value_clone(value);
+    asdf_value_t *cloned = asdf_value_copy(value);
     assert_true(asdf_value_is_ndarray(cloned));
     assert_string_equal(asdf_value_path(value), asdf_value_path(cloned));
     asdf_value_destroy(value);
@@ -2038,11 +2038,11 @@ MU_TEST(regression_read_flt_max) {
 }
 
 
-// asdf_value_clone on an attached node should use a shallow reference rather
+// asdf_value_copy on an attached node should use a shallow reference rather
 // than a full deep copy.  This is important for deeply nested structures (e.g.
 // GWCS pipeline transform trees) which would otherwise exceed libfyaml's
 // hard-coded recursive copy depth limit.
-MU_TEST(test_asdf_value_clone_attached_shallow) {
+MU_TEST(test_asdf_value_copy_attached_shallow) {
     asdf_file_t *file = asdf_open(NULL);
     assert_not_null(file);
 
@@ -2061,7 +2061,7 @@ MU_TEST(test_asdf_value_clone_attached_shallow) {
 
     // Clone should succeed even though the subtree exceeds the libfyaml deep-copy
     // depth limit; for attached nodes we take a shallow reference instead.
-    asdf_value_t *clone = asdf_value_clone(root);
+    asdf_value_t *clone = asdf_value_copy(root);
     assert_not_null(clone);
     assert_true(asdf_value_is_mapping(clone));
 
@@ -2139,10 +2139,10 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_raw_value_type_preserved_after_type_resolution),
     MU_RUN_TEST(anchors),
     // TODO: Maybe set up a separate test suite for regression tests
-    MU_RUN_TEST(regression_clone_extension_value),
+    MU_RUN_TEST(regression_copy_extension_value),
     MU_RUN_TEST(regression_read_min_int),
     MU_RUN_TEST(regression_read_flt_max),
-    MU_RUN_TEST(test_asdf_value_clone_attached_shallow)
+    MU_RUN_TEST(test_asdf_value_copy_attached_shallow)
 );
 
 


### PR DESCRIPTION
Just for consistency with #231 instead of having some routines that copy something end with _clone and some that end with _copy, just use the "copy" nomenclature throughout.  It doesn't really matter which is used as long as it's consistent.