### PR TITLE
Issue #233 -- time improvements

### DIFF
--- a/changes/91.feature
+++ b/changes/91.feature
@@ -1,0 +1,9 @@
+Support for the ``stsci.edu/asdf/time/time`` schema via a new
+``asdf/core/time.h`` API.  Time values can be read with ``asdf_get_time`` /
+``asdf_value_as_time`` and written with ``asdf_set_time``, exposing an
+``asdf_time_t`` with the original ``value`` string, the ``format`` and optional
+``base_format``, the ``scale`` and ``location``, and a computed timestamp
+(``struct timespec`` and ``struct tm``) for the supported formats.
+
+Files written with any of the ``time-1.0.0`` through ``time-1.4.0`` tags are
+read; newly written time values use ``time-1.4.0``.

--- a/docs/api/asdf/core/datatype.h.rst
+++ b/docs/api/asdf/core/datatype.h.rst
@@ -1,7 +1,7 @@
 :tocdepth: 2
 
-asdf/core/datatype.h
-====================
+asdf/core/datatype.h - ndarray datatypes
+========================================
 
 .. autodoc:: include/asdf/core/datatype.h
 

--- a/docs/api/asdf/core/ndarray.h.rst
+++ b/docs/api/asdf/core/ndarray.h.rst
@@ -1,7 +1,7 @@
 :tocdepth: 2
 
-asdf/core/ndarray.h
-===================
+asdf/core/ndarray.h - ndarray operations
+========================================
 
 .. autodoc:: include/asdf/core/ndarray.h
 

--- a/docs/api/asdf/core/time.h.rst
+++ b/docs/api/asdf/core/time.h.rst
@@ -1,0 +1,6 @@
+:tocdepth: 2
+
+asdf/core/time.h - Time tag operations
+======================================
+
+.. autodoc:: include/asdf/core/time.h

--- a/docs/api/asdf/error.h.rst
+++ b/docs/api/asdf/error.h.rst
@@ -1,7 +1,7 @@
 :tocdepth: 2
 
-asdf/error.h
-============
+asdf/error.h - Error handling
+=============================
 
 Here you can find the error codes returned by `asdf_error_code` (which itself is declared in :ref:`file.h`).
 

--- a/docs/api/asdf/file.h.rst
+++ b/docs/api/asdf/file.h.rst
@@ -2,7 +2,7 @@
 
 .. _file.h:
 
-asdf/file.h
-===========
+asdf/file.h - File-level and tree operations
+============================================
 
 .. autodoc:: include/asdf/file.h

--- a/docs/api/asdf/value.h.rst
+++ b/docs/api/asdf/value.h.rst
@@ -1,7 +1,7 @@
 :tocdepth: 2
 
-asdf/value.h
-============
+asdf/value.h - Generic value operations
+=======================================
 
 .. autodoc:: include/asdf/value.h
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ nitpick_ignore = [
     ('c:identifier', 'size_t'),
     ('c:identifier', 'ssize_t'),
     ('c:identifier', 'strtod'),
+    ('c:identifier', 'timespec'),
     ('c:identifier', 'uint16_t'),
     ('c:identifier', 'uint32_t'),
     ('c:identifier', 'uint64_t'),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,7 @@ including ``asdf.h``.  This in turn includes the following headers:
   api/asdf/error.h
   api/asdf/core/ndarray.h
   api/asdf/core/datatype.h
+  api/asdf/core/time.h
 
 Additional less commonly used APIs can be used by including the relevant
 headers.

--- a/include/asdf/core/time.h
+++ b/include/asdf/core/time.h
@@ -18,9 +18,8 @@ ASDF_BEGIN_DECLS
 #define ASDF_TIME_TIMESTR_MAXLEN 255
 
 typedef enum {
-    /** Unset/unspecified format; and the zero value */
-    ASDF_TIME_FORMAT_NONE = 0,
-    ASDF_TIME_FORMAT_ISO,
+    /** The default format is ISO */
+    ASDF_TIME_FORMAT_ISO = 0,
     ASDF_TIME_FORMAT_YDAY,
     ASDF_TIME_FORMAT_BYEAR,
     ASDF_TIME_FORMAT_JYEAR,
@@ -71,16 +70,18 @@ typedef struct {
 typedef struct {
     char *value;
     asdf_time_info_t info;
-    asdf_time_format_t format;
     /**
-     * The original format of the time object (the optional ``base_format``
-     * field, added in time-1.2.0)
+     * The effective (real) format of the time.
      *
-     * Left as ASDF_TIME_FORMAT_NONE (the zero value) when unset, in which case
-     * it is omitted on serialization; deserialization sets it only when the
-     * ``base_format`` key is present.
+     * This may be any format, including one of the schema's ``other_format``
+     * values (e.g. ``fits``, ``isot``, ``plot_date``) which the schema only
+     * permits in the ``base_format`` field on the wire.  On deserialization the
+     * ``format`` and ``base_format`` keys are collapsed into this single
+     * effective format (``base_format`` overrides ``format`` when present); on
+     * serialization the wire ``format`` / ``base_format`` split is derived back
+     * from it.
      */
-    asdf_time_format_t base_format;
+    asdf_time_format_t format;
     asdf_time_scale_t scale;
     asdf_time_location_t location;
 } asdf_time_t;

--- a/include/asdf/core/time.h
+++ b/include/asdf/core/time.h
@@ -10,11 +10,17 @@
 
 ASDF_BEGIN_DECLS
 
-#define ASDF_CORE_TIME_TAG "tag:stsci.edu:asdf/time/time-1.4.0"
+/* The default tag written for a time object; also the newest version read.
+ * Older versions (ASDF_CORE_TIME_TAG_BASE "1.x.0") are recognized when reading;
+ * see the ASDF_REGISTER_EXTENSION call in time.c. */
+#define ASDF_CORE_TIME_TAG_BASE "tag:stsci.edu:asdf/time/time-"
+#define ASDF_CORE_TIME_TAG ASDF_CORE_TIME_TAG_BASE "1.4.0"
 #define ASDF_TIME_TIMESTR_MAXLEN 255
 
 typedef enum {
-    ASDF_TIME_FORMAT_ISO_TIME = 0,
+    /** Unset/unspecified format; and the zero value */
+    ASDF_TIME_FORMAT_NONE = 0,
+    ASDF_TIME_FORMAT_ISO,
     ASDF_TIME_FORMAT_YDAY,
     ASDF_TIME_FORMAT_BYEAR,
     ASDF_TIME_FORMAT_JYEAR,
@@ -66,6 +72,15 @@ typedef struct {
     char *value;
     asdf_time_info_t info;
     asdf_time_format_t format;
+    /**
+     * The original format of the time object (the optional ``base_format``
+     * field, added in time-1.2.0)
+     *
+     * Left as ASDF_TIME_FORMAT_NONE (the zero value) when unset, in which case
+     * it is omitted on serialization; deserialization sets it only when the
+     * ``base_format`` key is present.
+     */
+    asdf_time_format_t base_format;
     asdf_time_scale_t scale;
     asdf_time_location_t location;
 } asdf_time_t;

--- a/include/asdf/core/time.h
+++ b/include/asdf/core/time.h
@@ -1,4 +1,9 @@
-/** Data type and extension for the stsci.edu/schemas/asdf/time/time schema */
+/**
+ * Data type and extension for the ``stsci.edu/schemas/asdf/time/time`` schema
+ */
+
+//
+
 #ifndef ASDF_CORE_TIME_H
 #define ASDF_CORE_TIME_H
 
@@ -10,52 +15,91 @@
 
 ASDF_BEGIN_DECLS
 
-/* The default tag written for a time object; also the newest version read.
- * Older versions (ASDF_CORE_TIME_TAG_BASE "1.x.0") are recognized when reading;
- * see the ASDF_REGISTER_EXTENSION call in time.c. */
-#define ASDF_CORE_TIME_TAG_BASE "tag:stsci.edu:asdf/time/time-"
-#define ASDF_CORE_TIME_TAG ASDF_CORE_TIME_TAG_BASE "1.4.0"
-#define ASDF_TIME_TIMESTR_MAXLEN 255
+/** .. _time-types:
+ *
+ * Types
+ * -----
+ */
 
+/**
+ * The representation format of a time.
+ *
+ * These correspond to the astropy time formats and the schema's ``format`` /
+ * ``base_format`` enums.  The values from ``ASDF_TIME_FORMAT_BYEAR_STR`` onward
+ * are the schema's ``other_format`` values, which are valid only in
+ * ``base_format`` on the wire; see `asdf_time_t` ``format`` for how the two
+ * collapse into a single effective format.
+ */
 typedef enum {
-    /** The default format is ISO */
+    /** ISO 8601 date-time, ``YYYY-MM-DDTHH:MM:SS.sss...`` (the default) */
     ASDF_TIME_FORMAT_ISO = 0,
+    /** Year, day-of-year and time, ``YYYY:DOY:HH:MM:SS.sss...`` */
     ASDF_TIME_FORMAT_YDAY,
+    /** Besselian epoch year, e.g. ``B1950.0`` */
     ASDF_TIME_FORMAT_BYEAR,
+    /** Julian epoch year, e.g. ``J2000.0`` */
     ASDF_TIME_FORMAT_JYEAR,
+    /** Decimal year, integer values being the start of the year */
     ASDF_TIME_FORMAT_DECIMALYEAR,
+    /** Julian Date: days since the start of the Julian period */
     ASDF_TIME_FORMAT_JD,
+    /** Modified Julian Date: days since 1858-11-17 00:00 */
     ASDF_TIME_FORMAT_MJD,
+    /** GPS time: seconds from 1980-01-06 00:00:00 UTC */
     ASDF_TIME_FORMAT_GPS,
+    /** Unix time: seconds from 1970-01-01 00:00:00 UTC, ignoring leap seconds */
     ASDF_TIME_FORMAT_UNIX,
+    /** UT seconds from 1979-01-01 00:00:00 UTC, ignoring leap seconds */
     ASDF_TIME_FORMAT_UTIME,
+    /** SI seconds from 1958-01-01 00:00:00, including leap seconds (TAI) */
     ASDF_TIME_FORMAT_TAI_SECONDS,
+    /** Chandra X-ray Center seconds from 1998-01-01 00:00:00 TT */
     ASDF_TIME_FORMAT_CXCSEC,
+    /** GALEX time: seconds from 1980-01-06 00:00:00 UTC */
     ASDF_TIME_FORMAT_GALEXSEC,
+    /** SI seconds from 1970-01-01 00:00:00 TAI */
     ASDF_TIME_FORMAT_UNIX_TAI,
+    /** Reserved; not a usable format */
     ASDF_TIME_FORMAT_RESERVED1,
-    /* "other" format(s) below */
+    /* The schema's ``other_format`` values follow (see the note above). */
+    /** Besselian epoch string form, e.g. ``B1950.0`` */
     ASDF_TIME_FORMAT_BYEAR_STR,
+    /** A Python ``datetime.datetime`` (naive or timezone-aware) */
     ASDF_TIME_FORMAT_DATETIME,
+    /** FITS date-time string; permits a signed five-digit "long" year */
     ASDF_TIME_FORMAT_FITS,
+    /** ISO 8601 with a literal ``T`` date/time separator */
     ASDF_TIME_FORMAT_ISOT,
+    /** Julian epoch string form, e.g. ``J2000.0`` */
     ASDF_TIME_FORMAT_JYEAR_STR,
+    /** matplotlib ordinal: days from 0001-01-01 00:00:00 UTC plus one */
     ASDF_TIME_FORMAT_PLOT_DATE,
+    /** Year/month/day/hour/minute/second fields */
     ASDF_TIME_FORMAT_YMDHMS,
+    /** NumPy ``datetime64`` */
     ASDF_TIME_FORMAT_DATETIME64,
 } asdf_time_format_t;
 
 
+/** The time scale (time standard), as in the schema's ``scale`` field. */
 typedef enum {
+    /** Coordinated Universal Time (the default scale) */
     ASDF_TIME_SCALE_UTC = 0,
+    /** International Atomic Time */
     ASDF_TIME_SCALE_TAI,
+    /** Barycentric Coordinate Time */
     ASDF_TIME_SCALE_TCB,
+    /** Geocentric Coordinate Time */
     ASDF_TIME_SCALE_TCG,
+    /** Barycentric Dynamical Time */
     ASDF_TIME_SCALE_TDB,
+    /** Terrestrial Time */
     ASDF_TIME_SCALE_TT,
+    /** Universal Time (UT1) */
     ASDF_TIME_SCALE_UT1,
 } asdf_time_scale_t;
 
+/** Observer location, used by location-sensitive scales such as ``tdb``. */
 typedef struct {
     double longitude;
     double latitude;
@@ -76,12 +120,11 @@ typedef struct {
  *   `ASDF_TIME_SCALE_UTC`, and the atomic-scale formats ``gps``, ``unix_tai``,
  *   ``cxcsec`` and ``tai_seconds``, these fields ignore leap seconds.
  *   libasdf has no leap-second table, so it does not apply the TAI/TT-to-UTC
- *   offsets
+ *   offsets.
  *
- *   The computed calendar reading is therefore the in the format's own
- *   timescale, off from UTC by the relevant offset.  The ``tdb``, ``ut1``,
- *   ``tcb`` and ``tcg`` scales need still more external data and are likewise
- *   approximate.
+ *   The computed calendar reading is therefore in the format's own timescale,
+ *   off from UTC by the relevant offset.  The ``tdb``, ``ut1``, ``tcb`` and
+ *   ``tcg`` scales need still more external data and are likewise approximate.
  *
  * Consumers needing an exact UTC instant for a non-UTC-scale time should
  * convert the raw ``value`` / ``format`` / ``scale`` themselves (e.g. via ERFA
@@ -94,11 +137,18 @@ typedef struct {
     struct tm tm;
 } asdf_time_info_t;
 
+/**
+ * A single instant in time, as read from or written to a ``time/time`` tag.
+ *
+ * The instant is defined by `value` together with `format` and `scale`; `info`
+ * is a derived, best-effort calendar representation for convenience.
+ */
 typedef struct {
+    /** The time value, exactly as it appears (or will appear) in the file. */
     char *value;
     /**
      * Derived calendar representation; best-effort and, for non-UTC scales,
-     * approximate.  See asdf_time_info_t for the leap-second caveat.
+     * approximate.  See `asdf_time_info_t` for the leap-second caveat.
      */
     asdf_time_info_t info;
     /**
@@ -118,13 +168,151 @@ typedef struct {
      * approximate (leap seconds are not applied); see asdf_time_info_t.
      */
     asdf_time_scale_t scale;
+    /** Observer location; used only by location-sensitive scales (e.g. ``tdb``). */
     asdf_time_location_t location;
 } asdf_time_t;
 
 ASDF_DECLARE_EXTENSION(time, asdf_time_t);
 
+
+/** .. _time-accessors:
+ *
+ * Accessors
+ * ---------
+ */
+
+
+// clang-format off
+
+/**
+ * .. c:function:: bool asdf_is_time(asdf_file_t *file, const char *path)
+ *
+ *   Test whether the value at ``path`` in the tree is a ``time/time`` object
+ *
+ *   :param file: The `asdf_file_t *` for the file
+ *   :param path: The :ref:`yaml-pointer` to the value
+ *   :return: ``true`` if the value exists and is a time, otherwise ``false``
+ */
+
+
+/**
+ * .. c:function:: asdf_value_err_t asdf_get_time(asdf_file_t *file, const char *path, asdf_time_t **out)
+ *
+ *   Get an `asdf_time_t *` out of the ASDF tree
+ *
+ *   The returned object is owned by the caller and must be freed with
+ *   `asdf_time_destroy`.
+ *
+ *   :param file: The `asdf_file_t *` for the file
+ *   :param path: The :ref:`yaml-pointer` to the time
+ *   :param out: An `asdf_time_t **` into which the `asdf_time_t *` is returned
+ *   :return: `ASDF_VALUE_OK` if the value exists and is a time, otherwise
+ *     `ASDF_VALUE_ERR_NOT_FOUND` or `ASDF_VALUE_ERR_TYPE_MISMATCH`.
+ */
+
+
+/**
+ * .. c:function:: asdf_value_err_t asdf_set_time(asdf_file_t *file, const char *path, const asdf_time_t *time)
+ *
+ *   Store an `asdf_time_t *` at a path in the ASDF tree
+ *
+ *   Only the ``value``, ``format``, ``scale`` and ``location`` fields need be
+ *   populated; the derived `asdf_time_info_t` ``info`` is not required for
+ *   writing.
+ *
+ *   :param file: The `asdf_file_t *` for the file
+ *   :param path: The :ref:`yaml-pointer` for the time
+ *   :param time: An `asdf_time_t *` to store
+ *   :return: `ASDF_VALUE_OK` on success, otherwise an error code
+ */
+
+
+/**
+ * .. c:function:: bool asdf_value_is_time(asdf_value_t *value)
+ *
+ *   Test whether a generic `asdf_value_t *` is a ``time/time`` object
+ *
+ *   :param value: The `asdf_value_t *` handle
+ *   :return: ``true`` if ``value`` is a time, otherwise ``false``
+ */
+
+
+/**
+ * .. c:function:: asdf_value_err_t asdf_value_as_time(asdf_value_t *value, asdf_time_t **out)
+ *
+ *   Interpret a generic `asdf_value_t *` as a time value, if possible
+ *
+ *   The returned object is owned by the caller and must be freed with
+ *   `asdf_time_destroy`.
+ *
+ *   :param value: The `asdf_value_t *` handle
+ *   :param out: An `asdf_time_t **` into which the `asdf_time_t *` is returned
+ *   :return: `ASDF_VALUE_OK` if ``value`` is a time, otherwise
+ *     `ASDF_VALUE_ERR_TYPE_MISMATCH`.
+ */
+
+
+/**
+ * .. c:function:: void asdf_time_destroy(asdf_time_t *time)
+ *
+ *   Free an `asdf_time_t *` returned by `asdf_get_time` or `asdf_value_as_time`
+ *
+ *   :param time: The `asdf_time_t *` to free
+ */
+
+// clang-format on
+
+
+/** .. _time-parsing:
+ *
+ * Parsing and formatting
+ * ----------------------
+ */
+
+
+/**
+ * Parse `time`'s ``value`` (according to its ``format``) into the derived
+ * `asdf_time_info_t` ``info`` fields.
+ *
+ * This is called automatically during deserialization; it may be called again
+ * after changing ``value`` or ``format``.  See `asdf_time_info_t` for the
+ * accuracy caveat on non-UTC scales.
+ *
+ * :param time: The time to parse; its ``info`` is filled in on success.
+ * :return: ``0`` on success, or ``-1`` on failure (e.g. an unsupported or
+ *     unparseable ``value``).
+ */
 ASDF_EXPORT int asdf_time_parse(asdf_time_t *time);
+
+/**
+ * Return the schema string name of a time format (e.g. ``"iso"``, ``"jd"``).
+ *
+ * :param format: A time format.
+ * :return: The format's name, or ``NULL`` if `format` is out of range or has no
+ *     string representation.
+ */
 ASDF_EXPORT const char *asdf_time_format_string(asdf_time_format_t format);
+
+
+/** .. _time-defines:
+ *
+ * Defines
+ * -------
+ */
+
+/** Tag URI prefix for time objects; a version is appended (e.g. ``"1.4.0"``). */
+#define ASDF_CORE_TIME_TAG_BASE "tag:stsci.edu:asdf/time/time-"
+
+/**
+ * The time tag written by libasdf, and the newest version it reads.
+ *
+ * Older versions (``ASDF_CORE_TIME_TAG_BASE`` ``"1.x.0"``) are also recognized
+ * when reading; see the ``ASDF_REGISTER_EXTENSION`` call in ``time.c``.
+ */
+#define ASDF_CORE_TIME_TAG ASDF_CORE_TIME_TAG_BASE "1.4.0"
+
+/** Maximum length in bytes of a time `asdf_time_t` ``value`` string. */
+#define ASDF_TIME_TIMESTR_MAXLEN 255
 
 ASDF_END_DECLS
 

--- a/include/asdf/core/time.h
+++ b/include/asdf/core/time.h
@@ -62,13 +62,44 @@ typedef struct {
     double height;
 } asdf_time_location_t;
 
+/**
+ * Best-effort calendar representation of a parsed time
+ *
+ * These fields are *computed* from ``value`` / ``format`` / ``scale`` purely
+ * for convenience.  The authoritative instant is always the ``value``,
+ * ``format`` and ``scale``, which libasdf preserves verbatim and round-trips
+ * losslessly; only this derived representation is approximate.
+ *
+ * .. warning::
+ *
+ *   For any time not on the UTC scale, i.e. ``scale`` other than
+ *   `ASDF_TIME_SCALE_UTC`, and the atomic-scale formats ``gps``, ``unix_tai``,
+ *   ``cxcsec`` and ``tai_seconds``, these fields ignore leap seconds.
+ *   libasdf has no leap-second table, so it does not apply the TAI/TT-to-UTC
+ *   offsets
+ *
+ *   The computed calendar reading is therefore the in the format's own
+ *   timescale, off from UTC by the relevant offset.  The ``tdb``, ``ut1``,
+ *   ``tcb`` and ``tcg`` scales need still more external data and are likewise
+ *   approximate.
+ *
+ * Consumers needing an exact UTC instant for a non-UTC-scale time should
+ * convert the raw ``value`` / ``format`` / ``scale`` themselves (e.g. via ERFA
+ * or astropy).
+ */
 typedef struct {
+    /** Seconds + nanoseconds from the Unix epoch (approximate; see above) */
     struct timespec ts;
+    /** Derived calendar fields (approximate; see above) */
     struct tm tm;
 } asdf_time_info_t;
 
 typedef struct {
     char *value;
+    /**
+     * Derived calendar representation; best-effort and, for non-UTC scales,
+     * approximate.  See asdf_time_info_t for the leap-second caveat.
+     */
     asdf_time_info_t info;
     /**
      * The effective (real) format of the time.
@@ -82,6 +113,10 @@ typedef struct {
      * from it.
      */
     asdf_time_format_t format;
+    /**
+     * The time scale.  A non-UTC scale means the derived ``info`` fields are
+     * approximate (leap seconds are not applied); see asdf_time_info_t.
+     */
     asdf_time_scale_t scale;
     asdf_time_location_t location;
 } asdf_time_t;

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -137,6 +137,28 @@ static const char *ASDF_TIME_SFMT_UNIX[] = {"%s"};
  * i.e. a plot_date value is the number of days from 0001-01-01 UTC plus one. */
 #define JD_PLOT_DATE_EPOCH 1721424.5
 
+/*
+ * Epochs (as Julian Dates) for the "seconds from epoch" formats.  Each JD below
+ * is the Julian Date of the epoch's calendar instant, anchored on
+ * JD_UNIX_EPOCH (JD of 1970-01-01 00:00:00).  unix_tai reuses JD_UNIX_EPOCH
+ * (same 1970-01-01 epoch, but the TAI scale).
+ *
+ * Epoch dates/scales are from astropy's TimeFromEpoch subclasses in
+ * ``astropy/time/formats.py``
+ *
+ * astropy runs gps/unix_tai/cxcsec/tai_seconds on the TAI or TT scale; libasdf
+ * has no leap-second table, so the computed calendar instant is really the
+ * reading in the format's own timescale (offset from UTC by the
+ * leap-second/scale difference), matching the best-effort treatment already
+ * applied to `unix`.  galexsec and utime are UTC (leap seconds ignored, like
+ * unix).
+ */
+#define JD_GPS_EPOCH (2444244.5 + 19.0 / 86400.0) /* 1980-01-06 00:00:19 TAI */
+#define JD_GALEXSEC_EPOCH 2444244.5               /* 1980-01-06 00:00:00 UTC */
+#define JD_CXCSEC_EPOCH 2450814.5                 /* 1998-01-01 00:00:00 TT */
+#define JD_TAI_SECONDS_EPOCH 2436204.5            /* 1958-01-01 00:00:00 TAI */
+#define JD_UTIME_EPOCH 2443874.5                  /* 1979-01-01 00:00:00 UTC */
+
 /* Calendar constants */
 static const double JD_GREGORIAN_START = 2299161.0;
 static const double JD_CORRECTION_REF = 1867216.25;
@@ -398,6 +420,27 @@ static int asdf_time_parse_plot_date(asdf_time_t *time) {
 }
 
 
+/* Seconds-from-epoch formats (gps, unix_tai, cxcsec, galexsec, tai_seconds,
+ * utime): the value is a count of SI seconds since a fixed epoch (given as a
+ * Julian Date).  See the epoch #defines for the leap-second/scale caveat. */
+static int asdf_time_parse_epoch_seconds(asdf_time_t *time, double epoch_jd) {
+    if (UNLIKELY(!time))
+        return -1;
+
+    const double jd = strtod(time->value, NULL) / SECONDS_PER_DAY + epoch_jd;
+    struct tm tm;
+    time_t t_nsec = 0;
+
+    julian_to_tm(jd, &tm, &t_nsec);
+    const time_t t_sec = timegm(&tm);
+
+    time->info.tm = tm;
+    time->info.ts.tv_sec = t_sec;
+    time->info.ts.tv_nsec = t_nsec;
+    return 0;
+}
+
+
 static int asdf_time_parse_mjd(asdf_time_t *time) {
     if (UNLIKELY(!time))
         return -1;
@@ -526,6 +569,24 @@ int asdf_time_parse(asdf_time_t *time) {
         break;
     case ASDF_TIME_FORMAT_PLOT_DATE:
         status = asdf_time_parse_plot_date(time);
+        break;
+    case ASDF_TIME_FORMAT_GPS:
+        status = asdf_time_parse_epoch_seconds(time, JD_GPS_EPOCH);
+        break;
+    case ASDF_TIME_FORMAT_UNIX_TAI:
+        status = asdf_time_parse_epoch_seconds(time, JD_UNIX_EPOCH);
+        break;
+    case ASDF_TIME_FORMAT_CXCSEC:
+        status = asdf_time_parse_epoch_seconds(time, JD_CXCSEC_EPOCH);
+        break;
+    case ASDF_TIME_FORMAT_GALEXSEC:
+        status = asdf_time_parse_epoch_seconds(time, JD_GALEXSEC_EPOCH);
+        break;
+    case ASDF_TIME_FORMAT_TAI_SECONDS:
+        status = asdf_time_parse_epoch_seconds(time, JD_TAI_SECONDS_EPOCH);
+        break;
+    case ASDF_TIME_FORMAT_UTIME:
+        status = asdf_time_parse_epoch_seconds(time, JD_UTIME_EPOCH);
         break;
     case ASDF_TIME_FORMAT_MJD:
         status = asdf_time_parse_mjd(time);

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -29,7 +29,7 @@
  * per compiled pattern.  Range validation is done manually after the match.
  *
  * Capture group layout per pattern index:
- *   TIME_AUTO_IDX_ISO_TIME:
+ *   TIME_AUTO_IDX_ISO:
  *     [1]=year [2]=month [3]=day
  *     [4]=optional "T/space + time" [5]=hour [6]=minute [7]=second [8]=frac
  *   TIME_AUTO_IDX_BYEAR:
@@ -40,7 +40,7 @@
  *     [1]=year [2]=day-of-year [3]=hour [4]=minute [5]=second [6]=optional frac
  */
 enum {
-    TIME_AUTO_IDX_ISO_TIME = 0,
+    TIME_AUTO_IDX_ISO = 0,
     TIME_AUTO_IDX_BYEAR,
     TIME_AUTO_IDX_JYEAR,
     TIME_AUTO_IDX_YDAY,
@@ -51,7 +51,7 @@ static const struct {
     asdf_time_format_t type;
     const char *pattern;
 } time_auto_patterns[TIME_AUTO_COUNT] = {
-    [TIME_AUTO_IDX_ISO_TIME] =
+    [TIME_AUTO_IDX_ISO] =
         {
             ASDF_TIME_FORMAT_ISO,
             "^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)([T ](\\d\\d):(\\d\\d):(\\d\\d)(.\\d+)?)?",
@@ -98,7 +98,7 @@ ASDF_DESTRUCTOR static void drop_time_auto_regexes(void) {
 }
 
 #ifdef HAVE_STRPTIME
-static const char *ASDF_TIME_SFMT_ISO_TIME[] = {"%Y-%m-%d %H:%M:%S", "%Y-%m-%d"};
+static const char *ASDF_TIME_SFMT_ISO[] = {"%Y-%m-%d %H:%M:%S", "%Y-%m-%d"};
 static const char *ASDF_TIME_SFMT_YDAY[] = {"%Y:%j:%H:%M:%S", "%Y:%j"};
 static const char *ASDF_TIME_SFMT_UNIX[] = {"%s"};
 
@@ -226,7 +226,8 @@ static int asdf_time_parse_std(asdf_time_t *time) {
     switch (time->format) {
     case ASDF_TIME_FORMAT_DATETIME:
     case ASDF_TIME_FORMAT_ISO:
-        check_format_strptime(ASDF_TIME_SFMT_ISO_TIME, buf, &tm, has_time, rest);
+    case ASDF_TIME_FORMAT_ISOT:
+        check_format_strptime(ASDF_TIME_SFMT_ISO, buf, &tm, has_time, rest);
         break;
     case ASDF_TIME_FORMAT_YDAY:
         check_format_strptime(ASDF_TIME_SFMT_YDAY, buf, &tm, has_time, rest);
@@ -420,9 +421,13 @@ int asdf_time_parse(asdf_time_t *time) {
     switch (time->format) {
     case ASDF_TIME_FORMAT_YDAY:
     case ASDF_TIME_FORMAT_ISO:
+    case ASDF_TIME_FORMAT_ISOT:
     case ASDF_TIME_FORMAT_DATETIME:
     case ASDF_TIME_FORMAT_UNIX:
         status = asdf_time_parse_std(time);
+        break;
+    case ASDF_TIME_FORMAT_FITS:
+        status = asdf_time_parse_fits(time);
         break;
     case ASDF_TIME_FORMAT_MJD:
         status = asdf_time_parse_mjd(time);
@@ -620,7 +625,7 @@ static void validate_yday_ranges(asdf_file_t *file, const char *cvs, csview *mat
 /* Run capture-group range checks for patterns that support them. */
 static void validate_datetime_ranges(asdf_file_t *file, int pat_idx, const char *vs, csview *m) {
     switch (pat_idx) {
-    case TIME_AUTO_IDX_ISO_TIME:
+    case TIME_AUTO_IDX_ISO:
         validate_iso_time_ranges(file, vs, m);
         break;
     case TIME_AUTO_IDX_YDAY:

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -431,9 +431,11 @@ int asdf_time_parse(asdf_time_t *time) {
         status = asdf_time_parse_jd(time);
         break;
     case ASDF_TIME_FORMAT_BYEAR:
+    case ASDF_TIME_FORMAT_BYEAR_STR:
         status = asdf_time_parse_byear(time);
         break;
     case ASDF_TIME_FORMAT_JYEAR:
+    case ASDF_TIME_FORMAT_JYEAR_STR:
         status = asdf_time_parse_jyear(time);
         break;
     case ASDF_TIME_FORMAT_DECIMALYEAR:
@@ -660,7 +662,30 @@ static asdf_value_t *asdf_time_serialize(
     if (err != ASDF_VALUE_OK)
         goto cleanup;
 
-    err = asdf_mapping_set_string0(map, "format", asdf_time_format_names[t->format]);
+    /* Astropy compatibility: a J-prefixed (Julian year) or B-prefixed
+     * (Besselian year) string value must currently be written with the
+     * jyear_str / byear_str format respectively, even if it was stored as
+     * plain jyear / byear.  Astropy only accepts the prefixed string forms
+     * under those *_str formats.
+     *
+     * I still hold that whatever happens with this in Astropy we should be more
+     * flexible in what asdf-astropy supports here; see
+     * https://github.com/astropy/asdf-astropy/pull/326
+     *
+     * But until that is changed we should try to remain compatible with what
+     * existing software is known to accept...
+     */
+    const char *format_name = asdf_time_format_names[t->format];
+    const char first = t->value[0];
+    if ((first == 'J' || first == 'j') &&
+        (t->format == ASDF_TIME_FORMAT_JYEAR || t->format == ASDF_TIME_FORMAT_JYEAR_STR))
+        format_name = asdf_time_format_names[ASDF_TIME_FORMAT_JYEAR_STR];
+    else if (
+        (first == 'B' || first == 'b') &&
+        (t->format == ASDF_TIME_FORMAT_BYEAR || t->format == ASDF_TIME_FORMAT_BYEAR_STR))
+        format_name = asdf_time_format_names[ASDF_TIME_FORMAT_BYEAR_STR];
+
+    err = asdf_mapping_set_string0(map, "format", format_name);
     if (err != ASDF_VALUE_OK)
         goto cleanup;
 
@@ -774,6 +799,24 @@ static int validate_or_guess_time_format(
     if (!asdf_time_format_parse(format_s, &format)) {
         ASDF_LOG(value->file, ASDF_LOG_WARN, "unrecognized time format '%s'", format_s);
         return -1;
+    }
+
+    /* jyear_str / byear_str are only accepted for a string value beginning with
+     * the corresponding 'J' / 'B' prefix, never a bare number.  (An unadorned
+     * jyear / byear may itself carry a J/B-prefixed string, which parses the
+     * same; these _str formats simply make that prefix mandatory.) */
+    if (format == ASDF_TIME_FORMAT_JYEAR_STR || format == ASDF_TIME_FORMAT_BYEAR_STR) {
+        const char prefix = (format == ASDF_TIME_FORMAT_JYEAR_STR) ? 'J' : 'B';
+        const char lower = (char)(prefix + ('a' - 'A'));
+        if (time_type != ASDF_VALUE_STRING || (time_s[0] != prefix && time_s[0] != lower)) {
+            ASDF_LOG(
+                value->file,
+                ASDF_LOG_WARN,
+                "time format '%s' requires a string value beginning with '%c'",
+                format_s,
+                prefix);
+            return -1;
+        }
     }
 
     /* Validate a string value against the format's auto-detect pattern, if one

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -267,6 +267,10 @@ static int asdf_time_parse_std(asdf_time_t *time) {
     case ASDF_TIME_FORMAT_DATETIME:
     case ASDF_TIME_FORMAT_ISO:
     case ASDF_TIME_FORMAT_ISOT:
+    case ASDF_TIME_FORMAT_YMDHMS:
+    case ASDF_TIME_FORMAT_DATETIME64:
+        /* ymdhms and datetime64 have no scalar ASDF representation of their own;
+         * astropy stores them (like isot) as an ISO-8601 string. */
         check_format_strptime(ASDF_TIME_SFMT_ISO, buf, &tm, has_time, rest);
         break;
     case ASDF_TIME_FORMAT_YDAY:
@@ -561,6 +565,8 @@ int asdf_time_parse(asdf_time_t *time) {
     case ASDF_TIME_FORMAT_ISO:
     case ASDF_TIME_FORMAT_ISOT:
     case ASDF_TIME_FORMAT_DATETIME:
+    case ASDF_TIME_FORMAT_YMDHMS:
+    case ASDF_TIME_FORMAT_DATETIME64:
     case ASDF_TIME_FORMAT_UNIX:
         status = asdf_time_parse_std(time);
         break;
@@ -706,18 +712,30 @@ static bool asdf_time_is_other_format(asdf_time_format_t format) {
 }
 
 
-/* True for "other" formats whose native value is numeric or structured rather
- * than a datetime string, and so must be reformatted into a string to be
- * serialized under the standard (iso) wire format. */
+/* True for "other" formats that may carry a numeric value which must be
+ * reformatted into a datetime string to be serialized under the standard (iso)
+ * wire format.  Only plot_date has a well-defined numeric scalar form; ymdhms
+ * and datetime64 are always stored as ISO strings (astropy converts them), and
+ * a bare-integer datetime64 is unit-ambiguous, so neither is reformatted. */
 static bool asdf_time_value_needs_reformat(asdf_time_format_t format) {
-    switch (format) {
-    case ASDF_TIME_FORMAT_PLOT_DATE:
-    case ASDF_TIME_FORMAT_YMDHMS:
-    case ASDF_TIME_FORMAT_DATETIME64:
-        return true;
-    default:
-        return false;
+    return format == ASDF_TIME_FORMAT_PLOT_DATE;
+}
+
+
+/* True if the value is already one of the guessable datetime string forms
+ * (iso/yday/byear/jyear/fits), and so can be written verbatim rather than
+ * reformatted from a numeric value.  This distinguishes, e.g., a plot_date
+ * stored as a raw float from one already read back as an ISO string. */
+static bool asdf_time_value_is_datetime_string(const char *value) {
+    compile_time_auto_regexes();
+    for (size_t idx = 0; idx < TIME_AUTO_COUNT; idx++) {
+        if (time_auto_regexes[idx].error != CREG_OK)
+            continue;
+        csview match[CREG_MAX_CAPTURES] = {0};
+        if (cregex_match(&time_auto_regexes[idx], value, match) == CREG_OK)
+            return true;
     }
+    return false;
 }
 
 
@@ -916,10 +934,12 @@ static asdf_value_t *asdf_time_serialize(
 
     /* A numeric "other" format (e.g. plot_date) cannot be written verbatim
      * under its string wire format, so reformat its value to an isot string
-     * from the parsed calendar fields. */
+     * from the parsed calendar fields.  Skip this when the value is already a
+     * datetime string (e.g. a plot_date just read back from the base_format
+     * form, whose value is an ISO string), which is written verbatim. */
     const char *value_out = t->value;
     char value_buf[ASDF_TIME_TIMESTR_MAXLEN];
-    if (asdf_time_value_needs_reformat(eff)) {
+    if (asdf_time_value_needs_reformat(eff) && !asdf_time_value_is_datetime_string(t->value)) {
         asdf_time_t tmp = *t;
         if (asdf_time_parse(&tmp) != 0 ||
             asdf_time_format_isot(&tmp.info, value_buf, sizeof(value_buf)) != 0) {

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -513,12 +513,6 @@ static int asdf_time_parse_std(asdf_time_t *time) {
 int asdf_time_parse(asdf_time_t *time) {
     int status = -1;
 
-    /* Refuse to parse an unset format.  The primary ``format`` is always
-     * guessed/validated to a concrete value, so NONE here indicates an
-     * invalid/unset time object rather than something we can interpret. */
-    if (time->format == ASDF_TIME_FORMAT_NONE)
-        return -1;
-
     switch (time->format) {
     case ASDF_TIME_FORMAT_YDAY:
     case ASDF_TIME_FORMAT_ISO:
@@ -604,12 +598,65 @@ static const char *const asdf_time_scale_names[] = {
 const char *asdf_time_format_string(asdf_time_format_t format) {
     const size_t nformats = ARRAY_SIZE(asdf_time_format_names);
 
-    /* Out-of-range (including a negative cast to a large size_t) yields NULL;
-     * ASDF_TIME_FORMAT_NONE (0) also maps to a NULL name entry. */
+    /* Out-of-range (including a negative cast to a large size_t) yields
+     * NULL
+     */
     if ((size_t)format >= nformats)
         return NULL;
 
     return asdf_time_format_names[format];
+}
+
+
+/*
+ * The schema's ``format`` field only permits the "standard" formats; the
+ * "other" astropy formats (fits, isot, datetime, plot_date, ymdhms,
+ * datetime64, jyear_str, byear_str) may appear only in ``base_format``.  The
+ * following helpers implement that split: an "other" format is mapped to a
+ * standard wire format for the ``format`` field, and recorded verbatim in
+ * ``base_format``.
+ */
+
+/* Map an effective format to the standard format used in the wire ``format``
+ * field.  Standard formats map to themselves. */
+static asdf_time_format_t asdf_time_standard_format(asdf_time_format_t format) {
+    switch (format) {
+    case ASDF_TIME_FORMAT_ISOT:
+    case ASDF_TIME_FORMAT_FITS:
+    case ASDF_TIME_FORMAT_DATETIME:
+    case ASDF_TIME_FORMAT_PLOT_DATE:
+    case ASDF_TIME_FORMAT_YMDHMS:
+    case ASDF_TIME_FORMAT_DATETIME64:
+        return ASDF_TIME_FORMAT_ISO;
+    case ASDF_TIME_FORMAT_JYEAR_STR:
+        return ASDF_TIME_FORMAT_JYEAR;
+    case ASDF_TIME_FORMAT_BYEAR_STR:
+        return ASDF_TIME_FORMAT_BYEAR;
+    default:
+        return format;
+    }
+}
+
+
+/* True if ``format`` is one of the schema's ``other_format`` values (i.e. it is
+ * not valid in the wire ``format`` field and must go in ``base_format``). */
+static bool asdf_time_is_other_format(asdf_time_format_t format) {
+    return asdf_time_standard_format(format) != format;
+}
+
+
+/* True for "other" formats whose native value is numeric or structured rather
+ * than a datetime string, and so must be reformatted into a string to be
+ * serialized under the standard (iso) wire format. */
+static bool asdf_time_value_needs_reformat(asdf_time_format_t format) {
+    switch (format) {
+    case ASDF_TIME_FORMAT_PLOT_DATE:
+    case ASDF_TIME_FORMAT_YMDHMS:
+    case ASDF_TIME_FORMAT_DATETIME64:
+        return true;
+    default:
+        return false;
+    }
 }
 
 
@@ -744,6 +791,31 @@ static void validate_datetime_ranges(asdf_file_t *file, int pat_idx, const char 
 }
 
 
+/* Render a parsed instant as an ISO-8601 "isot" string (``T`` separator).
+ * Used to serialize the numeric "other" formats (e.g. plot_date) whose value
+ * cannot be written verbatim under any of standard ASDF formats.  Returns 0
+ * on success, -1 on failure. */
+static int asdf_time_format_isot(const asdf_time_info_t *info, char *buf, size_t buflen) {
+    struct tm tm = info->tm;
+    size_t n = strftime(buf, buflen, "%Y-%m-%dT%H:%M:%S", &tm);
+    if (n == 0)
+        return -1;
+
+    long nsec = info->ts.tv_nsec;
+    if (nsec > 0) {
+        char frac[16];
+        int fn = snprintf(frac, sizeof(frac), ".%09ld", nsec);
+        /* Trim trailing zeros from the fractional part for a compact value. */
+        while (fn > 1 && frac[fn - 1] == '0')
+            frac[--fn] = '\0';
+        if (n + (size_t)fn < buflen)
+            memcpy(buf + n, frac, (size_t)fn + 1);
+    }
+
+    return 0;
+}
+
+
 static asdf_value_t *asdf_time_serialize(
     asdf_file_t *file, const void *obj, UNUSED(const void *userdata)) {
 
@@ -770,45 +842,55 @@ static asdf_value_t *asdf_time_serialize(
     if (!map)
         goto cleanup;
 
-    err = asdf_mapping_set_string0(map, "value", t->value);
-    if (err != ASDF_VALUE_OK)
-        goto cleanup;
-
-    /* Astropy compatibility: a J-prefixed (Julian year) or B-prefixed
-     * (Besselian year) string value must currently be written with the
-     * jyear_str / byear_str format respectively, even if it was stored as
-     * plain jyear / byear.  Astropy only accepts the prefixed string forms
-     * under those *_str formats.
-     *
-     * I still hold that whatever happens with this in Astropy we should be more
-     * flexible in what asdf-astropy supports here; see
-     * https://github.com/astropy/asdf-astropy/pull/326
-     *
-     * But until that is changed we should try to remain compatible with what
-     * existing software is known to accept...
-     */
-    const char *format_name = asdf_time_format_names[t->format];
+    /* Determine the effective format to serialize.  A J-/B-prefixed string
+     * value stored under jyear/byear is really the jyear_str/byear_str "other"
+     * form (astropy only accepts the prefixed strings under those formats), so
+     * relabel it; it then flows through the "other" format handling below. */
+    asdf_time_format_t eff = t->format;
     const char first = t->value[0];
-    if ((first == 'J' || first == 'j') &&
-        (t->format == ASDF_TIME_FORMAT_JYEAR || t->format == ASDF_TIME_FORMAT_JYEAR_STR))
-        format_name = asdf_time_format_names[ASDF_TIME_FORMAT_JYEAR_STR];
-    else if (
-        (first == 'B' || first == 'b') &&
-        (t->format == ASDF_TIME_FORMAT_BYEAR || t->format == ASDF_TIME_FORMAT_BYEAR_STR))
-        format_name = asdf_time_format_names[ASDF_TIME_FORMAT_BYEAR_STR];
+    if ((first == 'J' || first == 'j') && eff == ASDF_TIME_FORMAT_JYEAR)
+        eff = ASDF_TIME_FORMAT_JYEAR_STR;
+    else if ((first == 'B' || first == 'b') && eff == ASDF_TIME_FORMAT_BYEAR)
+        eff = ASDF_TIME_FORMAT_BYEAR_STR;
 
-    err = asdf_mapping_set_string0(map, "format", format_name);
+    /* A numeric "other" format (e.g. plot_date) cannot be written verbatim
+     * under its string wire format, so reformat its value to an isot string
+     * from the parsed calendar fields. */
+    const char *value_out = t->value;
+    char value_buf[ASDF_TIME_TIMESTR_MAXLEN];
+    if (asdf_time_value_needs_reformat(eff)) {
+        asdf_time_t tmp = *t;
+        if (asdf_time_parse(&tmp) != 0 ||
+            asdf_time_format_isot(&tmp.info, value_buf, sizeof(value_buf)) != 0) {
+            ASDF_LOG(
+                file,
+                ASDF_LOG_WARN,
+                ASDF_CORE_TIME_TAG " could not reformat %s value '%s' for serialization",
+                asdf_time_format_names[eff],
+                t->value);
+            goto cleanup;
+        }
+        value_out = value_buf;
+    }
+
+    err = asdf_mapping_set_string0(map, "value", value_out);
     if (err != ASDF_VALUE_OK)
         goto cleanup;
 
-    /* Write base_format only when set (it is an optional field) */
-    if (t->base_format != ASDF_TIME_FORMAT_NONE) {
-        const char *base_format = asdf_time_format_string(t->base_format);
-        if (base_format) {
-            err = asdf_mapping_set_string0(map, "base_format", base_format);
-            if (err != ASDF_VALUE_OK)
-                goto cleanup;
-        }
+    /* The schema only permits standard formats in ``format``; an "other"
+     * effective format is recorded in ``base_format`` instead, with ``format``
+     * omitted (its guessable standard wire format is re-inferred from the
+     * value on read, matching asdf-astropy).  A standard format is written
+     * directly.
+     */
+    if (asdf_time_is_other_format(eff)) {
+        err = asdf_mapping_set_string0(map, "base_format", asdf_time_format_names[eff]);
+        if (err != ASDF_VALUE_OK)
+            goto cleanup;
+    } else {
+        err = asdf_mapping_set_string0(map, "format", asdf_time_format_names[eff]);
+        if (err != ASDF_VALUE_OK)
+            goto cleanup;
     }
 
     /* Write scale only if non-UTC */
@@ -960,6 +1042,7 @@ static asdf_value_err_t asdf_time_deserialize(
     const char *value_s = NULL;
     const char *format_s = NULL;
     const char *scale_s = NULL;
+    const char *base_format_s = NULL;
     asdf_time_scale_t scale = ASDF_TIME_SCALE_UTC;
 
     asdf_mapping_t *mapping = NULL;
@@ -970,10 +1053,6 @@ static asdf_value_err_t asdf_time_deserialize(
 
     if (!time)
         return ASDF_VALUE_ERR_OOM;
-
-    /* base_format is optional; leave it unset unless a ``base_format`` key is
-     * present (NONE is the zero value, but be explicit about the intent). */
-    time->base_format = ASDF_TIME_FORMAT_NONE;
 
     if (asdf_value_is_mapping(value)) {
         if (asdf_value_as_mapping(value, &mapping) != ASDF_VALUE_OK)
@@ -1038,20 +1117,14 @@ static asdf_value_err_t asdf_time_deserialize(
         }
 
         /* base_format key is optional (added in time-1.2.0); it records the
-         * object's original format and may be any standard or "other" format
-         * name.  Left as ASDF_TIME_FORMAT_NONE when absent or unrecognized. */
+         * object's real/original format and may be any standard or "other"
+         * format name.  It is captured here and applied after parsing (below)
+         * as the effective format, overriding the wire ``format``. */
         prop = asdf_mapping_get(mapping, "base_format");
         if (prop) {
-            const char *base_format_s = NULL;
             if (ASDF_VALUE_OK != asdf_value_as_string0(prop, &base_format_s))
                 goto failure;
 
-            if (!asdf_time_format_parse(base_format_s, &time->base_format))
-                ASDF_LOG(
-                    value->file,
-                    ASDF_LOG_WARN,
-                    "unrecognized time base_format '%s'; ignoring",
-                    base_format_s);
             asdf_value_destroy(prop);
             prop = NULL;
         }
@@ -1068,6 +1141,9 @@ static asdf_value_err_t asdf_time_deserialize(
     time->format = format;
     time->scale = scale;
 
+    /* Parse the instant using the wire (parse) format: the value is stored in
+     * that format's representation, even when base_format labels it as
+     * something else (e.g. an astropy plot_date is stored as an iso string). */
     if (asdf_time_parse(time))
         ASDF_LOG(
             value->file,
@@ -1076,6 +1152,20 @@ static asdf_value_err_t asdf_time_deserialize(
             "without a computed timestamp",
             asdf_time_format_names[format] ? asdf_time_format_names[format] : "(unknown)",
             time->value);
+
+    /* base_format, when present, is the real/effective format; it overrides the
+     * wire format as ``time->format`` (mirroring asdf-astropy). */
+    if (base_format_s) {
+        asdf_time_format_t base_format;
+        if (asdf_time_format_parse(base_format_s, &base_format))
+            time->format = base_format;
+        else
+            ASDF_LOG(
+                value->file,
+                ASDF_LOG_WARN,
+                "unrecognized time base_format '%s'; ignoring",
+                base_format_s);
+    }
 
     *out = time;
 

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -38,12 +38,16 @@
  *     [1]=integer-part [2]=optional fractional
  *   TIME_AUTO_IDX_YDAY:
  *     [1]=year [2]=day-of-year [3]=hour [4]=minute [5]=second [6]=optional frac
+ *   TIME_AUTO_IDX_FITS:
+ *     same layout as ISO, but [1]=year additionally permits the FITS "long"
+ *     form: an explicit sign followed by exactly five digits (e.g. +02025).
  */
 enum {
     TIME_AUTO_IDX_ISO = 0,
     TIME_AUTO_IDX_BYEAR,
     TIME_AUTO_IDX_JYEAR,
     TIME_AUTO_IDX_YDAY,
+    TIME_AUTO_IDX_FITS,
     TIME_AUTO_COUNT,
 };
 
@@ -70,6 +74,17 @@ static const struct {
         {
             ASDF_TIME_FORMAT_YDAY,
             "^(\\d\\d\\d\\d):(\\d\\d\\d):(\\d\\d):(\\d\\d):(\\d\\d)(.\\d+)?",
+        },
+    /* Like ISO, but the year alternately allows the FITS "long" form: an
+     * explicit sign plus exactly five digits, for years outside 0-9999.  The
+     * plain four-digit branch means an ordinary FITS value validates too;
+     * because ISO is matched first during auto-detection, a value is only
+     * guessed as FITS when the signed long-year form is present. */
+    [TIME_AUTO_IDX_FITS] =
+        {
+            ASDF_TIME_FORMAT_FITS,
+            "^([+-]\\d\\d\\d\\d\\d|\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)([T "
+            "](\\d\\d):(\\d\\d):(\\d\\d)(.\\d+)?)?",
         },
 };
 
@@ -118,6 +133,9 @@ static const char *ASDF_TIME_SFMT_UNIX[] = {"%s"};
 #define JD_MJD 2400000.5
 #define JD_J2000 2451545.0
 #define JD_UNIX_EPOCH 2440587.5
+/* matplotlib "plot_date" epoch: JD of 0001-01-01 00:00:00 UTC minus one day,
+ * i.e. a plot_date value is the number of days from 0001-01-01 UTC plus one. */
+#define JD_PLOT_DATE_EPOCH 1721424.5
 
 /* Calendar constants */
 static const double JD_GREGORIAN_START = 2299161.0;
@@ -279,6 +297,71 @@ cleanup:
 }
 
 
+static int asdf_time_parse_fits(asdf_time_t *time) {
+    if (UNLIKELY(!time))
+        return -1;
+
+    struct tm tm = {0};
+    long nsec = 0;
+    int year = 0;
+    int mon = 1;
+    int day = 1;
+    int hour = 0;
+    int min = 0;
+    int sec = 0;
+    int ret = -1;
+    char *buf = strdup(time->value);
+
+    if (!buf) {
+        ASDF_ERROR_OOM(NULL);
+        goto cleanup;
+    }
+
+    /* Normalize the date/time separator (FITS uses 'T') to a space */
+    for (char *c = buf; *c; ++c) {
+        if (*c == 'T' || *c == 't')
+            *c = ' ';
+    }
+
+    /* Scan the fields directly rather than via strptime: the FITS "long" year
+     * form carries an explicit sign and up to five digits, which strptime's
+     * %Y cannot parse portably.  A plain "%d" handles the sign, leading zeros,
+     * and both the four- and five-digit widths.  A date-only value matches the
+     * first three fields, leaving the time at midnight. */
+    int matched = sscanf(buf, "%d-%d-%d %d:%d:%d", &year, &mon, &day, &hour, &min, &sec);
+    if (matched < 3)
+        goto cleanup;
+
+    if (matched >= 6) {
+        const char *dot = strchr(buf, '.');
+        if (dot) {
+            double frac = 0;
+            sscanf(dot, "%lf", &frac);
+            nsec = (long)(frac * 1e9);
+        }
+    }
+
+    tm.tm_year = year - 1900;
+    tm.tm_mon = mon - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = min;
+    tm.tm_sec = sec;
+
+    time_t t = timegm(&tm);
+    if (t == (time_t)-1)
+        goto cleanup;
+
+    time->info.tm = *gmtime(&t);
+    time->info.ts.tv_sec = t;
+    time->info.ts.tv_nsec = nsec;
+    ret = 0;
+cleanup:
+    free(buf);
+    return ret;
+}
+
+
 static int asdf_time_parse_jd(asdf_time_t *time) {
     if (UNLIKELY(!time))
         return -1;
@@ -291,6 +374,24 @@ static int asdf_time_parse_jd(asdf_time_t *time) {
     julian_to_tm(jd, &jd_tm, &t_nsec);
     t_sec = timegm(&jd_tm);
     time->info.tm = jd_tm;
+    time->info.ts.tv_sec = t_sec;
+    time->info.ts.tv_nsec = t_nsec;
+    return 0;
+}
+
+
+static int asdf_time_parse_plot_date(asdf_time_t *time) {
+    if (UNLIKELY(!time))
+        return -1;
+
+    const double jd = strtod(time->value, NULL) + JD_PLOT_DATE_EPOCH;
+    struct tm tm;
+    time_t t_nsec = 0;
+
+    julian_to_tm(jd, &tm, &t_nsec);
+    const time_t t_sec = timegm(&tm);
+
+    time->info.tm = tm;
     time->info.ts.tv_sec = t_sec;
     time->info.ts.tv_nsec = t_nsec;
     return 0;
@@ -428,6 +529,9 @@ int asdf_time_parse(asdf_time_t *time) {
         break;
     case ASDF_TIME_FORMAT_FITS:
         status = asdf_time_parse_fits(time);
+        break;
+    case ASDF_TIME_FORMAT_PLOT_DATE:
+        status = asdf_time_parse_plot_date(time);
         break;
     case ASDF_TIME_FORMAT_MJD:
         status = asdf_time_parse_mjd(time);
@@ -626,6 +730,9 @@ static void validate_yday_ranges(asdf_file_t *file, const char *cvs, csview *mat
 static void validate_datetime_ranges(asdf_file_t *file, int pat_idx, const char *vs, csview *m) {
     switch (pat_idx) {
     case TIME_AUTO_IDX_ISO:
+    case TIME_AUTO_IDX_FITS:
+        /* FITS shares the ISO capture-group layout (month/day/time in the same
+         * positions); the signed long-year in group [1] is not range-checked. */
         validate_iso_time_ranges(file, vs, m);
         break;
     case TIME_AUTO_IDX_YDAY:

--- a/src/core/time.c
+++ b/src/core/time.c
@@ -53,7 +53,7 @@ static const struct {
 } time_auto_patterns[TIME_AUTO_COUNT] = {
     [TIME_AUTO_IDX_ISO_TIME] =
         {
-            ASDF_TIME_FORMAT_ISO_TIME,
+            ASDF_TIME_FORMAT_ISO,
             "^(\\d\\d\\d\\d)-(\\d\\d)-(\\d\\d)([T ](\\d\\d):(\\d\\d):(\\d\\d)(.\\d+)?)?",
         },
     [TIME_AUTO_IDX_BYEAR] =
@@ -225,7 +225,7 @@ static int asdf_time_parse_std(asdf_time_t *time) {
 
     switch (time->format) {
     case ASDF_TIME_FORMAT_DATETIME:
-    case ASDF_TIME_FORMAT_ISO_TIME:
+    case ASDF_TIME_FORMAT_ISO:
         check_format_strptime(ASDF_TIME_SFMT_ISO_TIME, buf, &tm, has_time, rest);
         break;
     case ASDF_TIME_FORMAT_YDAY:
@@ -410,9 +410,16 @@ static int asdf_time_parse_std(asdf_time_t *time) {
 
 int asdf_time_parse(asdf_time_t *time) {
     int status = -1;
+
+    /* Refuse to parse an unset format.  The primary ``format`` is always
+     * guessed/validated to a concrete value, so NONE here indicates an
+     * invalid/unset time object rather than something we can interpret. */
+    if (time->format == ASDF_TIME_FORMAT_NONE)
+        return -1;
+
     switch (time->format) {
     case ASDF_TIME_FORMAT_YDAY:
-    case ASDF_TIME_FORMAT_ISO_TIME:
+    case ASDF_TIME_FORMAT_ISO:
     case ASDF_TIME_FORMAT_DATETIME:
     case ASDF_TIME_FORMAT_UNIX:
         status = asdf_time_parse_std(time);
@@ -443,7 +450,7 @@ int asdf_time_parse(asdf_time_t *time) {
  * Lookup table: asdf_time_format_t enum value -> YAML format name string
  */
 static const char *const asdf_time_format_names[] = {
-    [ASDF_TIME_FORMAT_ISO_TIME] = "iso_time",
+    [ASDF_TIME_FORMAT_ISO] = "iso",
     [ASDF_TIME_FORMAT_YDAY] = "yday",
     [ASDF_TIME_FORMAT_BYEAR] = "byear",
     [ASDF_TIME_FORMAT_JYEAR] = "jyear",
@@ -486,7 +493,9 @@ static const char *const asdf_time_scale_names[] = {
 const char *asdf_time_format_string(asdf_time_format_t format) {
     const size_t nformats = ARRAY_SIZE(asdf_time_format_names);
 
-    if (format < 0 || format > nformats)
+    /* Out-of-range (including a negative cast to a large size_t) yields NULL;
+     * ASDF_TIME_FORMAT_NONE (0) also maps to a NULL name entry. */
+    if ((size_t)format >= nformats)
         return NULL;
 
     return asdf_time_format_names[format];
@@ -655,6 +664,16 @@ static asdf_value_t *asdf_time_serialize(
     if (err != ASDF_VALUE_OK)
         goto cleanup;
 
+    /* Write base_format only when set (it is an optional field) */
+    if (t->base_format != ASDF_TIME_FORMAT_NONE) {
+        const char *base_format = asdf_time_format_string(t->base_format);
+        if (base_format) {
+            err = asdf_mapping_set_string0(map, "base_format", base_format);
+            if (err != ASDF_VALUE_OK)
+                goto cleanup;
+        }
+    }
+
     /* Write scale only if non-UTC */
     if (t->scale != ASDF_TIME_SCALE_UTC) {
         const size_t nscales = ARRAY_SIZE(asdf_time_scale_names);
@@ -797,6 +816,10 @@ static asdf_value_err_t asdf_time_deserialize(
     if (!time)
         return ASDF_VALUE_ERR_OOM;
 
+    /* base_format is optional; leave it unset unless a ``base_format`` key is
+     * present (NONE is the zero value, but be explicit about the intent). */
+    time->base_format = ASDF_TIME_FORMAT_NONE;
+
     if (asdf_value_is_mapping(value)) {
         if (asdf_value_as_mapping(value, &mapping) != ASDF_VALUE_OK)
             goto failure;
@@ -855,6 +878,25 @@ static asdf_value_err_t asdf_time_deserialize(
                     ASDF_LOG_WARN,
                     "unrecognized time scale '%s'; defaulting to utc",
                     scale_s);
+            asdf_value_destroy(prop);
+            prop = NULL;
+        }
+
+        /* base_format key is optional (added in time-1.2.0); it records the
+         * object's original format and may be any standard or "other" format
+         * name.  Left as ASDF_TIME_FORMAT_NONE when absent or unrecognized. */
+        prop = asdf_mapping_get(mapping, "base_format");
+        if (prop) {
+            const char *base_format_s = NULL;
+            if (ASDF_VALUE_OK != asdf_value_as_string0(prop, &base_format_s))
+                goto failure;
+
+            if (!asdf_time_format_parse(base_format_s, &time->base_format))
+                ASDF_LOG(
+                    value->file,
+                    ASDF_LOG_WARN,
+                    "unrecognized time base_format '%s'; ignoring",
+                    base_format_s);
             asdf_value_destroy(prop);
             prop = NULL;
         }
@@ -921,11 +963,17 @@ static const asdf_extension_vtab_t asdf_time_vtab = {
 
 
 // clang-format off
+/* tags[0] (1.4.0) is the version written; the older tags are recognized when
+ * reading files produced against earlier ASDF Standard versions. */
 ASDF_REGISTER_EXTENSION(
     time,
     asdf_time_t,
     &libasdf_software,
     &asdf_time_vtab,
     NULL,
-    ASDF_CORE_TIME_TAG);
+    ASDF_CORE_TIME_TAG,
+    ASDF_CORE_TIME_TAG_BASE "1.3.0",
+    ASDF_CORE_TIME_TAG_BASE "1.2.0",
+    ASDF_CORE_TIME_TAG_BASE "1.1.0",
+    ASDF_CORE_TIME_TAG_BASE "1.0.0");
 // clang-format on

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,13 @@
 #include <string.h>
 #include <sys/types.h>
 
+// Some versions of libfyaml.h started exporting its own internal
+// ARRAY_SIZE macro, which it probably shouldn't do...
+#include <libfyaml.h>
+#ifdef ARRAY_SIZE
+#undef ARRAY_SIZE
+#endif
+
 #include "asdf/util.h" // IWYU pragma: export
 
 

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -14,23 +14,24 @@ history:
     software: !core/software-1.0.0 {name: asdf, version: 5.0.0}
 t_byear: !time/time-1.4.0 {format: byear, value: '2025.78707178'}
 t_datetime: !time/time-1.4.0 {format: datetime, value: '2025-10-14 13:26:41.0000+00:00'}
-t_iso_time: !time/time-1.4.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
+t_iso: !time/time-1.4.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
 t_jd: !time/time-1.4.0 {format: jd, value: '2460963.060197'}
 t_mjd: !time/time-1.4.0 {format: mjd, value: '60962.560196'}
 t_unix: !time/time-1.4.0 {format: unix, value: '1760462801.00'}
 t_yday: !time/time-1.4.0 {format: yday, value: '2025:287:13:26:41.0000'}
 t_byear_bare: !time/time-1.4.0 'B2025.78707178'
-t_iso_time_bare: !time/time-1.4.0 '2025-10-14T13:26:41.0000'
+t_iso_bare: !time/time-1.4.0 '2025-10-14T13:26:41.0000'
 t_jyear_bare: !time/time-1.4.0 'J2025.78707178'
 t_yday_bare: !time/time-1.4.0 '2025:287:13:26:41.0000'
 t_yday_map_no_format: !time/time-1.4.0 {value: '2025:287:13:26:41.0000'}
 t_jyear: !time/time-1.4.0 {format: jyear, value: 'J2025.78707178'}
 t_jyear_num: !time/time-1.4.0 {format: jyear, value: 1948.78707178}
 t_decimalyear: !time/time-1.4.0 {format: decimalyear, value: 2025.5}
-t_iso_time_tai: !time/time-1.4.0 {format: iso, scale: tai, value: '2025-10-14T13:26:41.0000'}
+t_iso_tai: !time/time-1.4.0 {format: iso, scale: tai, value: '2025-10-14T13:26:41.0000'}
 t_iso_base_format: !time/time-1.4.0 {base_format: datetime, format: iso, value: '2025-10-14T13:26:41.0000'}
-t_iso_time_1_1_0: !time/time-1.1.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
-t_iso_time_1_0_0: !time/time-1.0.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
+t_iso_1_1_0: !time/time-1.1.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
+t_iso_1_0_0: !time/time-1.0.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
+t_isot: !time/time-1.4.0 {format: isot, value: '2025-10-14T13:26:41.0000'}
 t_jyear_str: !time/time-1.4.0 {format: jyear_str, value: 'J2025.78707178'}
 t_byear_str: !time/time-1.4.0 {format: byear_str, value: 'B2025.78707178'}
 t_jyear_str_bad: !time/time-1.4.0 {format: jyear_str, value: 2025.78707178}

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -13,7 +13,7 @@ history:
     manifest_software: !core/software-1.0.0 {name: asdf_standard, version: 1.4.0}
     software: !core/software-1.0.0 {name: asdf, version: 5.0.0}
 t_byear: !time/time-1.4.0 {format: byear, value: '2025.78707178'}
-t_datetime: !time/time-1.4.0 {format: datetime, value: '2025-10-14 13:26:41.0000+00:00'}
+t_datetime: !time/time-1.4.0 {value: '2025-10-14 13:26:41.0000+00:00', base_format: datetime}
 t_iso: !time/time-1.4.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
 t_jd: !time/time-1.4.0 {format: jd, value: '2460963.060197'}
 t_mjd: !time/time-1.4.0 {format: mjd, value: '60962.560196'}
@@ -31,12 +31,20 @@ t_iso_tai: !time/time-1.4.0 {format: iso, scale: tai, value: '2025-10-14T13:26:4
 t_iso_base_format: !time/time-1.4.0 {base_format: datetime, format: iso, value: '2025-10-14T13:26:41.0000'}
 t_iso_1_1_0: !time/time-1.1.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
 t_iso_1_0_0: !time/time-1.0.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
-t_isot: !time/time-1.4.0 {format: isot, value: '2025-10-14T13:26:41.0000'}
-t_jyear_str: !time/time-1.4.0 {format: jyear_str, value: 'J2025.78707178'}
-t_byear_str: !time/time-1.4.0 {format: byear_str, value: 'B2025.78707178'}
-t_jyear_str_bad: !time/time-1.4.0 {format: jyear_str, value: 2025.78707178}
-t_fits: !time/time-1.4.0 {format: fits, value: '2025-10-14T13:26:41.0000'}
-t_fits_long: !time/time-1.4.0 {format: fits, value: '+12025-10-14T13:26:41.0000'}
+# "other" formats: schema-valid form places the real format in base_format and
+# a standard (guessable) representation in value; format is omitted.
+t_isot: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: isot}
+t_jyear_str: !time/time-1.4.0 {value: 'J2025.78707178', base_format: jyear_str}
+t_byear_str: !time/time-1.4.0 {value: 'B2025.78707178', base_format: byear_str}
+t_fits: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: fits}
+t_plot_date: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: plot_date}
+# Bare FITS "long" year: only auto-detected as fits via the signed 5-digit year.
 t_fits_long_bare: !time/time-1.4.0 '+12025-10-14T13:26:41.0000'
-t_plot_date: !time/time-1.4.0 {format: plot_date, value: '739538.560197'}
+# Liberal-read cases: technically schema-invalid (an "other" format in the
+# format field, or a numeric value under a string-only format), but still
+# accepted on read.
+t_isot_liberal: !time/time-1.4.0 {format: isot, value: '2025-10-14T13:26:41.0000'}
+t_fits_long: !time/time-1.4.0 {format: fits, value: '+12025-10-14T13:26:41.0000'}
+t_plot_date_num: !time/time-1.4.0 {format: plot_date, value: 739538.560197}
+t_jyear_str_bad: !time/time-1.4.0 {format: jyear_str, value: 2025.78707178}
 ...

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -35,4 +35,8 @@ t_isot: !time/time-1.4.0 {format: isot, value: '2025-10-14T13:26:41.0000'}
 t_jyear_str: !time/time-1.4.0 {format: jyear_str, value: 'J2025.78707178'}
 t_byear_str: !time/time-1.4.0 {format: byear_str, value: 'B2025.78707178'}
 t_jyear_str_bad: !time/time-1.4.0 {format: jyear_str, value: 2025.78707178}
+t_fits: !time/time-1.4.0 {format: fits, value: '2025-10-14T13:26:41.0000'}
+t_fits_long: !time/time-1.4.0 {format: fits, value: '+12025-10-14T13:26:41.0000'}
+t_fits_long_bare: !time/time-1.4.0 '+12025-10-14T13:26:41.0000'
+t_plot_date: !time/time-1.4.0 {format: plot_date, value: '739538.560197'}
 ...

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -31,4 +31,7 @@ t_iso_time_tai: !time/time-1.4.0 {format: iso, scale: tai, value: '2025-10-14T13
 t_iso_base_format: !time/time-1.4.0 {base_format: datetime, format: iso, value: '2025-10-14T13:26:41.0000'}
 t_iso_time_1_1_0: !time/time-1.1.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
 t_iso_time_1_0_0: !time/time-1.0.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
+t_jyear_str: !time/time-1.4.0 {format: jyear_str, value: 'J2025.78707178'}
+t_byear_str: !time/time-1.4.0 {format: byear_str, value: 'B2025.78707178'}
+t_jyear_str_bad: !time/time-1.4.0 {format: jyear_str, value: 2025.78707178}
 ...

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -45,6 +45,8 @@ t_jyear_str: !time/time-1.4.0 {value: 'J2025.78707178', base_format: jyear_str}
 t_byear_str: !time/time-1.4.0 {value: 'B2025.78707178', base_format: byear_str}
 t_fits: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: fits}
 t_plot_date: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: plot_date}
+t_ymdhms: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: ymdhms}
+t_datetime64: !time/time-1.4.0 {value: '2025-10-14T13:26:41.0000', base_format: datetime64}
 # Bare FITS "long" year: only auto-detected as fits via the signed 5-digit year.
 t_fits_long_bare: !time/time-1.4.0 '+12025-10-14T13:26:41.0000'
 # Liberal-read cases: technically schema-invalid (an "other" format in the
@@ -53,5 +55,6 @@ t_fits_long_bare: !time/time-1.4.0 '+12025-10-14T13:26:41.0000'
 t_isot_liberal: !time/time-1.4.0 {format: isot, value: '2025-10-14T13:26:41.0000'}
 t_fits_long: !time/time-1.4.0 {format: fits, value: '+12025-10-14T13:26:41.0000'}
 t_plot_date_num: !time/time-1.4.0 {format: plot_date, value: 739538.560197}
+t_ymdhms_liberal: !time/time-1.4.0 {format: ymdhms, value: '2025-10-14T13:26:41.0000'}
 t_jyear_str_bad: !time/time-1.4.0 {format: jyear_str, value: 2025.78707178}
 ...

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -19,6 +19,13 @@ t_jd: !time/time-1.4.0 {format: jd, value: '2460963.060197'}
 t_mjd: !time/time-1.4.0 {format: mjd, value: '60962.560196'}
 t_unix: !time/time-1.4.0 {format: unix, value: '1760462801.00'}
 t_yday: !time/time-1.4.0 {format: yday, value: '2025:287:13:26:41.0000'}
+# seconds-from-epoch formats (values chosen to resolve to 2025-10-14 13:26:41)
+t_gps: !time/time-1.4.0 {format: gps, value: '1444483582.021'}
+t_unix_tai: !time/time-1.4.0 {format: unix_tai, value: '1760448401.021'}
+t_cxcsec: !time/time-1.4.0 {format: cxcsec, value: '876835601.021'}
+t_galexsec: !time/time-1.4.0 {format: galexsec, value: '1444483601.021'}
+t_tai_seconds: !time/time-1.4.0 {format: tai_seconds, value: '2139139601.021'}
+t_utime: !time/time-1.4.0 {format: utime, value: '1476451601.021'}
 t_byear_bare: !time/time-1.4.0 'B2025.78707178'
 t_iso_bare: !time/time-1.4.0 '2025-10-14T13:26:41.0000'
 t_jyear_bare: !time/time-1.4.0 'J2025.78707178'

--- a/tests/fixtures/time.asdf
+++ b/tests/fixtures/time.asdf
@@ -14,7 +14,7 @@ history:
     software: !core/software-1.0.0 {name: asdf, version: 5.0.0}
 t_byear: !time/time-1.4.0 {format: byear, value: '2025.78707178'}
 t_datetime: !time/time-1.4.0 {format: datetime, value: '2025-10-14 13:26:41.0000+00:00'}
-t_iso_time: !time/time-1.4.0 {format: iso_time, value: '2025-10-14T13:26:41.0000'}
+t_iso_time: !time/time-1.4.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
 t_jd: !time/time-1.4.0 {format: jd, value: '2460963.060197'}
 t_mjd: !time/time-1.4.0 {format: mjd, value: '60962.560196'}
 t_unix: !time/time-1.4.0 {format: unix, value: '1760462801.00'}
@@ -27,5 +27,8 @@ t_yday_map_no_format: !time/time-1.4.0 {value: '2025:287:13:26:41.0000'}
 t_jyear: !time/time-1.4.0 {format: jyear, value: 'J2025.78707178'}
 t_jyear_num: !time/time-1.4.0 {format: jyear, value: 1948.78707178}
 t_decimalyear: !time/time-1.4.0 {format: decimalyear, value: 2025.5}
-t_iso_time_tai: !time/time-1.4.0 {format: iso_time, scale: tai, value: '2025-10-14T13:26:41.0000'}
+t_iso_time_tai: !time/time-1.4.0 {format: iso, scale: tai, value: '2025-10-14T13:26:41.0000'}
+t_iso_base_format: !time/time-1.4.0 {base_format: datetime, format: iso, value: '2025-10-14T13:26:41.0000'}
+t_iso_time_1_1_0: !time/time-1.1.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
+t_iso_time_1_0_0: !time/time-1.0.0 {format: iso, value: '2025-10-14T13:26:41.0000'}
 ...

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -537,6 +537,112 @@ MU_TEST(test_asdf_time_versions) {
 }
 
 
+/**
+ * Check the jyear_str / byear_str formats: they parse identically to jyear /
+ * byear (from a J- / B-prefixed string), and are rejected for a numeric value.
+ */
+MU_TEST(test_asdf_time_jyear_byear_str) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const struct {
+        const char *key;
+        asdf_time_format_t expected_format;
+        int expected_year;
+    } cases[] = {
+        {"t_jyear_str", ASDF_TIME_FORMAT_JYEAR_STR, 2025},
+        {"t_byear_str", ASDF_TIME_FORMAT_BYEAR_STR, 2025},
+    };
+
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        const char *key = cases[idx].key;
+
+        asdf_value_t *value = asdf_get_value(file, key);
+        if (!value) {
+            munit_logf(MUNIT_LOG_ERROR, "failed to get value at '%s'", key);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+
+        if (err != ASDF_VALUE_OK) {
+            munit_logf(MUNIT_LOG_ERROR, "asdf_value_as_time failed for '%s'", key);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        assert_not_null(tm);
+        assert_int(tm->format, ==, cases[idx].expected_format);
+        assert_int(tm->info.tm.tm_year + 1900, ==, cases[idx].expected_year);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    /* A numeric value for jyear_str must be rejected. */
+    asdf_value_t *bad = asdf_get_value(file, "t_jyear_str_bad");
+    assert_not_null(bad);
+    asdf_time_t *tm_bad = NULL;
+    assert_int(asdf_value_as_time(bad, &tm_bad), !=, ASDF_VALUE_OK);
+    asdf_value_destroy(bad);
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Astropy-compatibility: a J-prefixed (Julian year) or B-prefixed (Besselian
+ * year) string value is serialized with the jyear_str / byear_str format even
+ * when stored as plain jyear / byear.
+ */
+MU_TEST(test_asdf_time_jyear_byear_str_serialize) {
+    const char *path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+
+    char jvalue[] = "J2000.0";
+    asdf_time_t jtime = {.value = jvalue, .format = ASDF_TIME_FORMAT_JYEAR};
+    assert_int(asdf_set_time(file, "t_jy", &jtime), ==, ASDF_VALUE_OK);
+
+    char bvalue[] = "B1950.0";
+    asdf_time_t btime = {.value = bvalue, .format = ASDF_TIME_FORMAT_BYEAR};
+    assert_int(asdf_set_time(file, "t_by", &btime), ==, ASDF_VALUE_OK);
+
+    assert_int(asdf_write_to(file, path), ==, 0);
+    asdf_close(file);
+
+    file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    asdf_time_t *t_out = NULL;
+    assert_int(asdf_get_time(file, "t_jy", &t_out), ==, ASDF_VALUE_OK);
+    assert_not_null(t_out);
+    /* jyear + "J..." was written as jyear_str, so it reads back as jyear_str */
+    assert_int(t_out->format, ==, ASDF_TIME_FORMAT_JYEAR_STR);
+    assert_string_equal(t_out->value, jvalue);
+    asdf_time_destroy(t_out);
+
+    t_out = NULL;
+    assert_int(asdf_get_time(file, "t_by", &t_out), ==, ASDF_VALUE_OK);
+    assert_not_null(t_out);
+    assert_int(t_out->format, ==, ASDF_TIME_FORMAT_BYEAR_STR);
+    assert_string_equal(t_out->value, bvalue);
+    asdf_time_destroy(t_out);
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     test_asdf_time_extension,
     MU_RUN_TEST(test_asdf_time),
@@ -548,7 +654,9 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_time_scale_roundtrip),
     MU_RUN_TEST(test_asdf_time_base_format),
     MU_RUN_TEST(test_asdf_time_base_format_roundtrip),
-    MU_RUN_TEST(test_asdf_time_versions)
+    MU_RUN_TEST(test_asdf_time_versions),
+    MU_RUN_TEST(test_asdf_time_jyear_byear_str),
+    MU_RUN_TEST(test_asdf_time_jyear_byear_str_serialize)
 );
 
 

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -141,7 +141,10 @@ MU_TEST(test_asdf_time_format_detection) {
         {"t_jyear_bare",    ASDF_TIME_FORMAT_JYEAR,     "J2025.78707178",           false},
         {"t_yday_bare",     ASDF_TIME_FORMAT_YDAY ,     "2025:287:13:26:41.0000",   true},
         /* mapping without explicit format key */
-        {"t_yday_map_no_format", ASDF_TIME_FORMAT_YDAY, "2025:287:13:26:41.0000",   true}
+        {"t_yday_map_no_format", ASDF_TIME_FORMAT_YDAY, "2025:287:13:26:41.0000",   true},
+        /* FITS long-year (signed, five-digit) is only auto-detected as fits;
+         * an ordinary four-digit value would be guessed as iso instead */
+        {"t_fits_long_bare", ASDF_TIME_FORMAT_FITS, "+12025-10-14T13:26:41.0000", true},
     };
 
     for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
@@ -210,6 +213,8 @@ MU_TEST(test_asdf_time_explicit_format_types) {
         {"t_unix",     ASDF_TIME_FORMAT_UNIX},
         {"t_jd",       ASDF_TIME_FORMAT_JD},
         {"t_mjd",      ASDF_TIME_FORMAT_MJD},
+        {"t_fits",     ASDF_TIME_FORMAT_FITS},
+        {"t_fits_long", ASDF_TIME_FORMAT_FITS},
     };
 
     for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
@@ -301,6 +306,42 @@ MU_TEST(test_asdf_time_jyear_decimalyear) {
         asdf_value_destroy(value);
     }
 
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Check the ``plot_date`` format (matplotlib ordinal days from an 0001-01-01
+ * UTC epoch): the numeric value is captured verbatim and the epoch offset
+ * resolves to the expected calendar instant.  739538.560197 is the same instant
+ * as the ``t_jd`` fixture (JD 2460963.060197), i.e. 2025-10-14 13:26:41 UTC.
+ */
+MU_TEST(test_asdf_time_plot_date) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    asdf_value_t *value = asdf_get_value(file, "t_plot_date");
+    assert_not_null(value);
+
+    asdf_time_t *tm = NULL;
+    asdf_value_err_t err = asdf_value_as_time(value, &tm);
+    assert_int(err, ==, ASDF_VALUE_OK);
+    assert_not_null(tm);
+
+    assert_string_equal(tm->value, "739538.560197");
+    assert_int(tm->format, ==, ASDF_TIME_FORMAT_PLOT_DATE);
+    assert_int(tm->info.tm.tm_year + 1900, ==, 2025);
+    assert_int(tm->info.tm.tm_mon + 1, ==, 10);
+    assert_int(tm->info.tm.tm_mday, ==, 14);
+    assert_int(tm->info.tm.tm_hour, ==, 13);
+    assert_int(tm->info.tm.tm_min, ==, 26);
+
+    asdf_time_destroy(tm);
+    asdf_value_destroy(value);
     asdf_close(file);
     return MUNIT_OK;
 }
@@ -490,6 +531,47 @@ MU_TEST(test_asdf_time_base_format_roundtrip) {
 
 
 /**
+ * Round-trip a ``fits`` time with the FITS "long" year form (an explicit sign
+ * plus five digits) to confirm the value string and format are preserved.
+ */
+MU_TEST(test_asdf_time_fits_roundtrip) {
+    const char *path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+
+    char time_value[] = "+12025-10-14T13:26:41.0000";
+    asdf_time_t time_obj = {
+        .value = time_value,
+        .format = ASDF_TIME_FORMAT_FITS,
+        .scale = ASDF_TIME_SCALE_UTC,
+    };
+
+    asdf_value_err_t err = asdf_set_time(file, "t_fits", &time_obj);
+    assert_int(err, ==, ASDF_VALUE_OK);
+
+    assert_int(asdf_write_to(file, path), ==, 0);
+    asdf_close(file);
+
+    file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    asdf_time_t *t_out = NULL;
+    err = asdf_get_time(file, "t_fits", &t_out);
+    assert_int(err, ==, ASDF_VALUE_OK);
+    assert_not_null(t_out);
+    assert_int(t_out->format, ==, ASDF_TIME_FORMAT_FITS);
+    assert_string_equal(t_out->value, "+12025-10-14T13:26:41.0000");
+
+    asdf_time_destroy(t_out);
+    asdf_close(file);
+
+    return MUNIT_OK;
+}
+
+
+/**
  * Check that time values tagged with older schema versions (time-1.0.0,
  * time-1.1.0) are still recognized and deserialized.
  */
@@ -651,10 +733,12 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_time_format_detection),
     MU_RUN_TEST(test_asdf_time_explicit_format_types),
     MU_RUN_TEST(test_asdf_time_jyear_decimalyear),
+    MU_RUN_TEST(test_asdf_time_plot_date),
     MU_RUN_TEST(test_asdf_time_scale),
     MU_RUN_TEST(test_asdf_time_scale_roundtrip),
     MU_RUN_TEST(test_asdf_time_base_format),
     MU_RUN_TEST(test_asdf_time_base_format_roundtrip),
+    MU_RUN_TEST(test_asdf_time_fits_roundtrip),
     MU_RUN_TEST(test_asdf_time_versions),
     MU_RUN_TEST(test_asdf_time_jyear_byear_str),
     MU_RUN_TEST(test_asdf_time_jyear_byear_str_serialize)

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -212,6 +212,9 @@ MU_TEST(test_asdf_time_explicit_format_types) {
         {"t_mjd",      ASDF_TIME_FORMAT_MJD},
         {"t_fits",     ASDF_TIME_FORMAT_FITS},
         {"t_fits_long", ASDF_TIME_FORMAT_FITS},
+        {"t_ymdhms",   ASDF_TIME_FORMAT_YMDHMS},
+        {"t_ymdhms_liberal", ASDF_TIME_FORMAT_YMDHMS},
+        {"t_datetime64", ASDF_TIME_FORMAT_DATETIME64},
     };
 
     for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
@@ -404,6 +407,125 @@ MU_TEST(test_asdf_time_epoch_seconds) {
     }
 
     asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Check ymdhms and datetime64: neither has a scalar ASDF representation of its
+ * own, so both are stored (like isot) as an ISO string with the real format in
+ * base_format.  Verify the effective format and that the instant parses, from
+ * the base_format form and the liberal explicit-format form.
+ */
+MU_TEST(test_asdf_time_ymdhms_datetime64) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const struct {
+        const char *key;
+        asdf_time_format_t expected_format;
+    } cases[] = {
+        {"t_ymdhms", ASDF_TIME_FORMAT_YMDHMS},
+        {"t_ymdhms_liberal", ASDF_TIME_FORMAT_YMDHMS},
+        {"t_datetime64", ASDF_TIME_FORMAT_DATETIME64},
+    };
+
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        asdf_value_t *value = asdf_get_value(file, cases[idx].key);
+        assert_not_null(value);
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+        assert_int(err, ==, ASDF_VALUE_OK);
+        assert_not_null(tm);
+
+        assert_int(tm->format, ==, cases[idx].expected_format);
+        assert_int(tm->info.tm.tm_year + 1900, ==, 2025);
+        assert_int(tm->info.tm.tm_mon + 1, ==, 10);
+        assert_int(tm->info.tm.tm_mday, ==, 14);
+        assert_int(tm->info.tm.tm_hour, ==, 13);
+        assert_int(tm->info.tm.tm_min, ==, 26);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Round-trip plot_date in both value representations:
+ *
+ *   1. a raw numeric value is reformatted to an ISO string on write (and the
+ *      written mapping is schema-valid: no format key, base_format: plot_date);
+ *   2. a value already in ISO-string form (as read back from the base_format
+ *      form) is written verbatim; regression test against re-parsing the
+ *      ISO string as a plot_date float.
+ *
+ * Both resolve to 2025-10-14 13:26:41.
+ */
+MU_TEST(test_asdf_time_plot_date_roundtrip) {
+    static const char *const values[] = {
+        "739538.560197", /* numeric -> reformatted */
+        "2025-10-14T13:26:41.0000" /* already ISO -> verbatim */
+    };
+
+    for (size_t idx = 0; idx < sizeof(values) / sizeof(values[0]); idx++) {
+        const char *path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
+        assert_not_null(path);
+
+        asdf_file_t *file = asdf_open(NULL);
+        assert_not_null(file);
+
+        char value_buf[64];
+        strncpy(value_buf, values[idx], sizeof(value_buf) - 1);
+        value_buf[sizeof(value_buf) - 1] = '\0';
+        asdf_time_t time_obj = {
+            .value = value_buf,
+            .format = ASDF_TIME_FORMAT_PLOT_DATE,
+            .scale = ASDF_TIME_SCALE_UTC,
+        };
+        assert_int(asdf_set_time(file, "t_plot_date", &time_obj), ==, ASDF_VALUE_OK);
+        assert_int(asdf_write_to(file, path), ==, 0);
+        asdf_close(file);
+
+        file = asdf_open(path, "r");
+        assert_not_null(file);
+
+        /* Written mapping is schema-valid: no format key, base_format plot_date. */
+        asdf_value_t *raw = asdf_get_value(file, "t_plot_date");
+        assert_not_null(raw);
+        asdf_mapping_t *map = NULL;
+        assert_int(asdf_value_as_mapping(raw, &map), ==, ASDF_VALUE_OK);
+        assert_null(asdf_mapping_get(map, "format"));
+        asdf_value_t *bf = asdf_mapping_get(map, "base_format");
+        assert_not_null(bf);
+        const char *bf_s = NULL;
+        assert_int(asdf_value_as_string0(bf, &bf_s), ==, ASDF_VALUE_OK);
+        assert_string_equal(bf_s, "plot_date");
+        asdf_value_destroy(bf);
+        asdf_value_destroy(raw);
+
+        /* Reads back as plot_date at the expected instant. */
+        asdf_time_t *t_out = NULL;
+        assert_int(asdf_get_time(file, "t_plot_date", &t_out), ==, ASDF_VALUE_OK);
+        assert_not_null(t_out);
+        assert_int(t_out->format, ==, ASDF_TIME_FORMAT_PLOT_DATE);
+        assert_int(t_out->info.tm.tm_year + 1900, ==, 2025);
+        assert_int(t_out->info.tm.tm_mon + 1, ==, 10);
+        assert_int(t_out->info.tm.tm_mday, ==, 14);
+        assert_int(t_out->info.tm.tm_hour, ==, 13);
+        assert_int(t_out->info.tm.tm_min, ==, 26);
+
+        asdf_time_destroy(t_out);
+        asdf_close(file);
+    }
+
     return MUNIT_OK;
 }
 
@@ -820,7 +942,9 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_time_explicit_format_types),
     MU_RUN_TEST(test_asdf_time_jyear_decimalyear),
     MU_RUN_TEST(test_asdf_time_plot_date),
+    MU_RUN_TEST(test_asdf_time_plot_date_roundtrip),
     MU_RUN_TEST(test_asdf_time_epoch_seconds),
+    MU_RUN_TEST(test_asdf_time_ymdhms_datetime64),
     MU_RUN_TEST(test_asdf_time_scale),
     MU_RUN_TEST(test_asdf_time_scale_roundtrip),
     MU_RUN_TEST(test_asdf_time_base_format),

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -23,7 +23,7 @@ MU_TEST(test_asdf_time) {
     char time_str[255] = {0};
 
     const char *fixture_keys[] = {
-        "t_iso_time",
+        "t_iso",
         "t_datetime",
         "t_yday",
         "t_unix",
@@ -136,7 +136,7 @@ MU_TEST(test_asdf_time_format_detection) {
         bool check_ts;
     } cases[] = {
         /* bare scalars: format must be inferred from value string */
-        {"t_iso_time_bare", ASDF_TIME_FORMAT_ISO,  "2025-10-14T13:26:41.0000", true},
+        {"t_iso_bare", ASDF_TIME_FORMAT_ISO,  "2025-10-14T13:26:41.0000", true},
         {"t_byear_bare",    ASDF_TIME_FORMAT_BYEAR,     "B2025.78707178",           true},
         {"t_jyear_bare",    ASDF_TIME_FORMAT_JYEAR,     "J2025.78707178",           false},
         {"t_yday_bare",     ASDF_TIME_FORMAT_YDAY ,     "2025:287:13:26:41.0000",   true},
@@ -202,7 +202,8 @@ MU_TEST(test_asdf_time_explicit_format_types) {
         const char *key;
         asdf_time_format_t expected_format;
     } cases[] = {
-        {"t_iso_time", ASDF_TIME_FORMAT_ISO},
+        {"t_iso", ASDF_TIME_FORMAT_ISO},
+        {"t_isot",     ASDF_TIME_FORMAT_ISOT},
         {"t_datetime", ASDF_TIME_FORMAT_DATETIME},
         {"t_yday",     ASDF_TIME_FORMAT_YDAY},
         {"t_byear",    ASDF_TIME_FORMAT_BYEAR},
@@ -320,8 +321,8 @@ MU_TEST(test_asdf_time_scale) {
         const char *key;
         asdf_time_scale_t expected_scale;
     } cases[] = {
-        {"t_iso_time_tai", ASDF_TIME_SCALE_TAI},
-        {"t_iso_time",     ASDF_TIME_SCALE_UTC},
+        {"t_iso_tai", ASDF_TIME_SCALE_TAI},
+        {"t_iso",     ASDF_TIME_SCALE_UTC},
     };
 
     for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
@@ -412,7 +413,7 @@ MU_TEST(test_asdf_time_base_format) {
         asdf_time_format_t expected_base_format;
     } cases[] = {
         {"t_iso_base_format", ASDF_TIME_FORMAT_DATETIME},
-        {"t_iso_time", ASDF_TIME_FORMAT_NONE},
+        {"t_iso", ASDF_TIME_FORMAT_NONE},
     };
 
     for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
@@ -500,8 +501,8 @@ MU_TEST(test_asdf_time_versions) {
     assert_not_null(file);
 
     static const char *const keys[] = {
-        "t_iso_time_1_1_0",
-        "t_iso_time_1_0_0",
+        "t_iso_1_1_0",
+        "t_iso_1_0_0",
     };
 
     for (size_t idx = 0; idx < sizeof(keys) / sizeof(keys[0]); idx++) {

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -358,6 +358,57 @@ MU_TEST(test_asdf_time_plot_date) {
 
 
 /**
+ * Check the "seconds from epoch" formats (gps, unix_tai, cxcsec, galexsec,
+ * tai_seconds, utime).  Each fixture value is chosen to resolve to the same
+ * instant (2025-10-14 13:26:41), confirming the correct epoch is applied.  (The
+ * TAI/TT-scale formats ignore the leap-second offset, per the parser's
+ * best-effort treatment.)
+ */
+MU_TEST(test_asdf_time_epoch_seconds) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const struct {
+        const char *key;
+        asdf_time_format_t expected_format;
+    } cases[] = {
+        {"t_gps", ASDF_TIME_FORMAT_GPS},
+        {"t_unix_tai", ASDF_TIME_FORMAT_UNIX_TAI},
+        {"t_cxcsec", ASDF_TIME_FORMAT_CXCSEC},
+        {"t_galexsec", ASDF_TIME_FORMAT_GALEXSEC},
+        {"t_tai_seconds", ASDF_TIME_FORMAT_TAI_SECONDS},
+        {"t_utime", ASDF_TIME_FORMAT_UTIME},
+    };
+
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        asdf_value_t *value = asdf_get_value(file, cases[idx].key);
+        assert_not_null(value);
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+        assert_int(err, ==, ASDF_VALUE_OK);
+        assert_not_null(tm);
+
+        assert_int(tm->format, ==, cases[idx].expected_format);
+        assert_int(tm->info.tm.tm_year + 1900, ==, 2025);
+        assert_int(tm->info.tm.tm_mon + 1, ==, 10);
+        assert_int(tm->info.tm.tm_mday, ==, 14);
+        assert_int(tm->info.tm.tm_hour, ==, 13);
+        assert_int(tm->info.tm.tm_min, ==, 26);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
  * Check that the optional ``scale`` mapping key is parsed (and defaults to UTC
  * when absent).
  */
@@ -769,6 +820,7 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_time_explicit_format_types),
     MU_RUN_TEST(test_asdf_time_jyear_decimalyear),
     MU_RUN_TEST(test_asdf_time_plot_date),
+    MU_RUN_TEST(test_asdf_time_epoch_seconds),
     MU_RUN_TEST(test_asdf_time_scale),
     MU_RUN_TEST(test_asdf_time_scale_roundtrip),
     MU_RUN_TEST(test_asdf_time_base_format),

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -81,7 +81,8 @@ MU_TEST(test_asdf_time_serialize) {
     char time_value[] = "2025-10-14T13:26:41.0000";
     asdf_time_t time_obj = {
         .value = time_value,
-        .format = ASDF_TIME_FORMAT_ISO_TIME,
+        .format = ASDF_TIME_FORMAT_ISO,
+        /* base_format left unset (zero-init), must read back as NONE */
         .scale = ASDF_TIME_SCALE_UTC,
     };
 
@@ -103,7 +104,9 @@ MU_TEST(test_asdf_time_serialize) {
     assert_not_null(t_out);
     assert_not_null(t_out->value);
     assert_string_equal(t_out->value, time_value);
-    assert_int(t_out->format, ==, ASDF_TIME_FORMAT_ISO_TIME);
+    assert_int(t_out->format, ==, ASDF_TIME_FORMAT_ISO);
+    /* base_format was NONE, so it should be omitted and read back as NONE */
+    assert_int(t_out->base_format, ==, ASDF_TIME_FORMAT_NONE);
 
     asdf_time_destroy(t_out);
     asdf_close(file);
@@ -133,7 +136,7 @@ MU_TEST(test_asdf_time_format_detection) {
         bool check_ts;
     } cases[] = {
         /* bare scalars: format must be inferred from value string */
-        {"t_iso_time_bare", ASDF_TIME_FORMAT_ISO_TIME,  "2025-10-14T13:26:41.0000", true},
+        {"t_iso_time_bare", ASDF_TIME_FORMAT_ISO,  "2025-10-14T13:26:41.0000", true},
         {"t_byear_bare",    ASDF_TIME_FORMAT_BYEAR,     "B2025.78707178",           true},
         {"t_jyear_bare",    ASDF_TIME_FORMAT_JYEAR,     "J2025.78707178",           false},
         {"t_yday_bare",     ASDF_TIME_FORMAT_YDAY ,     "2025:287:13:26:41.0000",   true},
@@ -199,7 +202,7 @@ MU_TEST(test_asdf_time_explicit_format_types) {
         const char *key;
         asdf_time_format_t expected_format;
     } cases[] = {
-        {"t_iso_time", ASDF_TIME_FORMAT_ISO_TIME},
+        {"t_iso_time", ASDF_TIME_FORMAT_ISO},
         {"t_datetime", ASDF_TIME_FORMAT_DATETIME},
         {"t_yday",     ASDF_TIME_FORMAT_YDAY},
         {"t_byear",    ASDF_TIME_FORMAT_BYEAR},
@@ -367,7 +370,7 @@ MU_TEST(test_asdf_time_scale_roundtrip) {
     char time_value[] = "2025-10-14T13:26:41.0000";
     asdf_time_t time_obj = {
         .value = time_value,
-        .format = ASDF_TIME_FORMAT_ISO_TIME,
+        .format = ASDF_TIME_FORMAT_ISO,
         .scale = ASDF_TIME_SCALE_TAI,
     };
 
@@ -393,6 +396,147 @@ MU_TEST(test_asdf_time_scale_roundtrip) {
 }
 
 
+/**
+ * Check that the optional ``base_format`` mapping key is parsed (to the matching
+ * format enum when present, and ASDF_TIME_FORMAT_NONE when absent).
+ */
+MU_TEST(test_asdf_time_base_format) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const struct {
+        const char *key;
+        asdf_time_format_t expected_base_format;
+    } cases[] = {
+        {"t_iso_base_format", ASDF_TIME_FORMAT_DATETIME},
+        {"t_iso_time", ASDF_TIME_FORMAT_NONE},
+    };
+
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        const char *key = cases[idx].key;
+
+        asdf_value_t *value = asdf_get_value(file, key);
+        if (!value) {
+            munit_logf(MUNIT_LOG_ERROR, "failed to get value at '%s'", key);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+
+        if (err != ASDF_VALUE_OK) {
+            munit_logf(MUNIT_LOG_ERROR, "asdf_value_as_time failed for '%s'", key);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        assert_not_null(tm);
+        assert_int(tm->base_format, ==, cases[idx].expected_base_format);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
+/**
+ * Round-trip a ``base_format`` through serialize + deserialize to confirm it is
+ * both written and read back correctly.
+ */
+MU_TEST(test_asdf_time_base_format_roundtrip) {
+    const char *path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(NULL);
+    assert_not_null(file);
+
+    char time_value[] = "2025-10-14T13:26:41.0000";
+    asdf_time_t time_obj = {
+        .value = time_value,
+        .format = ASDF_TIME_FORMAT_ISO,
+        .base_format = ASDF_TIME_FORMAT_DATETIME,
+        .scale = ASDF_TIME_SCALE_UTC,
+    };
+
+    asdf_value_err_t err = asdf_set_time(file, "t_base", &time_obj);
+    assert_int(err, ==, ASDF_VALUE_OK);
+
+    assert_int(asdf_write_to(file, path), ==, 0);
+    asdf_close(file);
+
+    file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    asdf_time_t *t_out = NULL;
+    err = asdf_get_time(file, "t_base", &t_out);
+    assert_int(err, ==, ASDF_VALUE_OK);
+    assert_not_null(t_out);
+    assert_int(t_out->base_format, ==, ASDF_TIME_FORMAT_DATETIME);
+
+    asdf_time_destroy(t_out);
+    asdf_close(file);
+
+    return MUNIT_OK;
+}
+
+
+/**
+ * Check that time values tagged with older schema versions (time-1.0.0,
+ * time-1.1.0) are still recognized and deserialized.
+ */
+MU_TEST(test_asdf_time_versions) {
+    const char *path = get_fixture_file_path("time.asdf");
+    assert_not_null(path);
+
+    asdf_file_t *file = asdf_open(path, "r");
+    assert_not_null(file);
+
+    static const char *const keys[] = {
+        "t_iso_time_1_1_0",
+        "t_iso_time_1_0_0",
+    };
+
+    for (size_t idx = 0; idx < sizeof(keys) / sizeof(keys[0]); idx++) {
+        const char *key = keys[idx];
+        assert_true(asdf_is_time(file, key));
+
+        asdf_value_t *value = asdf_get_value(file, key);
+        if (!value) {
+            munit_logf(MUNIT_LOG_ERROR, "failed to get value at '%s'", key);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+
+        if (err != ASDF_VALUE_OK) {
+            munit_logf(MUNIT_LOG_ERROR, "asdf_value_as_time failed for '%s'", key);
+            asdf_value_destroy(value);
+            asdf_close(file);
+            return MUNIT_FAIL;
+        }
+
+        assert_not_null(tm);
+        assert_int(tm->format, ==, ASDF_TIME_FORMAT_ISO);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
+    asdf_close(file);
+    return MUNIT_OK;
+}
+
+
 MU_TEST_SUITE(
     test_asdf_time_extension,
     MU_RUN_TEST(test_asdf_time),
@@ -401,7 +545,10 @@ MU_TEST_SUITE(
     MU_RUN_TEST(test_asdf_time_explicit_format_types),
     MU_RUN_TEST(test_asdf_time_jyear_decimalyear),
     MU_RUN_TEST(test_asdf_time_scale),
-    MU_RUN_TEST(test_asdf_time_scale_roundtrip)
+    MU_RUN_TEST(test_asdf_time_scale_roundtrip),
+    MU_RUN_TEST(test_asdf_time_base_format),
+    MU_RUN_TEST(test_asdf_time_base_format_roundtrip),
+    MU_RUN_TEST(test_asdf_time_versions)
 );
 
 

--- a/tests/test-time.c
+++ b/tests/test-time.c
@@ -82,7 +82,6 @@ MU_TEST(test_asdf_time_serialize) {
     asdf_time_t time_obj = {
         .value = time_value,
         .format = ASDF_TIME_FORMAT_ISO,
-        /* base_format left unset (zero-init), must read back as NONE */
         .scale = ASDF_TIME_SCALE_UTC,
     };
 
@@ -105,8 +104,6 @@ MU_TEST(test_asdf_time_serialize) {
     assert_not_null(t_out->value);
     assert_string_equal(t_out->value, time_value);
     assert_int(t_out->format, ==, ASDF_TIME_FORMAT_ISO);
-    /* base_format was NONE, so it should be omitted and read back as NONE */
-    assert_int(t_out->base_format, ==, ASDF_TIME_FORMAT_NONE);
 
     asdf_time_destroy(t_out);
     asdf_close(file);
@@ -313,9 +310,11 @@ MU_TEST(test_asdf_time_jyear_decimalyear) {
 
 /**
  * Check the ``plot_date`` format (matplotlib ordinal days from an 0001-01-01
- * UTC epoch): the numeric value is captured verbatim and the epoch offset
- * resolves to the expected calendar instant.  739538.560197 is the same instant
- * as the ``t_jd`` fixture (JD 2460963.060197), i.e. 2025-10-14 13:26:41 UTC.
+ * UTC epoch).  Two forms resolve to the effective PLOT_DATE format and the same
+ * instant (2025-10-14 13:26:41 UTC, the ``t_jd`` fixture JD 2460963.060197):
+ *   - the schema-valid form ``{value: <iso string>, base_format: plot_date}``
+ *   - the liberal numeric form ``{format: plot_date, value: 739538.560197}``,
+ *     which exercises the epoch-offset math in the parser.
  */
 MU_TEST(test_asdf_time_plot_date) {
     const char *path = get_fixture_file_path("time.asdf");
@@ -324,24 +323,35 @@ MU_TEST(test_asdf_time_plot_date) {
     asdf_file_t *file = asdf_open(path, "r");
     assert_not_null(file);
 
-    asdf_value_t *value = asdf_get_value(file, "t_plot_date");
-    assert_not_null(value);
+    static const struct {
+        const char *key;
+        const char *expected_value;
+    } cases[] = {
+        {"t_plot_date", "2025-10-14T13:26:41.0000"},
+        {"t_plot_date_num", "739538.560197"},
+    };
 
-    asdf_time_t *tm = NULL;
-    asdf_value_err_t err = asdf_value_as_time(value, &tm);
-    assert_int(err, ==, ASDF_VALUE_OK);
-    assert_not_null(tm);
+    for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
+        asdf_value_t *value = asdf_get_value(file, cases[idx].key);
+        assert_not_null(value);
 
-    assert_string_equal(tm->value, "739538.560197");
-    assert_int(tm->format, ==, ASDF_TIME_FORMAT_PLOT_DATE);
-    assert_int(tm->info.tm.tm_year + 1900, ==, 2025);
-    assert_int(tm->info.tm.tm_mon + 1, ==, 10);
-    assert_int(tm->info.tm.tm_mday, ==, 14);
-    assert_int(tm->info.tm.tm_hour, ==, 13);
-    assert_int(tm->info.tm.tm_min, ==, 26);
+        asdf_time_t *tm = NULL;
+        asdf_value_err_t err = asdf_value_as_time(value, &tm);
+        assert_int(err, ==, ASDF_VALUE_OK);
+        assert_not_null(tm);
 
-    asdf_time_destroy(tm);
-    asdf_value_destroy(value);
+        assert_string_equal(tm->value, cases[idx].expected_value);
+        assert_int(tm->format, ==, ASDF_TIME_FORMAT_PLOT_DATE);
+        assert_int(tm->info.tm.tm_year + 1900, ==, 2025);
+        assert_int(tm->info.tm.tm_mon + 1, ==, 10);
+        assert_int(tm->info.tm.tm_mday, ==, 14);
+        assert_int(tm->info.tm.tm_hour, ==, 13);
+        assert_int(tm->info.tm.tm_min, ==, 26);
+
+        asdf_time_destroy(tm);
+        asdf_value_destroy(value);
+    }
+
     asdf_close(file);
     return MUNIT_OK;
 }
@@ -439,8 +449,11 @@ MU_TEST(test_asdf_time_scale_roundtrip) {
 
 
 /**
- * Check that the optional ``base_format`` mapping key is parsed (to the matching
- * format enum when present, and ASDF_TIME_FORMAT_NONE when absent).
+ * Check that the optional ``base_format`` key overrides the wire ``format`` as
+ * the effective ``time->format``: a ``base_format`` value (whether an explicit
+ * ``format``/``base_format`` pair, or an "other" format written with ``format``
+ * omitted) collapses into the single effective format.  When absent, the
+ * effective format is the wire/guessed format.
  */
 MU_TEST(test_asdf_time_base_format) {
     const char *path = get_fixture_file_path("time.asdf");
@@ -451,10 +464,14 @@ MU_TEST(test_asdf_time_base_format) {
 
     static const struct {
         const char *key;
-        asdf_time_format_t expected_base_format;
+        asdf_time_format_t expected_format;
     } cases[] = {
+        /* explicit format: iso + base_format: datetime -> effective datetime */
         {"t_iso_base_format", ASDF_TIME_FORMAT_DATETIME},
-        {"t_iso", ASDF_TIME_FORMAT_NONE},
+        /* format omitted, base_format: fits -> effective fits */
+        {"t_fits", ASDF_TIME_FORMAT_FITS},
+        /* no base_format -> effective is the wire format */
+        {"t_iso", ASDF_TIME_FORMAT_ISO},
     };
 
     for (size_t idx = 0; idx < sizeof(cases) / sizeof(cases[0]); idx++) {
@@ -478,7 +495,7 @@ MU_TEST(test_asdf_time_base_format) {
         }
 
         assert_not_null(tm);
-        assert_int(tm->base_format, ==, cases[idx].expected_base_format);
+        assert_int(tm->format, ==, cases[idx].expected_format);
 
         asdf_time_destroy(tm);
         asdf_value_destroy(value);
@@ -490,8 +507,10 @@ MU_TEST(test_asdf_time_base_format) {
 
 
 /**
- * Round-trip a ``base_format`` through serialize + deserialize to confirm it is
- * both written and read back correctly.
+ * Round-trip an "other" format (``datetime``) and confirm the *written* mapping
+ * is schema-valid: the ``format`` field is omitted (its guessable wire format
+ * is re-inferred on read) and the real format is recorded in ``base_format``.
+ * It must then read back as the effective ``datetime`` format.
  */
 MU_TEST(test_asdf_time_base_format_roundtrip) {
     const char *path = get_temp_file_path(fixture->tempfile_prefix, ".asdf");
@@ -503,8 +522,7 @@ MU_TEST(test_asdf_time_base_format_roundtrip) {
     char time_value[] = "2025-10-14T13:26:41.0000";
     asdf_time_t time_obj = {
         .value = time_value,
-        .format = ASDF_TIME_FORMAT_ISO,
-        .base_format = ASDF_TIME_FORMAT_DATETIME,
+        .format = ASDF_TIME_FORMAT_DATETIME,
         .scale = ASDF_TIME_SCALE_UTC,
     };
 
@@ -517,11 +535,28 @@ MU_TEST(test_asdf_time_base_format_roundtrip) {
     file = asdf_open(path, "r");
     assert_not_null(file);
 
+    /* Inspect the raw mapping: no "format" key (omitted, guessable), and
+     * base_format carries the real "other" format, i.e. schema-valid. */
+    asdf_value_t *raw = asdf_get_value(file, "t_base");
+    assert_not_null(raw);
+    asdf_mapping_t *map = NULL;
+    assert_int(asdf_value_as_mapping(raw, &map), ==, ASDF_VALUE_OK);
+    assert_null(asdf_mapping_get(map, "format"));
+    asdf_value_t *bf = asdf_mapping_get(map, "base_format");
+    assert_not_null(bf);
+    const char *bf_str = NULL;
+    assert_int(asdf_value_as_string0(bf, &bf_str), ==, ASDF_VALUE_OK);
+    assert_string_equal(bf_str, "datetime");
+    asdf_value_destroy(bf);
+    asdf_value_destroy(raw);
+
+    /* And it reads back as the effective datetime format. */
     asdf_time_t *t_out = NULL;
     err = asdf_get_time(file, "t_base", &t_out);
     assert_int(err, ==, ASDF_VALUE_OK);
     assert_not_null(t_out);
-    assert_int(t_out->base_format, ==, ASDF_TIME_FORMAT_DATETIME);
+    assert_int(t_out->format, ==, ASDF_TIME_FORMAT_DATETIME);
+    assert_string_equal(t_out->value, time_value);
 
     asdf_time_destroy(t_out);
     asdf_close(file);


### PR DESCRIPTION
## Description

Resolves #233 , adding support from time<=1.4.0, and the `base_format` property for time>=1.2.

In scrutinizing the schemas I noticed that the `iso` format was mishandled--it's just called `iso`, not `iso_time` (I think that name might have been accidentally read from the defines).

Resolves #208 as well, except for time array handling which is deferred to #237 

## AI Disclosure
No AI tools used.