### PR TITLE
build: try to port the M4 ASDF_CHECK_HOMEBREW_PKG macro to CMake

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,9 +107,7 @@ jobs:
 
       - name: Dist check
         run: |
-          hbroot=/opt/homebrew
-          CMAKE_EXTRA_FLAGS="-DARGP_NO_PKGCONFIG=YES -DARGP_LIBDIR=${hbroot}/lib -DARGP_INCLUDEDIR=${hbroot}/include"
-          make distcheck ${{ github.event.inputs.make_flags }} CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}"
+          make distcheck ${{ github.event.inputs.make_flags }}
 
   # Test the documentation build if the build passes
   docs:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -104,14 +104,10 @@ jobs:
         mkdir -p build
         cd build
         export SDKROOT="$(xcrun --show-sdk-path)"
-        hbroot=/opt/homebrew
         cmake .. \
           -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
           -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PREFIX }} \
           -DENABLE_TESTING_ALL=YES \
-          -DARGP_NO_PKGCONFIG=YES \
-          -DARGP_LIBDIR=${hbroot}/lib \
-          -DARGP_INCLUDEDIR=${hbroot}/include \
           ${{ matrix.cmake_options }} \
           ${{ github.event.inputs.cmake_flags }}
         make VERBOSE=1 ${{ github.event.inputs.make_flags }}

--- a/README.rst
+++ b/README.rst
@@ -201,7 +201,7 @@ The next example shows how to read back in the same file:
        // read and print the numeric value stored under "foo"
        int64_t foo = 0;
        if (asdf_get_int64(file, "foo", &foo) == ASDF_VALUE_OK) {
-           printf("foo: %li\n", foo);
+           printf("foo: %lli\n", foo);
        }
    
        // read the "squares" array nested under the "powers" key
@@ -215,7 +215,7 @@ The next example shows how to read back in the same file:
                for (uint64_t idx = 0; idx < nelem; idx++) {
                    sum += squares_data[idx];
                }
-               printf("sum of squares values: %li\n", sum);
+               printf("sum of squares values: %llu\n", sum);
            }
        }
    

--- a/README.rst
+++ b/README.rst
@@ -311,9 +311,10 @@ Clone the repository and build the project as follows::
     make
     sudo make install   # Optional, installs the binary system-wide
 
-If doing a system install, as usual it's recommended to install to ``/usr/local``
-by providing ``-DCMAKE_INSTALL_PREFIX=/usr/local`` when running ``cmake``.  Or, if you
-have a ``${HOME}/.local`` you can set the prefix there, etc.
+If doing a system install, as usual it's recommended to install to
+``/usr/local`` by providing ``-DCMAKE_INSTALL_PREFIX=/usr/local`` when running
+``cmake``.  Or, if you have a ``${HOME}/.local`` you can set the prefix there,
+etc.
 
 Logging
 ^^^^^^^

--- a/cmake/ASDFDependencies.cmake
+++ b/cmake/ASDFDependencies.cmake
@@ -1,3 +1,49 @@
+# asdf_check_homebrew_pkg(<PREFIX> <package>)
+#
+# Detect a Homebrew-installed package on macOS (or Linux if you for some
+# reason use Homebrew on Linux) and populate cache-style variables analogous
+# to pkg_check_modules:
+#
+#   <PREFIX>_FOUND       -- TRUE if the package was found via Homebrew
+#   <PREFIX>_PREFIX      -- Homebrew prefix for the package
+#   <PREFIX>_INCLUDEDIR  -- <prefix>/include
+#   <PREFIX>_LIBDIR      -- <prefix>/lib
+#
+# This is a fallback for packages that ship without a pkg-config (.pc) file,
+# such as the Homebrew argp-standalone formula.  It is a no-op (aside from a
+# status message) if the brew program cannot be found.
+function(asdf_check_homebrew_pkg prefix package)
+    message(STATUS "Checking for Homebrew package '${package}'")
+
+    find_program(BREW_PROGRAM brew)
+    if(NOT BREW_PROGRAM)
+        message(STATUS "  Homebrew (brew) not found; cannot check for package '${package}'")
+        set(${prefix}_FOUND FALSE PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(
+        COMMAND ${BREW_PROGRAM} --prefix --installed ${package}
+        OUTPUT_VARIABLE brew_prefix
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE brew_result
+        ERROR_QUIET
+    )
+
+    if(NOT brew_result EQUAL 0 OR brew_prefix STREQUAL "")
+        message(STATUS "  Package '${package}' not found. Try: brew install ${package}")
+        set(${prefix}_FOUND FALSE PARENT_SCOPE)
+        return()
+    endif()
+
+    message(STATUS "  Found Homebrew package '${package}' at ${brew_prefix}")
+    set(${prefix}_FOUND TRUE PARENT_SCOPE)
+    set(${prefix}_PREFIX "${brew_prefix}" PARENT_SCOPE)
+    set(${prefix}_INCLUDEDIR "${brew_prefix}/include" PARENT_SCOPE)
+    set(${prefix}_LIBDIR "${brew_prefix}/lib" PARENT_SCOPE)
+endfunction()
+
+
 option(BZIP2_NO_PKGCONFIG NO)
 # Ubuntu decided not to provide a bzip2 pkg-config file
 # Uses the find_package function instead.
@@ -84,9 +130,28 @@ if(ENABLE_TOOL AND APPLE)
         set(ARGP_LDFLAGS "" CACHE STRING "Linker options for libargp")
     else()
         if(PKG_CONFIG_FOUND)
-            pkg_check_modules(ARGP libargp REQUIRED)
+            pkg_check_modules(ARGP libargp)
         else()
             message("pkg-config not found. Install pkg-config, or use ARGP_NO_PKGCONFIG=YES.")
+        endif()
+
+        # The Homebrew argp-standalone formula currently ships without a
+        # pkg-config (.pc) file, so fall back on locating it via Homebrew
+        # directly.  This can be dropped once argp-standalone provides a .pc
+        # file upstream; see https://github.com/asdf-format/libasdf/issues/176
+        # for the ongoing saga.
+        if(NOT ARGP_FOUND)
+            asdf_check_homebrew_pkg(ARGP argp-standalone)
+            if(ARGP_FOUND)
+                set(ARGP_LIBRARIES "argp")
+            endif()
+        endif()
+
+        if(NOT ARGP_FOUND)
+            message(FATAL_ERROR
+                "argp is required for the command-line tool but was not found. "
+                "Install argp-standalone (e.g. 'brew install argp-standalone'), "
+                "or disable the tool with -DENABLE_TOOL=OFF.")
         endif()
     endif()
 endif()

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,17 +1,14 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-/* Enable color output in logs */
-#cmakedefine ASDF_LOG_COLOR
-
-/* Default runtime log level */
-#define ASDF_LOG_DEFAULT_LEVEL ASDF_LOG_@LOG_DEFAULT@
-
-/* Enable logging */
-#cmakedefine ASDF_LOG_ENABLED
-
-/* Compile-time minimum log level */
-#define ASDF_LOG_MIN_LEVEL ASDF_LOG_@LOG_MIN@
+/*
+ * The ASDF_LOG_* and ASDF_HAVE_FLOAT16 macros are part of the installed
+ * public configuration and are defined in asdf/config.h.  Include it here
+ * rather than duplicating those definitions, which otherwise leads to
+ * -Wmacro-redefined warnings in any translation unit that also pulls in the
+ * public header.
+ */
+#include "asdf/config.h"
 
 /* Name of package */
 #define PACKAGE "@PACKAGE_NAME@"

--- a/configure.ac
+++ b/configure.ac
@@ -176,20 +176,12 @@ AC_ARG_ENABLE([logging],
   [enable_logging=yes]
 )
 
-AS_IF([test "x$enable_logging" = "xyes"],
-  [AC_DEFINE([ASDF_LOG_ENABLED], [1], [Enable logging])]
-)
-
 AC_ARG_ENABLE([log-color],
   [AS_HELP_STRING([--enable-log-color],
                   [Enable color output in logs (default: yes)])],
   [enable_log_color=$enableval],
   [enable_log_color=yes]
 )
-
-if test "x$enable_log_color" = "xyes"; then
-  AC_DEFINE([ASDF_LOG_COLOR], [1], [Enable color output in logs])
-fi
 
 AC_ARG_WITH([log-default],
   [AS_HELP_STRING([--with-log-default=LEVEL], [Set default runtime log level])],
@@ -199,9 +191,6 @@ AC_ARG_WITH([log-default],
   [with_log_default=WARN]
 )
 
-AC_DEFINE_UNQUOTED([ASDF_LOG_DEFAULT_LEVEL], [ASDF_LOG_$with_log_default],
-                   [Default runtime log level])
-
 AC_ARG_WITH([log-min],
   [AS_HELP_STRING([--with-log-min=LEVEL], [Set compile-time minimum log level])],
   [AS_CASE([$with_log_min],
@@ -209,9 +198,6 @@ AC_ARG_WITH([log-min],
     [AC_MSG_ERROR([Invalid min log level: $with_log_min])])],
   [with_log_min=TRACE]
 )
-
-AC_DEFINE_UNQUOTED([ASDF_LOG_MIN_LEVEL], [ASDF_LOG_$with_log_min],
-                   [Compile-time minimum log level])
 
 
 # Substitutions for the installed include/asdf/config.h.  Unlike the internal
@@ -361,6 +347,11 @@ AC_SUBST([PYTHON3])
 AC_SUBST([ASDF_CFLAGS])
 AC_SUBST([ASDF_LDFLAGS])
 AC_CONFIG_HEADERS([config.h]) # use config.h instead of passing -D in the command line
+
+# The ASDF_LOG_* and ASDF_HAVE_FLOAT16 macros are part of the installed public
+# configuration (include/asdf/config.h); pull them in here rather than
+# duplicating the definitions in the internal config.h.
+AH_BOTTOM([#include "asdf/config.h"])
 AC_CONFIG_FILES([Makefile include/Makefile tests/Makefile third_party/Makefile docs/Makefile libasdf.pc include/asdf/config.h])
 
 AC_OUTPUT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,7 +131,16 @@ if(ENABLE_TOOL)
         ${STC_DIR}/include
         ${CMAKE_BINARY_DIR}/include
         ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    # Mark the third-party dependency include dirs as SYSTEM (as libasdf_objs
+    # does above) so warnings from their headers are suppressed.  On macOS the
+    # dependency include dirs can resolve to the SDK's usr/include, and adding
+    # that as a plain -I (ahead of the sysroot) makes argp.h's <stdio.h> get
+    # treated as a user header, flooding the build with annoying
+    # -Wnullability-completeness warnings.
+    target_include_directories(asdf-cli SYSTEM PRIVATE
         ${ARGP_INCLUDEDIR}
+        ${all_includedir}
     )
     set_target_properties(asdf-cli ${PROJECT_NAME} PROPERTIES OUTPUT_NAME "asdf")
     install(TARGETS asdf-cli

--- a/src/util.h
+++ b/src/util.h
@@ -7,6 +7,13 @@
 #include <string.h>
 #include <sys/types.h>
 
+// Some versions of libfyaml.h started exporting its own internal
+// ARRAY_SIZE macro, which it probably shouldn't do...
+#include <libfyaml.h>
+#ifdef ARRAY_SIZE
+#undef ARRAY_SIZE
+#endif
+
 #include "asdf/util.h" // IWYU pragma: export
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -86,7 +86,8 @@ unit_test_ldadd = $(munit_ldflags) $(top_builddir)/libasdf.la $(ASDF_LIBS)
 # Unit tests
 check_LIBRARIES = libmunit.a
 libmunit_a_SOURCES = util.c $(munit_dir)/munit.c
-libmunit_a_CPPFLAGS = $(unit_test_base_cppflags)
+# util.c includes config.h, which pulls in the public asdf/config.h
+libmunit_a_CPPFLAGS = -I$(top_srcdir)/include -I$(top_builddir)/include $(unit_test_base_cppflags)
 libmunit_a_CFLAGS = $(unit_test_cflags) -w
 
 # test-block.unit


### PR DESCRIPTION
This will make argp detection on macOS+Homebrew frictionless for users and simplify the build experience (also in the CI) so long as arg-standalone can't be detected with pkg-config.

Fixes some other misc build warnings I noticed while debugging this.