### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
           - os: ubuntu-latest
             cc: gcc
             asan: no
+            # The one job whose `make dist` tarball is kept as an artifact
+            # (for release.yml to attach to the GitHub release)
+            dist_artifact: true
           - os: ubuntu-latest
             cc: gcc
             asan: yes
@@ -108,6 +111,17 @@ jobs:
       - name: Dist check
         run: |
           make distcheck ${{ github.event.inputs.make_flags }}
+
+      # Only on tags, and only from one job in the matrix: release.yml picks
+      # this up and attaches it to the GitHub release for the tag.
+      - name: Upload source tarball
+        if: github.ref_type == 'tag' && matrix.dist_artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-tarball
+          path: libasdf-*.tar.gz
+          if-no-files-found: error
+          retention-days: 14
 
   # Test the documentation build if the build passes
   docs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,15 +160,13 @@ jobs:
           run-id: ${{ steps.target.outputs.run_id }}
           github-token: ${{ github.token }}
 
-      - name: Release asset checksum
+      - name: Check the tarball
         working-directory: dist
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          set -euo pipefail
-          test -f "libasdf-$VERSION.tar.gz"
-          sha256sum libasdf-*.tar.gz > sha256sums.txt
-          cat sha256sums.txt
+          set -eu
+          test -f "libasdf-$VERSION.tar.gz" || ls -l
 
       - name: Create the release
         env:
@@ -183,13 +181,18 @@ jobs:
           args=(--title "libasdf v$VERSION"
                 --notes-file release-notes.md
                 --target "$SHA")
+          state=release
           if [ "$PRERELEASE" = true ]; then
             args+=(--prerelease)
+            state="pre-release"
           fi
           # Automatic (workflow_run) releases are always drafts; only an
           # explicit dispatch with draft=false publishes straight away
+          draft=false
           if [ "$EVENT_NAME" != workflow_dispatch ] || [ "$INPUT_DRAFT" = true ]; then
             args+=(--draft)
+            draft=true
+            state="draft $state"
           fi
           if gh release view "$TAG" > /dev/null 2>&1; then
             echo "::notice::release $TAG already exists; updating it"
@@ -198,4 +201,26 @@ jobs:
           else
             gh release create "$TAG" "${args[@]}" dist/*
           fi
-          gh release view "$TAG" --json url --jq .url >> "$GITHUB_STEP_SUMMARY"
+
+          # Best-effort summary: never fail the job over it, the release is
+          # already made by this point
+          {
+            echo "## libasdf $VERSION ($state)"
+            echo
+            echo "- Tag \`$TAG\` at \`$SHA\`"
+            url=$(gh release view "$TAG" --json url --jq .url) || url=
+            if [ "$draft" = true ]; then
+              # A draft has no published tag association yet, so the API hands
+              # back a placeholder ".../releases/tag/untagged-<hash>" URL; it
+              # becomes the real tag URL below once the draft is published
+              echo "- [Review and publish the draft]($url)"
+              echo "- Once published: https://github.com/$GH_REPO/releases/tag/$TAG"
+            else
+              echo "- Published at $url"
+            fi
+            echo
+            echo "### Assets"
+            for asset in dist/*; do
+              echo "- \`$(basename "$asset")\`"
+            done
+          } >> "$GITHUB_STEP_SUMMARY" || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,201 @@
+name: Release
+
+# Creates a draft GitHub release for a tag, but only once the Build workflow
+# has fully succeeded on that tag.  Build is used as the gate because it is the
+# most comprehensive: `make check` on the full matrix, then `make dist` and
+# `make distcheck` (which in turn runs distcheck-docs and distcheck-cmake).
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing version tag from which to create the release
+        required: true
+      draft:
+        description: Create the release as a draft
+        type: boolean
+        default: true
+
+permissions:
+  contents: write  # needed to create the release and upload assets
+  actions: read    # needed to download artifacts from the Build run
+
+# Aim to prevent accidental concurrent runs of the same release build
+concurrency:
+  group: release-${{ github.event.workflow_run.head_branch || inputs.tag }}
+
+jobs:
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    # build.yml only runs on `push` for main and for tags, so a successful
+    # push-triggered run whose head_branch is not main was a tag build.  This
+    # just keeps the workflow from appearing at all for ordinary main pushes;
+    # "Resolve release target" below verifies the tag properly via the API.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch != 'main')
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Resolve release target
+        id: target
+        # Values that originate outside the workflow (tag names, the dispatch
+        # input) go through the environment rather than being interpolated
+        # into the script body
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = workflow_dispatch ]; then
+            tag="$INPUT_TAG"
+            # Extract the run ID and head SHA from any workflows run on the
+            # input tag, if any.
+            run=$(gh run list --workflow build.yml --branch "$tag" \
+                    --event push --status success --limit 1 \
+                    --json databaseId,headSha \
+                    --jq '.[] | "\(.databaseId) \(.headSha)"')
+            if [ -z "$run" ]; then
+              echo "::error::no successful Build run found for tag $tag"
+              exit 1
+            fi
+            run_id=${run% *}
+            head_sha=${run#* }
+          else
+            tag="$RUN_BRANCH"
+            run_id="$RUN_ID"
+            head_sha="$RUN_SHA"
+          fi
+
+          # Guard: the ref must really be a tag (this 404s otherwise) and must
+          # point at the commit Build actually tested.  The /commits/<ref>
+          # endpoint dereferences annotated tags for us.
+          gh api "repos/$GH_REPO/git/ref/tags/$tag" > /dev/null
+          tag_sha=$(gh api "repos/$GH_REPO/commits/$tag" --jq .sha)
+          if [ "$tag_sha" != "$head_sha" ]; then
+            echo "::error::tag $tag ($tag_sha) does not point at the commit" \
+                 "Build ran on ($head_sha)"
+            exit 1
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "run_id=$run_id"
+            echo "sha=$head_sha"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Checkout the tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.target.outputs.tag }}
+
+      - name: Check the tag matches the project version
+        id: version
+        env:
+          TAG: ${{ steps.target.outputs.tag }}
+        run: |
+          set -euo pipefail
+          tag="$TAG"
+          version=$(sed -n 's/^current_version = "\(.*\)"$/\1/p' .bumpver.toml)
+          ac_version=$(sed -n 's/.*\[libasdf\], \[\([^]]*\)\].*/\1/p' configure.ac)
+          for got in "$version" "$ac_version"; do
+            if [ "$got" != "${tag#v}" ]; then
+              echo "::error::tag $tag does not match project version $got"
+              exit 1
+            fi
+          done
+
+          # The bumpver version pattern is MAJOR.MINOR.PATCH[PYTAGNUM], so
+          # anything carrying a release tag suffix (a2, b1, rc1, dev0, post1)
+          # is a pre-release.
+          prerelease=true
+          case "$version" in
+            *[!0-9.]*) ;;
+            *) prerelease=false ;;
+          esac
+
+          {
+            echo "version=$version"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
+
+      # Need Python for the release notes extraction script
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Generate release notes from CHANGES.rst
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # pypandoc_binary bundles the pandoc executable itself
+          python -m pip install --upgrade docutils pypandoc_binary
+          python scripts/extract_changelog_md.py CHANGES.rst > changelog.md
+          version="$VERSION"
+          if ! head -n 1 changelog.md | grep -qF "$version"; then
+            echo "::error::top section of CHANGES.rst is not for $version"
+            head -n 1 changelog.md
+            exit 1
+          fi
+          # Drop the top-level heading; the release title already says it
+          tail -n +2 changelog.md | sed '/./,$!d' > release-notes.md
+          cat release-notes.md
+
+      - name: Download the source tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-tarball
+          path: dist
+          run-id: ${{ steps.target.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Release asset checksum
+        working-directory: dist
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          test -f "libasdf-$VERSION.tar.gz"
+          sha256sum libasdf-*.tar.gz > sha256sums.txt
+          cat sha256sums.txt
+
+      - name: Create the release
+        env:
+          TAG: ${{ steps.target.outputs.tag }}
+          SHA: ${{ steps.target.outputs.sha }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_DRAFT: ${{ inputs.draft }}
+        run: |
+          set -euo pipefail
+          args=(--title "libasdf v$VERSION"
+                --notes-file release-notes.md
+                --target "$SHA")
+          if [ "$PRERELEASE" = true ]; then
+            args+=(--prerelease)
+          fi
+          # Automatic (workflow_run) releases are always drafts; only an
+          # explicit dispatch with draft=false publishes straight away
+          if [ "$EVENT_NAME" != workflow_dispatch ] || [ "$INPUT_DRAFT" = true ]; then
+            args+=(--draft)
+          fi
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "::notice::release $TAG already exists; updating it"
+            gh release edit "$TAG" "${args[@]}"
+            gh release upload "$TAG" dist/* --clobber
+          else
+            gh release create "$TAG" "${args[@]}" dist/*
+          fi
+          gh release view "$TAG" --json url --jq .url >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,4 @@ libasdf-*/
 # misc
 .cache
 .gdb_history
+scripts/__pycache__

--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ to a new file:
 With libasdf installed on your system (see :ref:`development`) you can compile
 and run this test like:
 
-.. code:: sh
+.. code:: console
 
    $ gcc asdf-write.c -o asdf-write -lasdf
    $ ./asdf-write
@@ -228,7 +228,7 @@ The next example shows how to read back in the same file:
 
 Likewise compile and run the example with the output from the previous program:
 
-.. code:: sh
+.. code:: console
 
    $ gcc asdf-read.c -o asdf-read -lasdf
    $ ./asdf-read

--- a/changes/+doc-rework.doc
+++ b/changes/+doc-rework.doc
@@ -1,0 +1,5 @@
+General enhancements to the documentation:
+
+- Simpler, tutorial-driven examples
+- Expanded and reflowed narrative documentation
+- Expanded API documentation coverage

--- a/changes/104.feature
+++ b/changes/104.feature
@@ -1,2 +1,2 @@
-asdf_set_<type> family of functions for setting scalar values in the ASDF
+``asdf_set_<type>`` family of functions for setting scalar values in the ASDF
 tree when open in write mode.

--- a/changes/173.bugfix
+++ b/changes/173.bugfix
@@ -1,1 +1,1 @@
-Fixed --help output of the asdf CLI tool to show available sub-commands.
+Fixed ``--help`` output of the asdf CLI tool to show available sub-commands.

--- a/changes/214.feature
+++ b/changes/214.feature
@@ -1,3 +1,5 @@
+ndarray read improvements:
+
 - Added support for the float16 ndarray datatype when reading arrays and
   converting datatypes
 

--- a/changes/73.general
+++ b/changes/73.general
@@ -1,1 +1,1 @@
-Reworked the iterator interfaces (asdf_mapping_iter_t, asdf_sequence_iter_t, asdf_container_iter_t, and asdf_find_iter_t) to be simpler, more consistent, and better documented.
+Reworked the iterator interfaces (``asdf_mapping_iter_t``, ``asdf_sequence_iter_t``, ``asdf_container_iter_t``, and ``asdf_find_iter_t``) to be simpler, more consistent, and better documented.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -6,7 +6,7 @@ EXTRA_DIST = \
     conf.py \
     api/asdf/core/datatype.h.rst \
     api/asdf/core/ndarray.h.rst \
-    api/asdf/error.h.rst \
+    api/asdf/core/time.h.rst \
     api/asdf/emitter.h.rst \
     api/asdf/error.h.rst \
     api/asdf/extension.h.rst \
@@ -14,6 +14,8 @@ EXTRA_DIST = \
     api/asdf/log.h.rst \
     api/asdf/value.h.rst \
     api/asdf/yaml.h.rst \
+    changes.rst \
+    development.rst \
     environment.yml \
     index.rst \
     links.rst \

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,0 +1,386 @@
+.. _development-resources:
+
+Development resources
+#####################
+
+This page covers building libasdf from a git checkout, the conventions the
+project follows, and how releases are made.  If you only want to *use* the
+library, the build instructions in the README *should* be sufficient.
+
+
+.. _build-systems:
+
+The two build systems
+=====================
+
+libasdf ships two parallel build systems, and both are kept working at all
+times:
+
+**Autotools** (``configure.ac`` / ``Makefile.am``) is the primary build system
+for development, and the one used to produce release tarballs.  ``make dist``
+and ``make distcheck`` give a canonical, self-contained source archive that
+builds without any of the tooling used to generate it--no autotools, no
+Sphinx, no git checkout.  ``make distcheck`` also verifies that the tarball
+builds *out of tree*, that everything needed was actually distributed, and that
+it uninstalls cleanly, which is what makes it trustworthy as a release
+artifact.
+
+**CMake** (``CMakeLists.txt``) exists for consumers, not for producing
+releases.  A great deal of C and C++ tooling assumes CMake: it drops into
+projects that use ``FetchContent`` or ``find_package``, into meta-build systems
+and package managers, and into IDEs that understand CMake projects natively.
+Requiring downstream users to deal with autotools in those settings would be a
+real obstacle.
+
+The two are not independent: ``make distcheck`` runs the CMake build *from the
+distribution tarball* (the ``distcheck-cmake`` target in the top-level
+``Makefile.am``), so a change that breaks CMake, or that forgets to distribute
+a file CMake needs, fails the autotools release check.  Both are also built and
+tested in CI, by the ``Build`` and ``CMake Build`` workflows respectively.
+
+The practical consequence: **when you add a source file, add it to both build
+systems.**
+
+CMake is generally more permissive and picks up most new source files
+automatically, whereas automake tends to require anything you want built to be
+listed explicitly.
+
+
+Building with autotools
+=======================
+
+A git checkout has no ``configure`` script; generate it first with
+``autogen.sh`` (a one-line wrapper around ``autoreconf --install``).  This is
+normally only needed once, or again after editing ``configure.ac`` or any
+``Makefile.am``, though the generated makefiles normally re-run the necessary
+steps by themselves:
+
+.. code:: console
+
+    $ git clone --recurse-submodules https://github.com/asdf-format/libasdf.git
+    $ cd libasdf
+    $ ./autogen.sh
+    $ ./configure
+    $ make
+    $ make check
+
+The ``asdf-standard`` submodule provides reference files used by the test
+suite; if you cloned without ``--recurse-submodules``, run ``git submodule
+update --init`` before building (this is also run automatically by the
+build system, but sometimes it can be flaky).
+
+Useful ``configure`` options:
+
+``--enable-debug``
+    Debug build: ``CFLAGS=-g -O0``, and ``DEBUG`` is defined.
+
+``--with-asan``
+    Build with AddressSanitizer.
+
+``--with-ubsan``
+    Build with UndefinedBehaviorSanitizer.
+
+``--disable-tool``
+    Skip building the ``asdf`` command-line tool.  Useful if ``argp`` is
+    unavailable.
+
+``--enable-docs``
+    Build the Sphinx documentation.  The default is ``auto``: docs are built if
+    Sphinx and its extensions are found, and silently skipped otherwise.
+
+``--enable-valgrind``
+    Enable the ``check-valgrind`` targets.
+
+``--enable-logging``, ``--enable-log-color``, ``--with-log-default=LEVEL``, ``--with-log-min=LEVEL``
+    Compile-time logging configuration; see :ref:`logging`.
+
+Autotools fully supports out-of-tree builds, and keeping several configurations
+side by side is the recommended way to work, since a change should pass under
+more than one of them:
+
+.. code:: console
+
+    $ mkdir build-asan && cd build-asan
+    $ ../configure --with-asan
+    $ make && make check
+
+Anything that touches library code should pass ``make check`` in both an
+AddressSanitizer build and a debug build before being committed.
+
+
+Building with CMake
+===================
+
+The CMake build is documented in the README and is reproduced here for
+convenience:
+
+.. code:: console
+
+    $ mkdir build && cd build
+    $ cmake .. \
+          -D CMAKE_BUILD_TYPE=RelWithDebInfo \
+          -D ENABLE_TESTING=YES \
+          -D ENABLE_ASAN=[YES/NO] \
+          -D ENABLE_TOOL=[YES/NO]
+    $ make
+    $ ctest --output-on-failure
+
+Other options of note:
+
+``-D ENABLE_TESTING_ALL=YES``
+    Enable every test target, including the shell-based integration tests.
+    This is what CI uses.
+
+``-D ENABLE_DOCS=YES``
+    Build the Sphinx documentation (``make docs``).
+
+``-D FYAML_NO_PKGCONFIG=YES``, ``-D ARGP_NO_PKGCONFIG=YES``
+    Locate libfyaml or argp by explicit path rather than ``pkg-config``; pair
+    with ``-D FYAML_LIBDIR=``/``-D FYAML_INCLUDEDIR=`` and the ``ARGP_``
+    equivalents.
+
+``make package_source`` and ``make package`` produce CPack archives.  Note that
+these are *not* what is published for a release--the release tarball comes
+from ``make dist`` under autotools.
+
+.. note::
+
+    On systems with a libasdf already installed under, say, ``~/.local/lib``,
+    be aware that CMake links test binaries with ``DT_RUNPATH`` rather than
+    ``DT_RPATH``, and the dynamic loader searches ``LD_LIBRARY_PATH`` *before*
+    ``DT_RUNPATH``.  An installed copy can therefore shadow the freshly built
+    one and cause confusing test failures.  Unset ``LD_LIBRARY_PATH`` before
+    running ``ctest`` if you hit this.
+
+
+Running the tests
+=================
+
+The test suite uses the `µnit <https://nemequ.github.io/munit/>`__ framework,
+with some custom wrappers around it (helper macros) defined in
+``tests/munit.h``.
+
+Test binaries are named ``test-<name>.unit`` and live in the ``tests/``
+directory of the build tree.  Some of them compile a subset of the sources
+directly, rather than linking against the library, so that internal components
+can be tested in isolation.
+
+From a build directory:
+
+.. code:: console
+
+    $ make check                      # everything
+    $ tests/test-block.unit           # one binary directly
+    $ tests/test-ndarray.unit --help  # munit options
+
+munit accepts a test path to run a single case, and other useful flags:
+
+.. code:: console
+
+    $ tests/test-ndarray.unit /test_ndarray/test_read_all
+    $ tests/test-ndarray.unit --seed 0x1234  # reproduce a specific ordering
+    $ tests/test-ndarray.unit --no-fork      # keep the debugger attached
+
+In particular, the ``--no-fork`` option is always enabled by default for debug
+builds, as it's extremely helpful if you want to run the tests under gdb (or
+your debugger of choice).
+
+Shell-based integration tests (``tests/test-events.sh``, ``tests/test-info.sh``
+and friends) exercise the ``asdf`` command-line tool against golden output
+files under ``tests/fixtures/``.  When a deliberate change alters that output,
+regenerate the golden files with ``make update-fixtures`` from the build
+directory, and check the diff carefully before committing it.
+
+Some test data comes from the ``asdf-standard`` submodule's
+``reference_files/`` directory.
+
+Two more targets, both requiring the corresponding ``configure`` option:
+
+- ``make check-valgrind`` (``--enable-valgrind``)
+- ``make check-code-coverage`` (``--enable-code-coverage``)
+
+
+Code style
+==========
+
+Formatting is enforced by ``clang-format``; the rules live in
+``.clang-format``.  Run:
+
+.. code:: console
+
+    $ make format
+
+from a build directory before committing.  It rewrites all library sources and
+headers in place.
+
+There is also a ``make tidy`` target that runs ``clang-tidy``, though its
+output is not currently clean and it is not enforced.
+
+To have formatting applied automatically, it is recommended to install the
+`pre-commit <https://pre-commit.com/>`__ hook shipped in
+``.pre-commit-config.yaml``:
+
+.. code:: console
+
+    $ pip install pre-commit      # or: pipx install pre-commit
+    $ pre-commit install
+
+That registers a git hook which runs ``clang-format -i`` over any staged files
+under ``src/`` or ``include/``.
+
+
+.. note::
+
+    The hook uses ``language: system``, so it runs *your* ``clang-format``;
+    a different major version may format differently from the rest of the tree.
+    To check the whole tree at any time::
+
+        pre-commit run --all-files
+
+
+Documentation
+=============
+
+The documentation is built with Sphinx.  API reference pages are generated from
+the doc comments in the public headers under ``include/asdf/`` using `Hawkmoth
+<https://hawkmoth.readthedocs.io/>`__, which extracts ``/** ... */`` comments
+and feeds them to Sphinx as reStructuredText.  Because of that, doc comments in
+public headers are written in reST, using field lists (``:param foo:``,
+``:return:``) rather than a Doxygen-style syntax.
+
+Build them with:
+
+.. code:: console
+
+    $ ./configure --enable-docs
+    $ make docs
+
+The rendered output lands in ``docs/_build/html`` under the build directory.
+CI builds the docs with ``-W``, so warnings are errors; if you add a page,
+make sure it is referenced from a ``toctree`` and that every cross-reference
+resolves.
+
+The ``asdf(1)`` man page is generated from ``docs/usage/cli.rst`` but is
+**committed to the repository** (as ``docs/man/asdf.1``), so that building or
+installing from a release tarball does not require Sphinx.  After changing
+``usage/cli.rst``, regenerate and commit it:
+
+.. code:: console
+
+    $ make man-page
+
+Adding a new documentation page also means adding it to ``EXTRA_DIST`` in
+``docs/Makefile.am``, or it will be missing from the release tarball and the
+documentation build inside ``make distcheck`` will fail.
+
+
+Changelog entries
+=================
+
+The changelog is assembled by `towncrier
+<https://towncrier.readthedocs.io/>`__ from individual *news fragments* in the
+``changes/`` directory.  Each fragment is a small reStructuredText file named
+for the issue or pull request it relates to, with the category as its
+extension::
+
+    changes/123.feature
+    changes/456.bugfix
+
+The available categories are ``general``, ``feature``, ``bugfix``, ``doc``,
+``removal`` and ``misc``.  For a change with no associated issue number, use a
+descriptive name prefixed with ``+``, for example
+``changes/+cmake-build.misc``.
+
+Write the entry for the reader of the release notes, not for the reviewer of
+the diff.
+
+
+.. _making-a-release:
+
+Making a release
+================
+
+Despite not being a Python package, version numbers follow :pep:`440`
+(because the author likes it) and are managed by
+`bumpver <https://github.com/mbarkhau/bumpver>`__, configured in
+``.bumpver.toml``.
+
+A single ``bumpver`` invocation rewrites the version everywhere it appears
+(``configure.ac``, ``CMakeLists.txt``, ``docs/conf.py``, ``towncrier.toml``,
+and ``.bumpver.toml`` itself), builds the changelog, commits, tags and pushes.
+
+Tags are the bare version string, with no ``v`` prefix--``0.1.0a2``, not
+``v0.1.0a2``.
+
+.. note::
+
+   CMake does *not* support :pep:`440`-style version tags ("a1", "rc0", etc.),
+   so the full version is written in ``CMakeLists.txt`` as a
+   ``PACKAGE_VERSION`` variable (mirroring autoconf); the CMake standard
+   variable ``PROJECT_VERSION`` is also managed by bumpver, but only contains
+   the ``MAJOR.MINOR.PATCH`` portion of the version.
+
+Signing the tag
+---------------
+
+Release tags should be signed with your GPG key (bumpver does this via
+``git tag --annotate``).  That command *does* honour git's ``tag.gpgSign``
+setting, so configure it once and release tags are signed automatically:
+
+.. code:: console
+
+    $ git config --local tag.gpgSign true
+
+This should be configured before making a release; you can find more
+information about generating a GPG key and registering it with GitHub
+at `Telling Git about your signing key`_.
+
+Cutting the release
+-------------------
+
+#. Make sure ``main`` is up to date, the working tree is clean, and CI is
+   passing.
+
+#. Check that every merged change has a news fragment in ``changes/``, and
+   preview the assembled changelog:
+
+   .. code:: console
+
+       $ towncrier build --draft --version <new version>
+
+#. Run bumpver with the appropriate increment.  Use ``--dry`` first to see
+   exactly what will be rewritten:
+
+   .. code:: console
+
+       $ bumpver update --tag-num --dry     # 0.1.0a2 -> 0.1.0a3
+       $ bumpver update --tag-num
+
+   Other useful increments are ``--patch``, ``--minor``, ``--major``, and
+   ``--tag beta`` / ``--tag final`` to move along the pre-release sequence.
+
+   This runs ``scripts/changelog.sh`` as a pre-commit hook, which consumes
+   every file in ``changes/`` and rewrites ``CHANGES.rst``, then commits, tags
+   and pushes.
+
+#. The rest is automated.  Pushing the tag triggers the ``Build`` workflow;
+   once it succeeds on that tag the ``Release`` workflow creates a **draft**
+   GitHub release, with the release notes converted from the new ``CHANGES.rst``
+   section and the ``make dist`` tarball attached.
+
+#. Review the draft release on GitHub and publish it.
+
+The release workflow refuses to run unless the tag matches the version recorded
+in ``.bumpver.toml`` and ``configure.ac``, and unless the top section of
+``CHANGES.rst`` is the one for that version, so a mistagged or half-finished
+release fails loudly rather than shipping.
+
+If the ``Release`` workflow needs to be re-run against a tag that has already
+built successfully, for instance after fixing something in the workflow
+itself, it can be triggered by hand, e.g. with the GitHub CLI:
+
+.. code:: console
+
+    $ gh workflow run release.yml -f tag=<version>
+
+Re-running updates the existing draft rather than failing.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,6 +83,7 @@ Resources
   :maxdepth: 2
 
   changes
+  development
 
 
 See also

--- a/docs/links.rst
+++ b/docs/links.rst
@@ -5,5 +5,6 @@
 .. _ASDF Numeric Literals: https://www.asdf-format.org/projects/asdf-standard/en/latest/tree.html#numeric-literals
 .. _JSON Pointer: https://www.rfc-editor.org/rfc/rfc6901
 .. _NumPy: https://numpy.org/
+.. _Telling Git about your signing key: https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key
 .. _YAML Core Schema: https://yaml.org/spec/1.2.2/#103-core-schema
 .. _libfyaml: https://github.com/pantoniou/libfyaml

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
+
+set -eu
+
+here=$(dirname "$0")
+
+# Unwrap changelog snippets before passing through towncrier
+# See unwrap_rst.py for more details
+python3 "$here"/unwrap_rst.py changes
+
 # Run towncrier to update changelog--this script is called automatically when
 # running bumpver
 towncrier build --yes

--- a/scripts/extract_changelog_md.py
+++ b/scripts/extract_changelog_md.py
@@ -9,24 +9,60 @@ Requires:
 """
 
 import argparse
+import contextlib
 import pathlib
 import sys
+import tempfile
 
 import docutils.core
 import docutils.nodes
 import pypandoc
 
 
+TITLE_REF_FILTER = """
+function Span(el)
+  if el.classes:includes("title-ref") then
+    return pandoc.Code(pandoc.utils.stringify(el))
+  end
+end
+"""
+"""
+Render single-backtick interpreted text as a code span.
+
+Single-backtick interpreted text, e.g. `asdf_ndarray_data`, uses whatever
+``default_role`` is configured (i.e. ``c:expr`` for our Sphinx docs) but pandoc
+knows nothing about that and falls back to reST's stock title-reference role,
+which it writes out as ``<span class="title-ref">``.
+
+GitHub strips the class when sanitizing a release body, so the markup silently
+vanishes and the text renders bare.
+
+This runs as a filter rather than a fixup of pandoc's output so that pandoc
+still handles escaping properly (trying to run it as a regexp didn't work).
+"""
+
+
+@contextlib.contextmanager
+def lua_filter(source: str):
+    """Write a Lua filter to a temporary file and yield its path."""
+
+    with tempfile.NamedTemporaryFile('w', suffix='.lua') as filter_file:
+        filter_file.write(source)
+        filter_file.flush()
+        yield filter_file.name
+
+
 def extract_first_section(rst_text: str) -> str:
     """
     Use docutils' doctree to extract the text of the first section
 
-    docutils' doctree section nodes have a line-number attached, but it's actually the (1-indexed)
-    line of the the section marker (e.g. =========).
+    docutils' doctree section nodes have a line-number attached, but
+    it's actually the (1-indexed) line of the the section marker
+    (e.g. =========).
 
-    It would be signifcantly nicer if docutils could just dump the text of the section node
-    directly but it doesn't seem to preserve that, so iterating through the sections and doing
-    line number math seems to be the best way.
+    It would be signifcantly nicer if docutils could just dump the text of the
+    section node directly but it doesn't seem to preserve that, so iterating
+    through the sections and doing line number math seems to be the best way.
     """
 
     doc = docutils.core.publish_doctree(rst_text)
@@ -49,12 +85,13 @@ def rst_to_md(rst_text: str) -> str:
     # 'gfm' (GitHub-Flavored Markdown): the output is destined for a
     # GitHub release body, and gfm avoids gratuitous backslash-escaping of
     # quotes
-    return pypandoc.convert_text(
-        rst_text,
-        'gfm',
-        format='rst',
-        extra_args=['--wrap=none']
-    )
+    with lua_filter(TITLE_REF_FILTER) as filter_path:
+        return pypandoc.convert_text(
+            rst_text,
+            'gfm',
+            format='rst',
+            extra_args=['--wrap=none', f'--lua-filter={filter_path}']
+        )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/extract_changelog_md.py
+++ b/scripts/extract_changelog_md.py
@@ -46,9 +46,12 @@ def extract_first_section(rst_text: str) -> str:
 
 
 def rst_to_md(rst_text: str) -> str:
+    # 'gfm' (GitHub-Flavored Markdown): the output is destined for a
+    # GitHub release body, and gfm avoids gratuitous backslash-escaping of
+    # quotes
     return pypandoc.convert_text(
         rst_text,
-        'md',
+        'gfm',
         format='rst',
         extra_args=['--wrap=none']
     )

--- a/scripts/unwrap_rst.py
+++ b/scripts/unwrap_rst.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python3
+"""
+Unwrap hard-wrapped paragraphs in towncrier news fragments.
+
+towncrier re-wraps its output (``wrap = true`` in towncrier.toml), but it
+wraps each *input* line independently rather than reflowing whole paragraphs.
+A fragment that is already hard-wrapped at some other column therefore comes
+out ragged, with stub lines::
+
+    New API features are being added to support adding content to files opened
+    for
+    writing, documented in some of the following changelog entries.
+
+Running this over the fragments first, so each paragraph is a single long line,
+lets towncrier do the wrapping it was going to do anyway, cleanly.
+
+Newlines within a paragraph become spaces.  Blank lines, section underlines,
+explicit markup (``.. directive::``) and indented literal blocks are all left
+alone.  Hopefully that covers most of the common cases.
+
+Lists are deliberately left alone too: towncrier indents every wrapped line of
+a bullet to the paragraph indent rather than to a hanging indent.
+Hand-wrapped list items already come through towncrier intact, so there is
+nothing to fix there anyway.
+"""
+
+import argparse
+import difflib
+import pathlib
+import sys
+
+import re
+
+
+LIST_ITEM_RE = re.compile(r'^\s*(?:[-*+]|\(?[0-9]+[.)]|#\.)\s')
+""""Starts a new list item: "- ", "* ", "+ ", "1. ", "1) ", "(1) ", "#. """
+
+ADORNMENT_RE = re.compile(r'^\s*([=\-~^"\'`#*+:.<>_])\1+\s*$')
+"""A section title underline/overline, e.g. "====" or "----\""""
+
+EXPLICIT_MARKUP_RE = re.compile(r'^\s*\.\.(\s|$)')
+"""Explicit markup: directives, comments, hyperlink targets, footnotes"""
+
+FIELD_RE = re.compile(r'^\s*:[^:\s][^:]*:\s')
+"""A field list or definition-ish line, e.g. ":param foo:\""""
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def is_boundary(line: str, prev: str) -> bool:
+    """
+    Should ``line`` start a new logical line rather than be joined onto
+    ``prev``?
+    """
+
+    return bool(
+        LIST_ITEM_RE.match(line)
+        or FIELD_RE.match(line)
+        or EXPLICIT_MARKUP_RE.match(line)
+        or ADORNMENT_RE.match(line)
+        or ADORNMENT_RE.match(prev)
+    )
+
+
+def unwrap_paragraph(lines: list[str]) -> list[str]:
+    """
+    Join the wrapped lines of a single paragraph, respecting item boundaries
+    """
+
+    logical: list[str] = []  # logical lines
+
+    for line in lines:
+        if not logical or is_boundary(line, logical[-1]):
+            logical.append(line.rstrip())
+        else:
+            logical[-1] = logical[-1] + ' ' + line.strip()
+
+    return logical
+
+
+def paragraphs(lines: list[str]):
+    """
+    Yield ``(is_blank, group)`` runs of consecutive blank / non-blank lines
+    """
+
+    group: list[str] = []
+    blank = None
+
+    for line in lines:
+        line_blank = not line.strip()
+
+        if blank is None or line_blank == blank:
+            group.append(line)
+        else:
+            yield blank, group
+            group = [line]
+
+        blank = line_blank
+
+    if group:
+        yield blank, group
+
+
+def unwrap(text: str) -> str:
+    """Unwrap every reflowable paragraph in an reST fragment"""
+
+    trailing_newline = text.endswith('\n')
+    result: list[str] = []
+    # Indent that an ongoing literal block / directive body sits inside of,
+    # or None
+    literal_indent = None
+    prev_indent = 0
+    prev_is_literal_intro = False
+
+    for blank, group in paragraphs(text.splitlines()):
+        if blank:
+            result.extend(group)
+            continue
+
+        base = min(indent_of(line) for line in group)
+
+        if literal_indent is not None and base > literal_indent:
+            # Still inside the literal block / directive body opened earlier
+            verbatim = True
+        elif prev_is_literal_intro and base > prev_indent:
+            # Indented block introduced by a paragraph ending in "::"
+            verbatim = True
+            literal_indent = prev_indent
+        elif EXPLICIT_MARKUP_RE.match(group[0]):
+            verbatim = True
+            literal_indent = base
+        elif LIST_ITEM_RE.match(group[0]):
+            # See the module docstring: towncrier cannot re-wrap a long list
+            # item without breaking the hanging indent, so leave lists as-is
+            verbatim = True
+            literal_indent = None
+        else:
+            verbatim = False
+            literal_indent = None
+
+        result.extend(group if verbatim else unwrap_paragraph(group))
+        prev_is_literal_intro = result[-1].rstrip().endswith('::')
+        prev_indent = base
+
+    out = '\n'.join(result)
+    if trailing_newline and not out.endswith('\n'):
+        out += '\n'
+    return out
+
+
+def fragment_paths(paths: list[pathlib.Path]) -> list[pathlib.Path]:
+    """Expand any directories into the news fragments they contain."""
+
+    expanded = []
+    for path in paths:
+        if path.is_dir():
+            # Skip dotfiles such as the .gitkeep towncrier needs
+            expanded.extend(sorted(
+                p for p in path.iterdir()
+                if p.is_file() and not p.name.startswith('.')
+            ))
+        else:
+            expanded.append(path)
+    return expanded
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('paths', type=pathlib.Path, nargs='+',
+                        help='news fragments, or directories containing them')
+    parser.add_argument('--diff', action='store_true',
+                        help='show what would change without rewriting')
+    args = parser.parse_args(argv)
+
+    changed = 0
+    for path in fragment_paths(args.paths):
+        try:
+            original = path.read_text()
+        except OSError as exc:
+            print(f'error: {exc}', file=sys.stderr)
+            return 1
+
+        unwrapped = unwrap(original)
+
+        if unwrapped == original:
+            continue
+
+        changed += 1
+        if args.diff:
+            sys.stdout.writelines(difflib.unified_diff(
+                original.splitlines(keepends=True),
+                unwrapped.splitlines(keepends=True),
+                fromfile=str(path), tofile=str(path)))
+        else:
+            path.write_text(unwrapped)
+            print(f'- unwrapped {path}')
+
+    if not changed:
+        print('no fragments needed unwrapping')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Attempt to automate as much as possible of the release process following a call to `bumpver`.

I experimented with this extensively over in my fork, and it seems to be pretty solid now.

It turns out it would have been a lot easier to just make "release" a job within one of the existing (probably `build.yml` workflows) but I started out with wanting to make it a separate workflow entirely and that turns out to be somewhat ill-supported surprisingly. But I stuck to my guns and this seems good enough.

In testing the release I also noticed more issues with the changelog that I tweaked, and am pretty happy with now.  Some interesting ideas for upstreaming to the relevant tools, `bumpver` and `towncrier`.  I like both of these tools but I feel like I'm fighting them more than I should have to.

Added a "Development resources" section to the docs--started out wanting to just to note down the release process once I got it working, but then fleshed it out further, so this is good to have.  I will probably add more to it later, especially if I get any new feedback from others getting stuck at various points, because I can't remember off the top of my head all the gotchas.