### PR TITLE
Fix misc test warnings

### DIFF
--- a/changes/+misc-warnings.misc
+++ b/changes/+misc-warnings.misc
@@ -1,0 +1,1 @@
+Fix some spurious warnings that could occur when compiling/linking the tests.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -80,7 +80,7 @@ unit_test_cflags += -DMUNIT_NO_FORK
 unit_test_ldflags += -rdynamic
 endif
 
-unit_test_ldflags += $(LDFLAGS) $(CODE_COVERAGE_LDFLAGS)
+unit_test_ldflags += $(CODE_COVERAGE_LDFLAGS)
 unit_test_ldadd = $(munit_ldflags) $(top_builddir)/libasdf.la $(ASDF_LIBS)
 
 # Unit tests
@@ -304,7 +304,8 @@ $(cpp_header_test): $(asdf_public_headers) $(srcdir)/scripts/generate_test_cpp_h
 test-cpp-headers$(EXEEXT): $(cpp_header_test) $(top_builddir)/libasdf.la
 	$(AM_V_at)$(LIBTOOL) --mode=link $(CXX) -std=c++17 -I$(top_srcdir)/include \
 	    -I$(top_builddir)/include \
-	    $(ASDF_LDFLAGS) $(unit_test_ldflags) $(cpp_header_test) $(top_builddir)/libasdf.la $(ASDF_LIBS) \
+	    $(ASDF_LDFLAGS) $(unit_test_ldflags) $(LDFLAGS) \
+	    $(cpp_header_test) $(top_builddir)/libasdf.la $(ASDF_LIBS) \
 	    -o $@ $(QUIET_OUT)
 
 TESTS += test-cpp-headers
@@ -337,7 +338,8 @@ $(DOC_EXAMPLES_DIR)/test-doc-examples.sh: $(DOC_EXAMPLE_DEPS)
 	    exe=$${f%.c}; \
 	    $(LIBTOOL) --mode=link $(CC) $(ASDF_CFLAGS) -I$(top_srcdir)/include \
 	      -I$(top_builddir)/include \
-	      $(ASDF_LDFLAGS) $(unit_test_ldflags) $$f $(top_builddir)/libasdf.la $(ASDF_LIBS) \
+	      $(ASDF_LDFLAGS) $(unit_test_ldflags) $(LDFLAGS) \
+	      $$f $(top_builddir)/libasdf.la $(ASDF_LIBS) \
 	      -o $$exe $(QUIET_OUT); \
 	done
 

--- a/tests/test-emitter.c
+++ b/tests/test-emitter.c
@@ -36,10 +36,10 @@
  * comparison meaningful.
  */
 MU_TEST(test_emitter_stream_switch) {
-    const size_t n = 1024;
+    uint8_t ref_data[1024];
+    const size_t n = sizeof(ref_data) / sizeof(ref_data[0]);
     const uint64_t shape[] = {n};
 
-    uint8_t ref_data[n];
     for (size_t idx = 0; idx < n; idx++)
         ref_data[idx] = (uint8_t)(idx % 256);
 


### PR DESCRIPTION
## Description
This fixes the duplicate `-rpath` warning seen in the conda build--automake already passes `$(LDFLAGS)` by default so this is a spurious duplication.

## AI Disclosure
No AI tools used.
